### PR TITLE
Establish package, release, and supply-chain governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to official Gluon packages are recorded in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and released versions follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- MIT licensing authorized by Marc Malerei.
+- Package topology, release governance, and supply-chain requirements.
+- A machine-readable package contract with independent export validation.
+
+### Changed
+
+- Renamed the private root package from the occupied unscoped name `gluon` to
+  the planned scoped name `@gluonjs/core`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2026 Marc Malerei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ import {
   foundationStyles,
   layerOrderStyles,
   render,
-} from 'gluon';
-import { q } from 'gluon/quarks';
-import { Button, atomStyles } from 'gluon/atoms';
-import { Card, moleculeStyles } from 'gluon/molecules';
+} from '@gluonjs/core';
+import { q } from '@gluonjs/core/quarks';
+import { Button, atomStyles } from '@gluonjs/core/atoms';
+import { Card, moleculeStyles } from '@gluonjs/core/molecules';
 
 adoptStyles(
   document,
@@ -68,7 +68,7 @@ render(Card({
 The same renderer can be used directly:
 
 ```ts
-import { html, render } from 'gluon';
+import { html, render } from '@gluonjs/core';
 
 const view = (name: string) => html`<h1>Hello ${name}</h1>`;
 render(view('world'), document.body);
@@ -112,7 +112,7 @@ Each expression must occupy a complete child or attribute value. Compose partial
 `GluonElement` turns the renderer and stylesheet contract into a small reactive Custom Element base:
 
 ```ts
-import { GluonElement, css, defineElement, html } from 'gluon';
+import { GluonElement, css, defineElement, html } from '@gluonjs/core';
 
 class GreetingElement extends GluonElement {
   static override readonly properties = {
@@ -140,7 +140,7 @@ Declared properties receive accessors, schedule microtask-batched updates, may r
 Gluon component styles are `CSSStyleSheet` instances. They are installed through `adoptedStyleSheets`; the library deliberately ships no `<style>` fallback:
 
 ```ts
-import { adoptStyles, css } from 'gluon/styles';
+import { adoptStyles, css } from '@gluonjs/core/styles';
 
 const theme = css`
   :root { color-scheme: light dark; }
@@ -164,11 +164,11 @@ Gluon is the base system. Its UI vocabulary increases in scope without changing 
 
 | Layer | Current role and entry point |
 | --- | --- |
-| **Gluon** | Template runtime, Custom Element base, prop merging, and stylesheet adoption from `gluon`. |
-| **Quarks** | Typed factories for native HTML elements through `gluon/quarks` and `q.<tag>()`. |
-| **Atoms** | Focused primitives such as `Icon`, `Button`, `Input`, and `Label` from `gluon/atoms`. |
-| **Molecules** | Reusable compositions such as `Card` and `FormField` from `gluon/molecules`. |
-| **Organisms** | Larger interface structures such as `AppShell` from `gluon/organisms`. |
+| **Gluon** | Template runtime, Custom Element base, prop merging, and stylesheet adoption from `@gluonjs/core`. |
+| **Quarks** | Typed factories for native HTML elements through the transitional `@gluonjs/core/quarks` subpath and `q.<tag>()`. |
+| **Atoms** | Focused primitives such as `Icon`, `Button`, `Input`, and `Label` through the transitional `@gluonjs/core/atoms` subpath. |
+| **Molecules** | Reusable compositions such as `Card` and `FormField` through the transitional `@gluonjs/core/molecules` subpath. |
+| **Organisms** | Larger interface structures such as `AppShell` through the transitional `@gluonjs/core/organisms` subpath. |
 
 ```text
                          increasing UI scope
@@ -179,6 +179,10 @@ Gluon is the base system. Its UI vocabulary increases in scope without changing 
 ```
 
 Every component created with `defineAtom`, `defineMolecule`, or `defineOrganism` carries explicit `layer` and `displayName` metadata.
+
+The accepted package graph moves Quarks, Atoms, Molecules, and Organisms into
+optional `@gluonjs/*` packages before 1.0. The current subpaths remain documented
+as transitional because those separate packages are not implemented yet.
 
 ## Why Gluon?
 
@@ -206,6 +210,8 @@ The following points describe architectural advantages and design goals. Outcome
 - [Gluon 1.0 product scope RFC](docs/rfcs/0001-gluon-1.0-product-scope.md)
 - [Unified component and Custom Element model RFC](docs/rfcs/0002-unified-component-model.md)
 - [Browser, runtime, and style transport ADR](docs/adrs/0001-browser-runtime-and-style-transport.md)
+- [Package, release, and supply-chain governance ADR](docs/adrs/0002-package-release-and-supply-chain-governance.md)
+- [Machine-readable package contract](package-contract.json)
 - [Gluon 1.0 roadmap](docs/roadmap.md)
 - [Tiny-Lit transfer record](docs/tiny-lit-migration.md)
 - [Runnable source example](examples/quick-start.ts)
@@ -238,10 +244,11 @@ npm run typecheck
 npm test
 npm run test:coverage
 npm run build
+npm run check:packages
 npm audit --audit-level=moderate
 ```
 
-`npm run test:coverage` prints the V8 coverage summary and writes the ignored HTML report to `coverage/`. Run all project checks, including the coverage thresholds, with `npm run check`.
+`npm run test:coverage` prints the V8 coverage summary and writes the ignored HTML report to `coverage/`. `npm run check:packages` validates every planned package contract and the built export and pack contents of current packages. Run all project checks, including the coverage thresholds and package contract, with `npm run check`.
 
 ## Contributing
 
@@ -249,4 +256,4 @@ The runtime exists, but the API remains experimental. Use [GitHub Issues](https:
 
 ## License
 
-No license file is currently included in this repository.
+[MIT](LICENSE) — Copyright © 2026 Marc Malerei.

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -1,0 +1,285 @@
+# ADR 0002: Package, release, and supply-chain governance
+
+- **Status:** Accepted
+- **Decision date:** 2026-07-10
+- **Tracking issue:** [#17](https://github.com/marcmalerei/gluon/issues/17)
+- **Roadmap tracker:** [#42](https://github.com/marcmalerei/gluon/issues/42)
+- **Depends on:** [RFC 0001](../rfcs/0001-gluon-1.0-product-scope.md), [RFC 0002](../rfcs/0002-unified-component-model.md), [ADR 0001](0001-browser-runtime-and-style-transport.md)
+- **Supersedes:** Nothing
+
+## Decision summary
+
+Official framework packages use the `@gluonjs` npm scope. The project generator
+uses the unscoped name `create-gluon`. The current private root package is named
+`@gluonjs/core`; its existing UI subpath exports are transitional and will move
+to separately consumable packages before 1.0.
+
+Every official package follows one lockstep Semantic Versioning release train,
+one changelog, one source tag, and one immutable GitHub release. Public releases
+use npm trusted publishing from GitHub Actions, npm provenance, GitHub artifact
+attestations, per-package and aggregate SBOMs, checksums, and a clean-build
+reproducibility check. Long-lived npm publication tokens are prohibited.
+
+The repository and packages use the MIT License with the authorized notice
+`Copyright © 2026 Marc Malerei`.
+
+No package may be published until control of the `@gluonjs` npm scope is
+verified. Provenance-bearing public publication additionally requires this
+repository to be public. The current repository is private, so publication
+remains blocked.
+
+## Verified registry and repository state
+
+The following observations were made against the public npm registry and the
+repository on 2026-07-10:
+
+- `npm view gluon` resolved the existing third-party package `gluon@1.8.4`.
+  Gluon therefore rejects the unscoped `gluon` package name.
+- Exact registry requests returned HTTP 404 for `create-gluon` and each selected
+  `@gluonjs/*` package listed below.
+- An HTTP 404 does not establish ownership, reservation, or future availability.
+- `npm whoami` failed because the local npm client is not authenticated. Control
+  of the `@gluonjs` organization could not be verified.
+- The GitHub repository is private, has no releases, and has no Git tags.
+- The root package was private, version `0.0.0`, and named `gluon` before this
+  decision. `npm pack --dry-run --json` succeeded, but its output contained no
+  license or changelog.
+
+The selected namespace is a release contract, not an assertion of registry
+ownership. Issue [#41](https://github.com/marcmalerei/gluon/issues/41) must
+verify organization control and trusted-publisher configuration before the
+first publication. If `@gluonjs` cannot be controlled, a superseding ADR must
+choose a different namespace and update every package, import, template, and
+documentation reference before publication.
+
+## Package topology
+
+[`package-contract.json`](../../package-contract.json) is the machine-readable
+source of truth. `npm run check:packages` validates its names, exports,
+dependencies, and acyclic graph. It also validates actual build targets and
+`npm pack` contents for every package whose state is `current`. A named contract
+can be checked independently with:
+
+```bash
+npm run check:packages -- --package @gluonjs/core
+npm run check:packages -- --package @gluonjs/reactivity
+```
+
+Planned packages pass contract validation before their directories exist. When
+implementation starts, changing a package state to `current` makes its package
+manifest, export targets, license, changelog, README, and pack output mandatory.
+
+| Package | Responsibility | Allowed official dependencies |
+| --- | --- | --- |
+| `@gluonjs/reactivity` | Signals, computed state, effects, scopes, and scheduler-independent reactive primitives | none |
+| `@gluonjs/compiler` | Static template analysis and shared diagnostics | none |
+| `@gluonjs/core` | Templates, renderer, component/application runtime, Custom Elements, and style APIs | `reactivity` |
+| `@gluonjs/router` | History, route matching, navigation, guards, and route components | `core`, `reactivity` |
+| `@gluonjs/store` | Request-local and client shared state | `reactivity` |
+| `@gluonjs/ssr` | Server rendering, streaming, hydration payloads, and request isolation | `core`, `reactivity` |
+| `@gluonjs/vite` | Build integration, transforms, manifests, and HMR | `compiler` |
+| `@gluonjs/test-utils` | Public mounting, queries, scheduler control, and cleanup | `core`, `reactivity` |
+| `@gluonjs/devtools-api` | Versioned, environment-neutral inspection protocol | none |
+| `@gluonjs/devtools` | Browser Devtools client and integrations | `devtools-api` |
+| `@gluonjs/language-server` | Editor analysis and protocol server | `compiler` |
+| `@gluonjs/quarks` | Typed native-element factories | `core` |
+| `@gluonjs/atoms` | Focused UI primitives | `core`, `quarks` |
+| `@gluonjs/molecules` | Reusable primitive compositions | `core`, `quarks`, `atoms` |
+| `@gluonjs/organisms` | Larger interface structures | `core`, `quarks`, `atoms`, `molecules` |
+| `create-gluon` | Project generator and maintained templates | none at runtime |
+
+Package dependency names in the table omit the common `@gluonjs/` prefix.
+Third-party build dependencies are not part of this architectural graph.
+
+### Dependency rules
+
+1. The graph is acyclic. Core never depends on the router, store, SSR, tooling,
+   Devtools, test utilities, or UI packages.
+2. Reactivity and compiler packages do not depend on DOM APIs. Store state is
+   server-safe and request-local when used during SSR.
+3. UI dependencies point only downward: Organisms to Molecules to Atoms to
+   Quarks to Core. Applications can omit every UI package.
+4. Tooling consumes versioned public exports. Cross-package source deep imports,
+   `dist` deep imports, and undeclared package entry points are prohibited.
+5. Browser packages used by universal rendering must not evaluate browser-only
+   globals at Node import time. ADR 0001 controls style extraction and the
+   server-to-browser handoff.
+6. Runtime integrations that require one application or reactivity identity use
+   compatible peer dependencies plus matching development dependencies. Pure
+   implementation dependencies in the release group use the exact lockstep
+   version.
+7. `@gluonjs/devtools-api` owns only a serializable protocol. Framework-specific
+   adapters belong in their consuming packages, preventing a protocol-to-core
+   dependency cycle.
+
+### Transitional root exports
+
+The current root build exposes `.`, `./styles`, `./quarks`, `./atoms`,
+`./molecules`, and `./organisms`. The final Core contract exposes only `.` and
+`./styles`; issue [#39](https://github.com/marcmalerei/gluon/issues/39) moves the
+four UI layers to their named packages. Until that issue is complete, README
+examples use the real current `@gluonjs/core/*` subpaths and do not claim that
+the separate UI packages are already implemented.
+
+## Public API boundary
+
+The following are public compatibility commitments once a package reaches a
+stable release:
+
+- package export names, JavaScript behavior, TypeScript declarations, and
+  documented configuration
+- Custom Element tag names, properties, attributes, methods, events, slots, and
+  lifecycle timing
+- CSS custom properties, parts, states, layers, and other documented style hooks
+- serialized SSR/hydration formats, style manifests, Devtools protocols, and
+  compiler or language-server protocols that are marked public
+- CLI commands, flags, exit codes, stable diagnostic codes, and maintained
+  template behavior
+
+Undocumented source paths, internal symbols, generated file layout, private
+diagnostics, test fixtures, and benchmark internals are not public API. The
+`exports` map is the enforcement boundary; adding an export requires documented
+ownership and compatibility tests.
+
+## Versioning and support
+
+All official packages use the same version and are released together, including
+packages without source changes. One lockstep train prevents unsupported
+combinations while the component, SSR, compiler, Devtools, and UI protocols
+stabilize.
+
+Gluon follows Semantic Versioning:
+
+- `0.y.z` releases are explicitly unstable. Minor releases may contain breaking
+  changes, and every such change must be called out in the changelog.
+- Starting with `1.0.0`, incompatible public API changes require a major release,
+  backward-compatible additions require a minor release, and compatible fixes
+  require a patch release.
+- A released version is immutable and is never rebuilt or republished. A defect
+  is fixed in a new version.
+- `latest` points only to stable releases, `next` to release candidates or other
+  planned prereleases, and `canary` to explicitly unsupported commit previews.
+- The latest major and its latest minor receive regular fixes. The latest minor
+  of the immediately preceding major receives critical security fixes. Older
+  lines are unsupported unless a release notice explicitly extends support.
+- Supported Node and browser versions follow ADR 0001 and the immutable
+  compatibility manifest attached to each release.
+
+## Deprecation and removal
+
+A stable public API is deprecated before removal:
+
+1. Introduce the deprecation in a minor release with an alternative, migration
+   instructions, a changelog entry, TypeScript `@deprecated` metadata where
+   applicable, and a stable development diagnostic where runtime use is visible.
+2. Retain it through at least the next stable minor release.
+3. Remove it only in a major release and list the removal under `Removed`.
+
+Security, legal, or data-integrity emergencies may require immediate disabling
+or removal. The security advisory and release notes must record the reason and
+the smallest safe migration path.
+
+Published npm versions are deprecated rather than unpublished. Unpublishing is
+reserved for legal requirements, exposed secrets, or security emergencies and
+must comply with npm policy. A defective release is fixed with a new version;
+moving a dist-tag may limit discovery but does not rewrite history.
+
+## Changelog and release process
+
+`CHANGELOG.md` is maintained in the repository with `Added`, `Changed`,
+`Deprecated`, `Removed`, `Fixed`, and `Security` categories. Every release PR:
+
+1. verifies a clean source tree, lockfile, package graph, public exports, types,
+   full test matrix, documentation, licenses, dependency audit, and package
+   contents
+2. updates all official package versions and exact intra-repository dependencies
+3. freezes the release compatibility manifest and changelog
+4. builds every package from a clean checkout and compares the unpacked,
+   canonical package-file SHA-256 digests with the candidate artifacts
+5. creates one protected `vX.Y.Z` tag for the reviewed source commit
+6. creates one immutable GitHub release containing packages, checksums,
+   compatibility evidence, SBOMs, and attestations
+7. obtains required approval through a protected GitHub release environment
+8. publishes through npm trusted publishing with public access and provenance
+9. verifies registry installation, exports, types, provenance, and dist-tags
+   from an empty consumer project
+
+The first public release additionally verifies the npm organization, package
+names, public repository state, trusted-publisher bindings, recovery owners,
+and account multi-factor authentication.
+
+## Supply-chain evidence
+
+Public release jobs use GitHub-hosted runners, minimal job permissions, and
+`id-token: write` only where OIDC or attestations require it. npm trusted
+publishing is the only authorized publication identity; repository or
+organization secrets must not contain a long-lived npm publication token.
+
+Each package and the aggregate release receive:
+
+- npm provenance linked to the public source repository and GitHub Actions run
+- GitHub artifact attestations backed by Sigstore's transparency log
+- an SPDX 2.3 JSON SBOM and a CycloneDX 1.7 JSON SBOM
+- a `SHA256SUMS` manifest covering release assets
+- source commit, workflow identity, Node/npm versions, and lockfile digest in
+  the release evidence
+
+Provenance authenticates build origin; it does not prove that source or
+dependencies are safe. Tests, review, dependency policy, audits, and incident
+response remain separate release gates.
+
+npm documents that automatic provenance from trusted publishing is
+available only for public repositories publishing public packages. Because this
+repository is private, issue #41 must make it public before a compliant release.
+Static GPG release keys are not required: the OIDC, npm provenance, and Sigstore-
+backed GitHub attestations provide the selected short-lived signing model.
+
+## Authorization and licensing
+
+Marc Malerei explicitly authorized the following repository license and notice
+on 2026-07-10:
+
+> MIT License, Copyright © 2026 Marc Malerei.
+
+The root [`LICENSE`](../../LICENSE) contains the MIT terms and exact notice.
+Every package manifest declares `MIT`, and every package archive includes the
+license. Third-party code and dependencies retain their own notices and license
+obligations; they must not be relabeled as Gluon-owned code.
+
+## Consequences
+
+- The private package now has its final planned Core name, while publication is
+  blocked until registry authority and public provenance prerequisites exist.
+- The current single-package build remains usable while package extraction is
+  staged through roadmap issues.
+- Lockstep releases publish unchanged packages too, trading extra registry
+  versions for one compatibility matrix.
+- UI packages remain optional and cannot grow Core through reverse dependencies.
+- Release automation has more gates and artifacts, but every public package can
+  be traced to reviewed source and independently inspected.
+
+## Primary references
+
+- [npm scoped packages](https://docs.npmjs.com/cli/v11/using-npm/scope/)
+- [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
+- [npm provenance statements](https://docs.npmjs.com/generating-provenance-statements/)
+- [npm dist-tags](https://docs.npmjs.com/adding-dist-tags-to-packages/)
+- [npm package deprecation](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions/)
+- [npm unpublish policy](https://docs.npmjs.com/policies/unpublish/)
+- [Semantic Versioning 2.0.0](https://semver.org/)
+- [Open Source Initiative MIT License](https://opensource.org/license/mit)
+- [GitHub artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations)
+- [GitHub supply-chain security and immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/supply-chain-security)
+- [SPDX 2.3 specification](https://spdx.github.io/spdx-spec/v2.3/)
+- [CycloneDX 1.7 JSON specification](https://cyclonedx.org/docs/1.7/json/)
+
+## Acceptance checklist
+
+- [x] The namespace decision records observed registry results without claiming ownership.
+- [x] Package responsibilities, dependency direction, public exports, and graph validation are defined.
+- [x] The authorized MIT license and exact copyright notice are present.
+- [x] SemVer, support, deprecation, changelog, and release rules are documented.
+- [x] Provenance, attestation, signing, SBOM, checksum, and reproducibility gates are documented.
+- [x] Every planned package contract can be validated independently.
+- [x] Current package exports, types, license, changelog, and pack contents are validated after build.
+- [x] Publication remains blocked until npm scope control and public-repository provenance requirements are verified.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -7,6 +7,7 @@ weaken an accepted ADR without a superseding decision record.
 | ADR | Status | Decision |
 | --- | --- | --- |
 | [0001](0001-browser-runtime-and-style-transport.md) | Accepted | Browser, runtime, adopted stylesheet, and SSR style transport contract |
+| [0002](0002-package-release-and-supply-chain-governance.md) | Accepted | Package topology, licensing, releases, and supply-chain governance |
 
 ## Process
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,12 @@ src/
 └── organisms/          AppShell
 ```
 
-The package builds separate ESM entry points for `gluon`, `gluon/styles`, `gluon/quarks`, `gluon/atoms`, `gluon/molecules`, and `gluon/organisms`.
+The current private package builds separate ESM entry points for `@gluonjs/core`,
+`@gluonjs/core/styles`, `@gluonjs/core/quarks`, `@gluonjs/core/atoms`,
+`@gluonjs/core/molecules`, and `@gluonjs/core/organisms`. The accepted
+[package governance ADR](adrs/0002-package-release-and-supply-chain-governance.md)
+makes the four UI-layer subpaths transitional and defines their final optional
+packages.
 
 ## Runtime contract
 
@@ -108,6 +113,11 @@ compose any of these functional layers.
 Layer styles are exported as constructable sheets and must be adopted explicitly. This avoids import-time DOM mutation and keeps application stylesheet ownership visible.
 
 ## Verification boundaries
+
+The machine-readable [`package-contract.json`](../package-contract.json) defines
+the complete planned package graph. `npm run check:packages` validates every
+declared package independently and additionally verifies built exports, types,
+license, changelog, README, and `npm pack` contents for implemented packages.
 
 The browser suite verifies DOM identity, nested templates, arrays, all binding forms, spread cleanup, refs, Custom Element properties and reflection, SVG namespaces, Quark factories, layer composition, and stylesheet adoption.
 

--- a/docs/rfcs/0001-gluon-1.0-product-scope.md
+++ b/docs/rfcs/0001-gluon-1.0-product-scope.md
@@ -249,9 +249,12 @@ Vue implementation details or public names.
 
 ## Scope change process
 
-Issues #15, #16, and #17 decide the component, browser/stylesheet, and package/
-release contracts within this product boundary. They may choose implementation
-details, but they must not remove an in-scope Gluon 1.0 outcome from this RFC.
+[RFC 0002](0002-unified-component-model.md),
+[ADR 0001](../adrs/0001-browser-runtime-and-style-transport.md), and
+[ADR 0002](../adrs/0002-package-release-and-supply-chain-governance.md) define
+the component, browser/stylesheet, and package/release contracts within this
+product boundary. They may choose implementation details, but they must not
+remove an in-scope Gluon 1.0 outcome from this RFC.
 
 Changing a required outcome, supported application type, minimum reference
 surface, or explicit non-goal requires:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,6 +16,9 @@ The accepted product and component boundaries are defined by
 and [RFC 0002: Unified component and Custom Element model](rfcs/0002-unified-component-model.md).
 The supported environments and style transport are defined by
 [ADR 0001: Browser, runtime, and style transport contract](adrs/0001-browser-runtime-and-style-transport.md).
+The package graph, authorized license, versioning, release, and supply-chain
+rules are defined by
+[ADR 0002: Package, release, and supply-chain governance](adrs/0002-package-release-and-supply-chain-governance.md).
 
 This document records the product contract, dependency order, milestone exit
 criteria, and release gates. Individual issues contain the authoritative
@@ -58,8 +61,7 @@ Gluon currently provides:
 
 The current repository does not provide standalone reactivity, an application
 runtime, routing, shared state management, SSR, hydration, SSG, Gluon-specific
-HMR, language tooling, Devtools, consumer test utilities, a public release, or a
-license file.
+HMR, language tooling, Devtools, consumer test utilities, or a public release.
 
 ## Product principles
 

--- a/docs/tiny-lit-migration.md
+++ b/docs/tiny-lit-migration.md
@@ -9,7 +9,12 @@
 - Its README ended with the text `MIT`.
 - The inspected snapshot contained no `LICENSE`, `LICENSE.md`, `COPYING`, or `NOTICE` file, and its `package.json` contained no `license` field.
 
-This repository does not infer a copyright holder or add a license from those incomplete files. Gluon's existing README continues to state that no license file is present.
+Those incomplete snapshot files did not establish a copyright holder or license
+authority. On 2026-07-10, Marc Malerei explicitly authorized Gluon under the MIT
+License with `Copyright © 2026 Marc Malerei`. The repository license is therefore
+based on that later authorization, not an inference from the Tiny-Lit snapshot.
+See [ADR 0002](adrs/0002-package-release-and-supply-chain-governance.md)
+and the root [`LICENSE`](../LICENSE).
 
 ## Transferred concepts and code paths
 

--- a/package-contract.json
+++ b/package-contract.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "./schemas/package-contract.schema.json",
+  "version": 1,
+  "releaseGroup": "gluon-framework",
+  "versioning": "lockstep",
+  "registry": {
+    "url": "https://registry.npmjs.org",
+    "checkedAt": "2026-07-10",
+    "scope": "@gluonjs",
+    "scopeControl": "unverified",
+    "publicationState": "blocked",
+    "observation": "The exact scoped package requests returned HTTP 404 when checked; this does not prove scope ownership, reservation, or future availability."
+  },
+  "packages": [
+    {
+      "name": "@gluonjs/reactivity",
+      "directory": "packages/reactivity",
+      "state": "planned",
+      "environment": "universal",
+      "exports": ["."],
+      "dependencies": []
+    },
+    {
+      "name": "@gluonjs/compiler",
+      "directory": "packages/compiler",
+      "state": "planned",
+      "environment": "universal",
+      "exports": ["."],
+      "dependencies": []
+    },
+    {
+      "name": "@gluonjs/core",
+      "directory": ".",
+      "state": "current",
+      "environment": "browser",
+      "exports": [".", "./styles", "./quarks", "./atoms", "./molecules", "./organisms"],
+      "finalExports": [".", "./styles"],
+      "currentDependencies": [],
+      "dependencies": ["@gluonjs/reactivity"]
+    },
+    {
+      "name": "@gluonjs/router",
+      "directory": "packages/router",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/core", "@gluonjs/reactivity"]
+    },
+    {
+      "name": "@gluonjs/store",
+      "directory": "packages/store",
+      "state": "planned",
+      "environment": "universal",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/reactivity"]
+    },
+    {
+      "name": "@gluonjs/ssr",
+      "directory": "packages/ssr",
+      "state": "planned",
+      "environment": "node",
+      "exports": [".", "./streaming"],
+      "dependencies": ["@gluonjs/core", "@gluonjs/reactivity"]
+    },
+    {
+      "name": "@gluonjs/vite",
+      "directory": "packages/vite",
+      "state": "planned",
+      "environment": "node",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/compiler"]
+    },
+    {
+      "name": "@gluonjs/test-utils",
+      "directory": "packages/test-utils",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/core", "@gluonjs/reactivity"]
+    },
+    {
+      "name": "@gluonjs/devtools-api",
+      "directory": "packages/devtools-api",
+      "state": "planned",
+      "environment": "universal",
+      "exports": ["."],
+      "dependencies": []
+    },
+    {
+      "name": "@gluonjs/devtools",
+      "directory": "packages/devtools",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/devtools-api"]
+    },
+    {
+      "name": "@gluonjs/language-server",
+      "directory": "packages/language-server",
+      "state": "planned",
+      "environment": "node",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/compiler"]
+    },
+    {
+      "name": "@gluonjs/quarks",
+      "directory": "packages/quarks",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/core"]
+    },
+    {
+      "name": "@gluonjs/atoms",
+      "directory": "packages/atoms",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/core", "@gluonjs/quarks"]
+    },
+    {
+      "name": "@gluonjs/molecules",
+      "directory": "packages/molecules",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/core", "@gluonjs/quarks", "@gluonjs/atoms"]
+    },
+    {
+      "name": "@gluonjs/organisms",
+      "directory": "packages/organisms",
+      "state": "planned",
+      "environment": "browser",
+      "exports": ["."],
+      "dependencies": ["@gluonjs/core", "@gluonjs/quarks", "@gluonjs/atoms", "@gluonjs/molecules"]
+    },
+    {
+      "name": "create-gluon",
+      "directory": "packages/create-gluon",
+      "state": "planned",
+      "environment": "node",
+      "exports": ["."],
+      "bins": ["create-gluon"],
+      "dependencies": []
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "gluon",
+  "name": "@gluonjs/core",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gluon",
+      "name": "@gluonjs/core",
       "version": "0.0.0",
+      "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.0",
         "@vitest/browser-playwright": "^4.0.18",
@@ -17,7 +18,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^22.12.0 || ^24.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,23 @@
 {
-  "name": "gluon",
+  "name": "@gluonjs/core",
   "version": "0.0.0",
   "description": "A native-first UI system built on Custom Elements, HTML template literals, and adopted stylesheets.",
   "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marcmalerei/gluon.git"
+  },
+  "homepage": "https://github.com/marcmalerei/gluon#readme",
+  "bugs": {
+    "url": "https://github.com/marcmalerei/gluon/issues"
+  },
   "type": "module",
   "module": "./dist/index.js",
   "types": "./dist/types/index.d.ts",
   "sideEffects": false,
   "engines": {
-    "node": "^20.19.0 || >=22.12.0"
+    "node": "^22.12.0 || ^24.0.0"
   },
   "exports": {
     ".": {
@@ -38,15 +47,22 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
   ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "vite build && tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
-    "check": "npm run typecheck && npm run test:coverage && npm run build"
+    "check:packages": "node scripts/validate-package-contract.mjs",
+    "check": "npm run typecheck && npm run test:coverage && npm run build && npm run check:packages"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/schemas/package-contract.schema.json
+++ b/schemas/package-contract.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/marcmalerei/gluon/schemas/package-contract.schema.json",
+  "title": "Gluon package contract",
+  "type": "object",
+  "required": ["version", "releaseGroup", "versioning", "registry", "packages"],
+  "properties": {
+    "version": { "const": 1 },
+    "releaseGroup": { "type": "string", "minLength": 1 },
+    "versioning": { "const": "lockstep" },
+    "registry": {
+      "type": "object",
+      "required": ["url", "checkedAt", "scope", "scopeControl", "publicationState", "observation"],
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "checkedAt": { "type": "string", "format": "date" },
+        "scope": { "const": "@gluonjs" },
+        "scopeControl": { "enum": ["unverified", "verified"] },
+        "publicationState": { "enum": ["blocked", "allowed"] },
+        "observation": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "packages": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "directory", "state", "environment", "exports", "dependencies"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "directory": { "type": "string", "minLength": 1 },
+          "state": { "enum": ["current", "planned"] },
+          "environment": { "enum": ["browser", "node", "universal"] },
+          "exports": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "finalExports": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "bins": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "currentDependencies": { "type": "array", "items": { "type": "string" } },
+          "dependencies": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/validate-package-contract.mjs
+++ b/scripts/validate-package-contract.mjs
@@ -1,0 +1,151 @@
+import { access, readFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+const root = resolve(import.meta.dirname, '..');
+const contract = JSON.parse(await readFile(resolve(root, 'package-contract.json'), 'utf8'));
+const selectedName = process.argv[2] === '--package' ? process.argv[3] : undefined;
+
+if (process.argv.length > 2 && (!selectedName || process.argv.length !== 4)) {
+  throw new Error('Usage: node scripts/validate-package-contract.mjs [--package <package-name>]');
+}
+
+const packages = contract.packages;
+const byName = new Map(packages.map((entry) => [entry.name, entry]));
+
+if (contract.version !== 1 || contract.versioning !== 'lockstep') {
+  throw new Error('Only package contract version 1 with lockstep versioning is supported.');
+}
+if (contract.registry.scope !== '@gluonjs') {
+  throw new Error('The package contract must use the accepted @gluonjs scope.');
+}
+
+if (byName.size !== packages.length) {
+  throw new Error('Package names must be unique.');
+}
+if (new Set(packages.map((entry) => entry.directory)).size !== packages.length) {
+  throw new Error('Package directories must be unique.');
+}
+
+if (selectedName && !byName.has(selectedName)) {
+  throw new Error(`Unknown package ${selectedName}.`);
+}
+
+const validPackageName = /^(?:@gluonjs\/[a-z0-9]+(?:-[a-z0-9]+)*|create-gluon)$/;
+const validExport = /^\.$|^\.\/[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+for (const entry of packages) {
+  if (!validPackageName.test(entry.name)) {
+    throw new Error(`Invalid official package name: ${entry.name}.`);
+  }
+
+  for (const exports of [entry.exports, entry.finalExports].filter(Boolean)) {
+    if (new Set(exports).size !== exports.length || exports.some((item) => !validExport.test(item))) {
+      throw new Error(`${entry.name} has duplicate or unsafe exports.`);
+    }
+  }
+  if (entry.bins?.some((bin) => !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(bin))) {
+    throw new Error(`${entry.name} has an unsafe executable name.`);
+  }
+
+  for (const dependency of entry.dependencies) {
+    if (!byName.has(dependency)) {
+      throw new Error(`${entry.name} references undeclared package ${dependency}.`);
+    }
+    if (dependency === entry.name) {
+      throw new Error(`${entry.name} cannot depend on itself.`);
+    }
+  }
+}
+
+const visiting = new Set();
+const visited = new Set();
+
+function visit(name, path = []) {
+  if (visiting.has(name)) {
+    throw new Error(`Package dependency cycle: ${[...path, name].join(' -> ')}.`);
+  }
+  if (visited.has(name)) return;
+
+  visiting.add(name);
+  const entry = byName.get(name);
+  for (const dependency of entry.dependencies) visit(dependency, [...path, name]);
+  visiting.delete(name);
+  visited.add(name);
+}
+
+for (const entry of packages) visit(entry.name);
+
+async function validateCurrentPackage(entry) {
+  const directory = resolve(root, entry.directory);
+  const packageJson = JSON.parse(await readFile(resolve(directory, 'package.json'), 'utf8'));
+
+  if (packageJson.name !== entry.name) {
+    throw new Error(`${entry.name} does not match ${packageJson.name} in package.json.`);
+  }
+  if (packageJson.license !== 'MIT') {
+    throw new Error(`${entry.name} must declare the authorized MIT license.`);
+  }
+
+  const actualOfficialDependencies = new Set(
+    ['dependencies', 'peerDependencies']
+      .flatMap((field) => Object.keys(packageJson[field] ?? {}))
+      .filter((name) => byName.has(name)),
+  );
+  const expectedCurrentDependencies = new Set(entry.currentDependencies ?? entry.dependencies);
+  if (
+    actualOfficialDependencies.size !== expectedCurrentDependencies.size
+    || [...actualOfficialDependencies].some((name) => !expectedCurrentDependencies.has(name))
+  ) {
+    throw new Error(`${entry.name} installed official dependencies do not match its current package contract.`);
+  }
+
+  const exportNames = Object.keys(packageJson.exports ?? {});
+  if (JSON.stringify(exportNames.sort()) !== JSON.stringify([...entry.exports].sort())) {
+    throw new Error(`${entry.name} package.json exports do not match its package contract.`);
+  }
+
+  const requiredPackFiles = ['package.json', 'README.md', 'LICENSE', 'CHANGELOG.md'];
+  for (const required of ['LICENSE', 'CHANGELOG.md']) {
+    if (!packageJson.files?.includes(required)) {
+      throw new Error(`${entry.name} must include ${required} in its files allowlist.`);
+    }
+  }
+
+  const exportTargets = [];
+  for (const [exportName, targets] of Object.entries(packageJson.exports)) {
+    for (const condition of ['types', 'import']) {
+      const target = targets?.[condition];
+      if (typeof target !== 'string' || !target.startsWith('./')) {
+        throw new Error(`${entry.name} export ${exportName} requires a relative ${condition} target.`);
+      }
+      const relativeTarget = target.slice(2);
+      await access(resolve(directory, relativeTarget));
+      exportTargets.push(relativeTarget);
+    }
+  }
+
+  const packOutput = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+    cwd: directory,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const packResult = JSON.parse(packOutput)[0];
+  const packedFiles = new Set(packResult.files.map((file) => file.path));
+
+  for (const required of [...requiredPackFiles, ...exportTargets]) {
+    if (!packedFiles.has(required)) {
+      throw new Error(`${entry.name} pack output is missing ${required}.`);
+    }
+  }
+}
+
+const selectedPackages = selectedName ? [byName.get(selectedName)] : packages;
+
+for (const entry of selectedPackages) {
+  if (entry.state === 'current') await validateCurrentPackage(entry);
+  console.log(`validated ${entry.name} (${entry.state}: ${entry.exports.join(', ')})`);
+}
+
+console.log(`package contract valid: ${selectedPackages.length} package${selectedPackages.length === 1 ? '' : 's'}`);


### PR DESCRIPTION
## Summary
- accept ADR 0002 with the `@gluonjs/*` package graph, dependency rules, lockstep SemVer, deprecation, support, changelog, and release contracts
- add the authorized MIT license with `Copyright © 2026 Marc Malerei`
- rename the private root package to `@gluonjs/core` and add a machine-readable contract plus independent export and tarball validation for all 16 planned packages
- require trusted publishing, provenance, attestations, SPDX and CycloneDX SBOMs, checksums, and reproducibility evidence while blocking publication until npm scope control and a public repository are verified

## Verification
- `npm run check`
  - 7 test files and 26 tests passed
  - 97.07% statements, 93.42% branches, 99.13% functions, 97.94% lines
  - all 16 package contracts validated; current Core exports, types, license, changelog, README, and pack contents validated
- `npm run check:packages -- --package @gluonjs/reactivity`
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check`
- two independent read-only reviews reported no findings

Closes #17