### PR TITLE
Increase core test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install
 npm run check
 ```
 
-`npm run check` runs strict type checking, the Chromium browser suite, and the production library build.
+`npm run check` runs strict type checking, the instrumented Chromium browser suite, and the production library build. The coverage gate requires at least 95% statement, function, and line coverage plus 90% branch coverage.
 
 ## Quick start
 
@@ -225,11 +225,12 @@ Not included now:
 ```bash
 npm run typecheck
 npm test
+npm run test:coverage
 npm run build
 npm audit --audit-level=moderate
 ```
 
-Run all project checks with `npm run check`.
+`npm run test:coverage` prints the V8 coverage summary and writes the ignored HTML report to `coverage/`. Run all project checks, including the coverage thresholds, with `npm run check`.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     "build": "vite build && tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "check": "npm run typecheck && npm test && npm run build"
+    "check": "npm run typecheck && npm run test:coverage && npm run build"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/tests/components-and-utilities.spec.ts
+++ b/tests/components-and-utilities.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  adoptStyles,
+  createStyleSheet,
+  css,
+  defineAtom,
+  html,
+  installGluonStyles,
+  mergeProps,
+  render,
+} from '../src/index.js';
+import { Button, Icon } from '../src/atoms/index.js';
+import { Card, FormField } from '../src/molecules/index.js';
+import { AppShell } from '../src/organisms/index.js';
+import { fragment, q, quark } from '../src/quarks/index.js';
+
+describe('component variants and utilities', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+    document.adoptedStyleSheets = [];
+    vi.unstubAllGlobals();
+  });
+
+  it('merges class aliases and object styles while preserving scalar overrides', () => {
+    expect(mergeProps({
+      className: 'base',
+      style: { color: 'red', padding: '4px' },
+    }, {
+      class: { active: true },
+      style: { color: 'blue' },
+    })).toEqual({
+      class: ['base', { active: true }],
+      style: { color: 'blue', padding: '4px' },
+    });
+
+    expect(mergeProps({ class: 'base', style: { color: 'red' } })).toEqual({
+      class: ['base', undefined],
+      style: { color: 'red' },
+    });
+    expect(mergeProps({ style: { color: 'red' } }, { style: 'display: block' }).style)
+      .toBe('display: block');
+  });
+
+  it('installs interpolated constructable stylesheets and reports unsupported targets', () => {
+    const sheet = css`:root { --space: ${4}px; }`;
+    expect(sheet.cssRules[0]?.cssText).toContain('--space: 4px');
+
+    const uninstall = installGluonStyles();
+    expect(document.adoptedStyleSheets).toHaveLength(2);
+    uninstall();
+    expect(document.adoptedStyleSheets).toHaveLength(0);
+
+    expect(() => adoptStyles({} as ShadowRoot, sheet)).toThrow(/adoptedStyleSheets support/i);
+
+    vi.stubGlobal('CSSStyleSheet', undefined);
+    expect(() => createStyleSheet(':root {}')).toThrow(/constructable CSSStyleSheet support/i);
+  });
+
+  it('renders icon, component, and optional composition variants', () => {
+    const root = document.createElement('div');
+    const click = vi.fn();
+    const unnamed = defineAtom(() => html`<span>anonymous</span>`);
+
+    render(fragment([
+      Icon({ name: 'trend-up', size: 16, label: 'Rising' }),
+      Icon({ name: 'trend-down' }),
+      Icon({ name: 'alert', label: 'Alert' }),
+      Button({
+        children: q.strong({ children: 'Continue' }),
+        label: 'Ignored',
+        variant: 'secondary',
+        size: 'large',
+        disabled: true,
+        onClick: click,
+        attributes: { class: 'custom-button' },
+      }),
+      Card({}),
+      Card({
+        subtitle: 'Details',
+        tone: 'warning',
+        actions: false,
+        media: q.img({ alt: 'Preview', src: 'preview.png' }),
+        children: 0,
+      }),
+      FormField({ label: 'Name' }),
+      AppShell({ children: q.p({ children: 'Content' }) }),
+      unnamed({}),
+    ]), root);
+
+    const icons = [...root.querySelectorAll('.gluon-icon')];
+    expect(icons).toHaveLength(3);
+    expect(icons[0]?.getAttribute('width')).toBe('16');
+    expect(icons[0]?.getAttribute('role')).toBe('img');
+    expect(icons[1]?.getAttribute('aria-hidden')).toBe('true');
+    expect(root.querySelector('.custom-button strong')?.textContent).toBe('Continue');
+    expect((root.querySelector('.gluon-button') as HTMLButtonElement).disabled).toBe(true);
+    expect(root.querySelector('.is-warning')).not.toBeNull();
+    expect(root.querySelector('.gluon-card-media img')).not.toBeNull();
+    expect(root.querySelector('.gluon-card-body')?.textContent).toBe('0');
+    expect(root.querySelector('.gluon-form-helper')).toBeNull();
+    expect(root.querySelector('.gluon-app-shell-header')).toBeNull();
+    expect(root.querySelector('.gluon-app-shell-navigation')).toBeNull();
+    expect(root.querySelector('.gluon-app-shell-footer')).toBeNull();
+    expect(unnamed.displayName).toBe('AnonymousComponent');
+  });
+
+  it('validates quark names and caches fragment templates', () => {
+    const root = document.createElement('div');
+
+    expect(() => quark('Invalid Tag')).toThrow(/invalid quark tag name/i);
+    render(fragment('first'), root);
+    const text = root.firstChild;
+    render(fragment('second'), root);
+    expect(root.firstChild).toBe(text);
+    expect(root.textContent).toBe('second');
+    expect((q as unknown as { toJSON?: unknown }).toJSON).toBeUndefined();
+  });
+});

--- a/tests/element-advanced.spec.ts
+++ b/tests/element-advanced.spec.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GluonElement,
+  css,
+  defineElement,
+  html,
+  type PropertyDeclarations,
+} from '../src/index.js';
+
+let advancedElementSequence = 0;
+
+describe('advanced GluonElement behavior', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('inherits declarations and styles, converts values, reflects aliases, and emits events', async () => {
+    const baseStyle = css`:host { display: block; }`;
+    const childStyle = css`:host { color: blue; }`;
+    const tagName = `gluon-advanced-${advancedElementSequence += 1}` as `${string}-${string}`;
+
+    class BaseElement extends GluonElement {
+      static override readonly properties: PropertyDeclarations = {
+        titleText: String,
+        settings: { type: Object, reflect: true, default: () => ({ ready: true }) },
+        items: { type: Array, reflect: true, default: () => ['first'] },
+        internalOnly: { attribute: false, reflect: true, default: 'secret' },
+      };
+
+      static override readonly styles: CSSStyleSheet | readonly CSSStyleSheet[] = baseStyle;
+      declare titleText: string | null;
+      declare settings: unknown;
+      declare items: unknown[] | null;
+      declare internalOnly: string;
+
+      protected override render() {
+        return html`<span>${this.titleText ?? ''}</span>`;
+      }
+    }
+
+    class AdvancedElement extends BaseElement {
+      static override readonly properties: PropertyDeclarations = {
+        count: { type: Number, reflect: true, default: 1 },
+        active: { type: Boolean, reflect: true, default: false },
+        aliased: { attribute: 'data-label', reflect: true, default: 'initial' },
+        custom: {
+          reflect: true,
+          default: 'initial',
+          converter: {
+            fromAttribute: (value) => value?.replace(/^external:/, '') ?? null,
+            toAttribute: (value) => value == null ? null : `external:${String(value)}`,
+          },
+        },
+        stable: {
+          default: 'ready',
+          hasChanged: (value, oldValue) => value !== oldValue && value !== 'skip',
+        },
+      };
+
+      static override readonly styles: CSSStyleSheet | readonly CSSStyleSheet[] = [
+        baseStyle,
+        childStyle,
+      ];
+
+      declare count: number | null;
+      declare active: boolean;
+      declare aliased: string;
+      declare custom: string | null;
+      declare stable: string;
+      renders = 0;
+
+      fire(detail: { id: number }): boolean {
+        return this.emit('advance', detail, { cancelable: true });
+      }
+
+      protected override render() {
+        this.renders += 1;
+        return html`
+          <output>${this.count}:${this.active}:${this.custom}:${this.stable}</output>
+          ${super.render()}
+        `;
+      }
+    }
+
+    defineElement(tagName, AdvancedElement);
+    const element = document.createElement(tagName) as AdvancedElement;
+    document.body.append(element);
+    await element.updateComplete;
+
+    expect(element.shadowRoot?.adoptedStyleSheets).toEqual([baseStyle, childStyle]);
+    expect(element.settings).toEqual({ ready: true });
+    expect(element.items).toEqual(['first']);
+    expect(element.getAttribute('settings')).toBe('{"ready":true}');
+    expect(element.getAttribute('items')).toBe('["first"]');
+    expect(element.hasAttribute('internal-only')).toBe(false);
+    expect(element.getAttribute('data-label')).toBe('initial');
+    expect(element.getAttribute('custom')).toBe('external:initial');
+
+    element.settings = { mode: 'set' };
+    element.items = ['second'];
+    element.active = true;
+    element.custom = 'property';
+    await element.updateComplete;
+    expect(element.getAttribute('settings')).toBe('{"mode":"set"}');
+    expect(element.getAttribute('items')).toBe('["second"]');
+    expect(element.getAttribute('active')).toBe('');
+    expect(element.getAttribute('custom')).toBe('external:property');
+
+    element.setAttribute('settings', '{"mode":"attribute"}');
+    element.setAttribute('items', '[1,2]');
+    element.setAttribute('count', '4');
+    element.setAttribute('custom', 'external:converted');
+    await element.updateComplete;
+    expect(element.settings).toEqual({ mode: 'attribute' });
+    expect(element.items).toEqual([1, 2]);
+    expect(element.count).toBe(4);
+    expect(element.custom).toBe('converted');
+
+    element.setAttribute('settings', 'invalid-json');
+    element.removeAttribute('items');
+    element.removeAttribute('count');
+    element.removeAttribute('active');
+    await element.updateComplete;
+    expect(element.settings).toBe('invalid-json');
+    expect(element.items).toBeNull();
+    expect(element.count).toBeNull();
+    expect(element.active).toBe(false);
+
+    const renders = element.renders;
+    element.stable = 'skip';
+    await Promise.resolve();
+    expect(element.renders).toBe(renders);
+
+    const listener = vi.fn((event: Event) => event.preventDefault());
+    element.addEventListener('advance', listener);
+    expect(element.fire({ id: 7 })).toBe(false);
+    expect(listener).toHaveBeenCalledOnce();
+    const event = listener.mock.calls[0]?.[0] as CustomEvent<{ id: number }>;
+    expect(event.detail).toEqual({ id: 7 });
+    expect(event.bubbles).toBe(true);
+    expect(event.composed).toBe(true);
+
+    const rendersBeforeDisconnect = element.renders;
+    element.remove();
+    element.count = 9;
+    await Promise.resolve();
+    expect(element.renders).toBe(rendersBeforeDisconnect);
+    document.body.append(element);
+    await element.updateComplete;
+    expect(element.shadowRoot?.textContent).toContain('9::converted:ready');
+    expect(element.active).toBe(false);
+    expect(element.getAttribute('count')).toBe('9');
+  });
+
+  it('captures properties assigned before upgrade and rejects conflicting definitions', async () => {
+    const tagName = `gluon-preupgrade-${advancedElementSequence += 1}` as `${string}-${string}`;
+    const element = document.createElement(tagName) as HTMLElement & { value?: string };
+    element.value = 'captured';
+    document.body.append(element);
+
+    class PreUpgradeElement extends GluonElement {
+      static override readonly properties: PropertyDeclarations = {
+        value: { reflect: true, default: 'default' },
+      };
+
+      declare value: string;
+
+      protected override render() {
+        return html`<span>${this.value}</span>`;
+      }
+    }
+
+    class ConflictingElement extends GluonElement {
+      protected override render() {
+        return html`<span>conflict</span>`;
+      }
+    }
+
+    expect(defineElement(tagName, PreUpgradeElement)).toBe(PreUpgradeElement);
+    expect(defineElement(tagName, PreUpgradeElement)).toBe(PreUpgradeElement);
+    await (element as unknown as PreUpgradeElement).updateComplete;
+    expect((element as unknown as PreUpgradeElement).value).toBe('captured');
+    expect(element.getAttribute('value')).toBe('captured');
+    expect(element.shadowRoot?.textContent).toBe('captured');
+    expect(() => defineElement(tagName, ConflictingElement)).toThrow(/already defined/i);
+  });
+});

--- a/tests/runtime-edge-cases.spec.ts
+++ b/tests/runtime-edge-cases.spec.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  html,
+  isTemplateResult,
+  nothing,
+  render,
+  svg,
+  type TemplateResult,
+  type TemplateValue,
+} from '../src/index.js';
+
+describe('template runtime edge cases', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('renders empty values, DOM nodes, nested arrays, and SVG templates', () => {
+    const root = document.createElement('div');
+    const view = (value: TemplateValue) => html`<section>${value}</section>`;
+
+    render(view('same'), root);
+    const text = root.querySelector('section')?.firstChild;
+    render(view('same'), root);
+    expect(root.querySelector('section')?.firstChild).toBe(text);
+
+    render(view(false), root);
+    expect(root.querySelector('section')?.textContent).toBe('');
+
+    const strong = document.createElement('strong');
+    strong.textContent = 'node';
+    render(view(strong), root);
+    expect(root.querySelector('strong')).toBe(strong);
+
+    render(view(['a', [1, true, null, nothing, strong]]), root);
+    expect(root.querySelector('section')?.textContent).toBe('a1truenode');
+    expect(root.querySelector('strong')).toBe(strong);
+
+    const graphic = svg`<svg viewBox="0 0 10 10"><circle cx=${5} cy=${5} r=${4}></circle></svg>`;
+    expect(isTemplateResult(graphic)).toBe(true);
+    expect(isTemplateResult({})).toBe(false);
+    render(graphic, root);
+    expect(root.querySelector('circle')?.namespaceURI).toBe('http://www.w3.org/2000/svg');
+  });
+
+  it('renders into document fragments, ignores null containers, and rejects invalid input', () => {
+    const fragment = document.createDocumentFragment();
+
+    render(html`<p>${'fragment'}</p>`, fragment);
+    expect(fragment.textContent).toBe('fragment');
+
+    expect(() => render({} as TemplateResult, fragment)).toThrow(/expects a TemplateResult/i);
+    expect(() => render(html`<p>ignored</p>`, null)).not.toThrow();
+  });
+
+  it('disconnects attribute and array event listeners when their templates leave the tree', () => {
+    const root = document.createElement('div');
+    const rootListener = { handleEvent: vi.fn() };
+    const itemListener = vi.fn();
+    const item = (label: string) => html`<button @click=${itemListener}>${label}</button>`;
+    const list = (labels: readonly string[]) => html`<div>${labels.map(item)}</div>`;
+
+    render(html`<button @click=${rootListener}>Root</button>`, root);
+    const rootButton = root.querySelector('button') as HTMLButtonElement;
+    rootButton.click();
+    render(html`<p>replacement</p>`, root);
+    rootButton.click();
+    expect(rootListener.handleEvent).toHaveBeenCalledOnce();
+
+    render(list(['one', 'two']), root);
+    const buttons = [...root.querySelectorAll('button')] as HTMLButtonElement[];
+    buttons[1]?.click();
+    render(list(['one']), root);
+    buttons[1]?.click();
+    expect(itemListener).toHaveBeenCalledOnce();
+  });
+
+  it('reconciles every spread binding category across value and removal transitions', () => {
+    const root = document.createElement('div');
+    const callbackRef = vi.fn<(element: Element | undefined) => void>();
+    const objectRef: { value?: Element } = {};
+    const firstListener = { handleEvent: vi.fn() };
+    const secondListener = vi.fn();
+    const view = (props: Readonly<Record<string, unknown>>) => html`<button ...=${props}>Save</button>`;
+    const initial = {
+      className: ['action', { active: true }, false],
+      style: 'color: red; font-weight: 700;',
+      dataset: { trackId: 'alpha', removeMe: 'yes' },
+      aria: { label: 'Save', hidden: null },
+      ref: callbackRef,
+      '@click': firstListener,
+      '.value': 'first',
+      '?disabled': true,
+      title: 'Initial',
+    };
+
+    render(view(initial), root);
+    const button = root.querySelector('button') as HTMLButtonElement & { value?: unknown };
+    button.dispatchEvent(new MouseEvent('click'));
+    render(view(initial), root);
+    expect(callbackRef).toHaveBeenCalledTimes(1);
+    expect(firstListener.handleEvent).toHaveBeenCalledOnce();
+    expect(button.className).toBe('action active');
+    expect(button.style.color).toBe('red');
+    expect(button.dataset.trackId).toBe('alpha');
+    expect(button.getAttribute('aria-hidden')).toBeNull();
+    expect(button.value).toBe('first');
+    expect(button.disabled).toBe(true);
+
+    render(view({
+      class: null,
+      style: {
+        '--accent': 'blue',
+        'font-size': '12px',
+        opacity: 0.5,
+        color: null,
+      },
+      data: { trackId: 'beta', ignored: null },
+      aria: { expanded: false, label: null },
+      ref: objectRef,
+      onClick: secondListener,
+      '.value': 'second',
+      '?disabled': false,
+      title: false,
+    }), root);
+    button.click();
+
+    expect(callbackRef).toHaveBeenLastCalledWith(undefined);
+    expect(objectRef.value).toBe(button);
+    expect(firstListener.handleEvent).toHaveBeenCalledOnce();
+    expect(secondListener).toHaveBeenCalledOnce();
+    expect(button.hasAttribute('class')).toBe(false);
+    expect(button.style.getPropertyValue('--accent')).toBe('blue');
+    expect(button.style.fontSize).toBe('12px');
+    expect(button.style.opacity).toBe('0.5');
+    expect(button.dataset.trackId).toBe('beta');
+    expect(button.dataset.removeMe).toBeUndefined();
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(button.hasAttribute('aria-label')).toBe(false);
+    expect(button.value).toBe('second');
+    expect(button.disabled).toBe(false);
+    expect(button.hasAttribute('title')).toBe(false);
+
+    render(view({}), root);
+    button.click();
+    expect(objectRef.value).toBeUndefined();
+    expect(secondListener).toHaveBeenCalledOnce();
+    expect(button.style.length).toBe(0);
+    expect(button.hasAttribute('data-track-id')).toBe(false);
+    expect(button.hasAttribute('aria-expanded')).toBe(false);
+    expect(button.value).toBe('undefined');
+  });
+
+  it('rejects expressions that the HTML parser cannot represent as parts', () => {
+    const root = document.createElement('div');
+    const invalid = (value: string) => html`<textarea>${value}</textarea>`;
+
+    expect(() => render(invalid('content'), root)).toThrow(/complete child or attribute value/i);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,5 +32,16 @@ export default defineConfig({
       provider: playwright(),
       instances: [{ browser: 'chromium' }],
     },
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      reporter: ['text', 'html'],
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 95,
+        lines: 95,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add browser tests for runtime transitions, spread cleanup, advanced custom-element behavior, stylesheet failure paths, utilities, and component variants
- raise the Chromium suite from 15 to 26 tests
- add a test:coverage command and make the standard check enforce coverage
- document the coverage workflow and thresholds

## Coverage
| Metric | Before | After | Enforced minimum |
| --- | ---: | ---: | ---: |
| Statements | 80.11% | 97.07% | 95% |
| Branches | 68.32% | 93.42% | 90% |
| Functions | 90.43% | 99.13% | 95% |
| Lines | 83.54% | 97.94% | 95% |

## Validation
- npm run check
- npm audit --audit-level=moderate
- 7 test files and 26 tests passed in Chromium
- production build completed
- 0 audit vulnerabilities

Closes #11