### PR TITLE
Define the Gluon 1.0 product scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The following points describe architectural advantages and design goals. Outcome
 ## Architecture and provenance
 
 - [Architecture](docs/architecture.md)
+- [Gluon 1.0 product scope RFC](docs/rfcs/0001-gluon-1.0-product-scope.md)
 - [Gluon 1.0 roadmap](docs/roadmap.md)
 - [Tiny-Lit transfer record](docs/tiny-lit-migration.md)
 - [Runnable source example](examples/quick-start.ts)

--- a/docs/rfcs/0001-gluon-1.0-product-scope.md
+++ b/docs/rfcs/0001-gluon-1.0-product-scope.md
@@ -1,0 +1,272 @@
+# RFC 0001: Gluon 1.0 product scope and non-goals
+
+- **Status:** Accepted
+- **Decision date:** 2026-07-10
+- **Tracking issue:** [#14](https://github.com/marcmalerei/gluon/issues/14)
+- **Roadmap tracker:** [#42](https://github.com/marcmalerei/gluon/issues/42)
+- **Supersedes:** Nothing
+
+## Decision summary
+
+Gluon 1.0 will be a production-ready, browser-native alternative to Vue for
+web user interfaces and applications. “Alternative” means that Gluon covers
+the application outcomes required to build, inspect, test, render, deploy, and
+maintain those applications without Vue. It does not mean Vue source, syntax,
+component-file, or API compatibility.
+
+Gluon's differentiating contracts remain:
+
+- Custom Elements as the public interoperability boundary
+- JavaScript and TypeScript with `html` and `svg` tagged template literals
+- explicit child, attribute, property, boolean, event, and spread bindings
+- constructable stylesheets and `adoptedStyleSheets` for browser runtime styling
+- separately consumable Quark, Atom, Molecule, and Organism UI layers
+
+Gluon 1.0 is complete only when its runtime and developer workflow are both
+production-ready. Developer experience, universal rendering, verification,
+documentation, and release engineering are product requirements rather than
+optional follow-up polish.
+
+## Why this decision exists
+
+The repository already contains a tested renderer, a reactive Custom Element
+base, adopted stylesheet helpers, typed Quarks, and representative UI layers.
+It does not yet contain standalone reactivity, an application runtime, routing,
+shared state management, Gluon-specific development tooling, SSR, hydration,
+SSG, public packages, a license, or stable APIs.
+
+Without a product-scope contract, roadmap work could drift toward Vue API
+cloning, expand optional UI packages into framework core, or treat isolated
+runtime coverage as evidence of application readiness. This RFC establishes
+the required outcomes and the evidence needed to call them complete.
+
+## Target users
+
+Gluon 1.0 targets:
+
+1. **Application developers** building maintainable browser applications in
+   JavaScript or TypeScript who want a declarative, component-based model
+   without a Vue runtime or Vue-specific component-file format.
+2. **Platform and design-system teams** distributing standards-based Custom
+   Elements that must work in Gluon, plain HTML, and third-party framework hosts.
+3. **Teams shipping universal web applications** that need the same public
+   component model for client rendering, SSR, hydration, streaming, and SSG.
+4. **Library authors** building reusable reactive logic, components, plugins,
+   router integrations, store integrations, or UI packages on documented public APIs.
+
+TypeScript-quality inference and diagnostics are required, but JavaScript use is
+not excluded. The public runtime must not require an editor extension to work.
+
+## Supported application types
+
+Gluon 1.0 supports these application outcomes:
+
+- enhancing existing HTML with Gluon Custom Elements and browser modules
+- build-tool-backed single-page applications
+- component libraries consumed from plain HTML and third-party frameworks
+- server-rendered applications hydrated into interactive browser applications
+- streamed server-rendered applications with asynchronous boundaries
+- statically generated applications using the same public component model
+
+The full-application reference workflow uses the accepted Gluon build tooling.
+Progressive enhancement and component-library consumption must remain possible
+without adopting the complete application platform.
+
+## Required Gluon 1.0 outcomes
+
+The requirements below define outcome parity. They do not prescribe Vue API
+names or implementation techniques.
+
+| ID | Required outcome | Roadmap delivery | Required evidence |
+| --- | --- | --- | --- |
+| G1 | A documented product, component, browser, stylesheet, package, license, and release contract | M0, [#14](https://github.com/marcmalerei/gluon/issues/14)–[#17](https://github.com/marcmalerei/gluon/issues/17) | Accepted RFCs/ADRs and traceable public contracts |
+| G2 | Declarative rendering driven by independently reusable reactive state, with deterministic scheduling and cleanup | M1, [#18](https://github.com/marcmalerei/gluon/issues/18)–[#22](https://github.com/marcmalerei/gluon/issues/22) | Unit and browser conformance suites, identity tests, and memory-retention evidence |
+| G3 | Typed components with props, events, slots, models, refs, context, lifecycle, plugins, and error boundaries | M2, [#23](https://github.com/marcmalerei/gluon/issues/23)–[#24](https://github.com/marcmalerei/gluon/issues/24) | Public type fixtures, component tests, multi-app isolation, and error-path tests |
+| G4 | Production SPA routing and shared state management | M2, [#25](https://github.com/marcmalerei/gluon/issues/25)–[#26](https://github.com/marcmalerei/gluon/issues/26) | Router/store contract tests and production-build end-to-end flows |
+| G5 | Async components, loading boundaries, portals, cached views, and transitions | M2, [#27](https://github.com/marcmalerei/gluon/issues/27) | Browser tests covering loading, failure, cancellation, cleanup, and reduced motion |
+| G6 | A production-like reference SPA built only with public Gluon APIs | M2, [#28](https://github.com/marcmalerei/gluon/issues/28) | Clean install/build plus complete end-to-end acceptance suite |
+| G7 | Scaffolding, Vite integration, state-preserving HMR, language tooling, Devtools, test utilities, playground, and stable diagnostics | M3, [#29](https://github.com/marcmalerei/gluon/issues/29)–[#34](https://github.com/marcmalerei/gluon/issues/34) | Starter matrix, editor/CLI fixtures, HMR state tests, Devtools protocol tests, and consumer test fixtures |
+| G8 | SSR, request isolation, hydration, mismatch diagnostics, streaming, SSG, asset delivery, and initial style transport | M4, [#35](https://github.com/marcmalerei/gluon/issues/35)–[#37](https://github.com/marcmalerei/gluon/issues/37) | Node/server tests, hydration identity fixtures, concurrent-request tests, and deployment fixtures |
+| G9 | Enforced browser/runtime support, accessibility, security, performance, bundle, and memory quality gates | M5, [#38](https://github.com/marcmalerei/gluon/issues/38) | Cross-browser CI, reviewed security/accessibility evidence, and reproducible benchmark artifacts |
+| G10 | Optional, separately consumable, stable UI layers rather than UI dependencies embedded in framework core | M5, [#39](https://github.com/marcmalerei/gluon/issues/39) | Tree-shaking checks, public manifests, component contracts, accessibility evidence, and visual/browser tests |
+| G11 | Versioned guides, API references, examples, migration concepts, and public release artifacts | M5, [#40](https://github.com/marcmalerei/gluon/issues/40)–[#41](https://github.com/marcmalerei/gluon/issues/41) | Clean-room documentation runs and verified registry/release artifacts |
+
+Every roadmap milestone maps to at least one requirement above. Closing an issue
+does not waive the evidence listed in its acceptance criteria or this table.
+
+## Minimum reference applications and fixtures
+
+Gluon 1.0 requires three independent evidence surfaces.
+
+### 1. Production-like SPA
+
+The SPA proves the client application platform and developer workflow. It must:
+
+- use only public Gluon packages and exports
+- include nested and lazy routes, navigation guards, and deep-link reloads
+- include local reactive state and shared stores
+- include accessible forms with validation and async submission
+- include asynchronous views, loading and error boundaries, portals, cached views,
+  and transitions
+- include responsive and keyboard-operable user flows
+- build from a clean install and pass production-build end-to-end tests
+- act as an HMR, Devtools, language-tooling, testing, and bundle-analysis fixture
+
+### 2. Universal application
+
+The universal application proves that the same public component definitions can:
+
+- render as client-side HTML, SSR, streamed SSR, and SSG
+- hydrate without replacing matching owned nodes
+- isolate application, router, store, and reactive state between concurrent requests
+- surface deterministic hydration mismatch diagnostics
+- deliver initial styles through the accepted SSR styling contract
+- pass server, browser, hydration, and deployment tests
+
+### 3. Interoperability fixture
+
+The interoperability fixture proves that a published Gluon Custom Element can be:
+
+- used from plain HTML without the Gluon application runtime
+- used inside the production-like Gluon SPA
+- consumed by at least one documented non-Gluon framework host
+- configured through attributes and properties, observed through native events,
+  and styled according to its public contract
+
+These surfaces prove different requirements. A passing SPA cannot substitute
+for universal-rendering or third-party interoperability evidence.
+
+## Developer experience contract
+
+A stable runtime feature is not complete for Gluon 1.0 until developers can:
+
+- create or enable it through supported project tooling
+- author it with public JavaScript and TypeScript APIs
+- receive editor and command-line diagnostics for invalid use
+- update compatible code through HMR without unnecessary state loss
+- inspect relevant component, reactivity, router, store, event, error, and timing data
+- test it through documented public utilities
+- reproduce failures in a maintained fixture or playground
+- find version-matched guide, API, error, and deployment documentation
+
+The runtime remains usable without the editor extension or Devtools. Tooling
+enhances authoring and diagnosis; it must not be a hidden runtime dependency.
+
+## Explicit Gluon 1.0 non-goals
+
+The following are not Gluon 1.0 requirements:
+
+- Vue source compatibility
+- Vue runtime or Composition/Options API compatibility
+- Vue directive syntax compatibility
+- `.vue` Single-File Component parsing or compilation
+- an automatic Vue-to-Gluon source converter or migration codemod
+- a Vue-compatible runtime template compiler
+- islands or partial-hydration architecture
+- non-DOM renderers for native mobile, desktop, terminal, canvas, or WebGL targets
+- support for browsers outside the browser contract accepted through issue #16
+- embedding the complete Quark/Atom/Molecule/Organism catalog in framework core
+- completing every possible UI component before the stable UI subset can ship
+- claiming that Gluon is faster, smaller, more accessible, more secure, or more
+  compatible than another system without the evidence required below
+
+These items may be proposed after 1.0 through new issues and RFCs. Their absence
+does not prevent Gluon 1.0 when all in-scope requirements are satisfied.
+
+## Claim and verification rules
+
+### Performance and bundle claims
+
+A comparative performance or size claim requires:
+
+- public benchmark source and commands
+- pinned Gluon, comparison-system, browser, runtime, and dependency versions
+- recorded commit identifiers and build modes
+- documented hardware, operating system, and relevant browser/runtime settings
+- identical workloads and output validation across implementations
+- warm-up and sample-count rules defined before comparing results
+- reported distributions or repeated measurements rather than a selected run
+- raw machine-readable results retained as CI or release artifacts
+
+Until those conditions are met, documentation may describe implementation goals
+or measured Gluon values but must not claim superiority over Vue, Lit, or another renderer.
+
+### Compatibility claims
+
+A browser, runtime, framework-host, or deployment compatibility claim requires:
+
+- an accepted support contract naming the target and supported version range
+- automated tests in that target where automation is feasible
+- documented manual evidence for requirements that cannot be automated
+- a public failure or unsupported-environment contract
+- release artifacts produced by the same pipeline used for verification
+
+Passing Chromium tests alone does not establish Firefox, WebKit, server,
+framework-host, accessibility, or deployment compatibility.
+
+### Accessibility, security, memory, and universal-rendering claims
+
+- Accessibility claims require automated checks plus documented keyboard and
+  assistive-technology protocols applicable to the component or workflow.
+- Security claims require an explicit threat model and review of HTML, URLs,
+  styles, serialized state, CSP, and Trusted Types where applicable.
+- Memory-safety claims require repeatable retention tests for components,
+  reactive scopes, listeners, refs, router/store subscriptions, and caches.
+- SSR, hydration, streaming, and SSG claims require server-side tests,
+  concurrent-request isolation, node-identity evidence, mismatch fixtures, and
+  deployment output validation.
+
+Source coverage is useful implementation evidence, but it cannot by itself prove
+an application-, browser-, server-, accessibility-, security-, memory-, or
+performance-level claim.
+
+## Relationship to Vue
+
+The comparison baseline uses Vue's official documentation as evidence of the
+application outcomes developers can reasonably expect from a Vue alternative:
+
+- Vue describes its core as declarative rendering and reactivity and documents
+  progressive enhancement, Web Components, SPA, SSR, and SSG use cases:
+  <https://vuejs.org/guide/introduction>
+- Vue documents component composition and the broader component guide:
+  <https://vuejs.org/guide/essentials/component-basics>
+- Vue documents its expected scaffolding, Vite, IDE, Devtools, TypeScript,
+  testing, linting, and formatting workflow:
+  <https://vuejs.org/guide/scaling-up/tooling>
+- Vue Router documents nested and dynamic routing, history modes, guards, lazy
+  routes, and scroll behavior: <https://router.vuejs.org/introduction.html>
+- Vue recommends Pinia for shared state and identifies Devtools, HMR, SSR, and
+  TypeScript inference as production state-management concerns:
+  <https://vuejs.org/guide/scaling-up/state-management.html>
+- Vue documents unit, component, and end-to-end testing as distinct confidence
+  layers: <https://vuejs.org/guide/scaling-up/testing>
+- Vue's SSR guide documents server rendering, hydration, SSG, request-local
+  application state, and cross-request pollution risks:
+  <https://vuejs.org/guide/scaling-up/ssr>
+
+These sources establish an outcome baseline. They do not require Gluon to copy
+Vue implementation details or public names.
+
+## Scope change process
+
+Issues #15, #16, and #17 decide the component, browser/stylesheet, and package/
+release contracts within this product boundary. They may choose implementation
+details, but they must not remove an in-scope Gluon 1.0 outcome from this RFC.
+
+Changing a required outcome, supported application type, minimum reference
+surface, or explicit non-goal requires:
+
+1. a superseding RFC linked to this document
+2. an update to `docs/roadmap.md`
+3. an update to GitHub tracker #42 and affected roadmap issues
+4. explicit evidence that the revised release gates remain internally consistent
+
+## Acceptance checklist
+
+- [x] Target users and supported application types are explicit.
+- [x] Outcome parity is defined without Vue API compatibility.
+- [x] Vue compatibility, SFC compilation, automatic migration, and islands are explicit non-goals.
+- [x] Minimum SPA, universal, and interoperability reference surfaces are defined.
+- [x] Every roadmap milestone maps to a numbered Gluon 1.0 requirement.
+- [x] Performance and compatibility claims require reproducible evidence.
+- [x] README, roadmap, GitHub issue, and tracker links identify this contract.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,18 @@
+# Gluon RFCs
+
+Accepted RFCs define Gluon's public product and architecture contracts. A
+roadmap issue may refine implementation details, but it must not weaken an
+accepted RFC without a superseding RFC.
+
+| RFC | Status | Decision |
+| --- | --- | --- |
+| [0001](0001-gluon-1.0-product-scope.md) | Accepted | Gluon 1.0 product scope and non-goals |
+
+## Process
+
+1. Open a GitHub issue that states the decision and its acceptance criteria.
+2. Draft the RFC on an issue branch and link it from the roadmap when applicable.
+3. Verify every factual current-state statement against repository or external
+   primary-source evidence.
+4. Merge the RFC through a pull request. The merge records acceptance.
+5. Use a new RFC to change an accepted product or architecture contract.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,6 +11,9 @@ GitHub is the source of truth for delivery status:
 - [Open roadmap issues](https://github.com/marcmalerei/gluon/issues?q=is%3Aissue%20is%3Aopen%20label%3Aroadmap)
 - [Milestones](https://github.com/marcmalerei/gluon/milestones)
 
+The accepted product boundary is defined by
+[RFC 0001: Gluon 1.0 product scope and non-goals](rfcs/0001-gluon-1.0-product-scope.md).
+
 This document records the product contract, dependency order, milestone exit
 criteria, and release gates. Individual issues contain the authoritative
 implementation scope, acceptance criteria, and dependency links.
@@ -34,8 +37,8 @@ The target includes:
 - Custom Element interoperability with plain HTML and third-party frameworks
 
 Vue compatibility syntax, Vue Single-File Component compilation, and automatic
-Vue source migration are not assumed to be Gluon 1.0 requirements. Any such
-requirement must be added through the accepted product-scope RFC.
+Vue source migration are not Gluon 1.0 requirements. Any such requirement must
+be added through a superseding RFC.
 
 ## Verified starting point
 


### PR DESCRIPTION
## Summary
- add accepted RFC 0001 defining the Gluon 1.0 product scope and non-goals
- define target users, supported application types, 11 traceable outcome requirements, and three minimum reference surfaces
- make Vue outcome parity explicit without Vue source, API, directive, runtime-template, or SFC compatibility
- define reproducible evidence rules for performance, compatibility, accessibility, security, memory, SSR, hydration, streaming, and SSG claims
- add an RFC index and link the accepted contract from the README and roadmap

## Delegated review
- three read-only analysis tasks ran on the cost-efficient gpt-5.4-mini model: repository audit, official Vue outcome baseline, and RFC scope critique
- two independent gpt-5.4-mini reviews checked issue acceptance/traceability and factual claims/source links
- both final reviews reported no findings
- delegated findings were independently checked against the repository and current official Vue, Vue Router, and Pinia documentation before inclusion

## Validation
- RFC criteria: 10/10
- roadmap milestone mappings: 6/6
- numbered Gluon 1.0 requirements: 11/11
- local documentation links: valid
- npm run check
- npm audit --audit-level=moderate
- 7 test files and 26 Chromium tests passed
- coverage thresholds passed
- production build completed
- 0 audit vulnerabilities

Closes #14