### PR TITLE
Add standalone DOM-free reactivity package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- A standalone, DOM-free `@gluonjs/reactivity` package with refs, deep and
+  shallow object and collection proxies, effects, computed values, dependency
+  debugging hooks, Node tests, and declaration contract tests.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - cached `html` and `svg` template results with part-level DOM updates
 - child, attribute, property, boolean, event, and first-class spread bindings
 - nested templates and array rendering with cached template instances
+- standalone DOM-free reactivity with refs, proxies, effects, and computed values
 - reactive Custom Elements through `GluonElement`
 - constructable `CSSStyleSheet` creation and `adoptedStyleSheets` adoption only
 - typed `q.<tag>()` Quark factories for `HTMLElementTagNameMap`
@@ -35,7 +36,11 @@ npm install
 npm run check
 ```
 
-`npm run check` runs strict type checking, the instrumented Chromium browser suite, and the production library build. The coverage gate requires at least 95% statement, function, and line coverage plus 90% branch coverage.
+`npm run check` runs DOM-free Reactivity type and Node tests, strict Core type
+checking, the instrumented Chromium browser suite, both production builds,
+public declaration contract tests, and package archive validation. Each coverage
+gate requires at least 95% statement, function, and line coverage plus 90%
+branch coverage.
 
 ## Quick start
 
@@ -76,6 +81,26 @@ render(view('Gluon'), document.body);
 ```
 
 The second call updates the existing text part when the template shape is unchanged.
+
+## Standalone reactivity
+
+`@gluonjs/reactivity` is a separate, DOM-free package for state that can be
+shared by browser components, stores, and server code:
+
+```ts
+import { computed, effect, reactive, ref } from '@gluonjs/reactivity';
+
+const count = ref(1);
+const settings = reactive({ multiplier: 2 });
+const total = computed(() => count.value * settings.multiplier);
+
+effect(() => console.log(total.value));
+count.value = 2;
+```
+
+Deep and shallow mutable or readonly proxies support plain objects, arrays,
+`Map`, and `Set`. Effects track only the properties and collection operations
+they read; computed values remain lazy and cached until a dependency changes.
 
 ## Bindings and spreading
 
@@ -223,6 +248,7 @@ The initial implementation was transferred and restructured from the local `tiny
 Included now:
 
 - browser-side rendering and updates
+- standalone DOM-free reactive state
 - Custom Element authoring
 - adopted stylesheet management
 - Quark, Atom, Molecule, and Organism composition
@@ -232,7 +258,6 @@ Not included now:
 
 - server-side rendering or hydration
 - islands
-- a reactivity package outside `GluonElement` properties
 - Vue compatibility APIs or migration tooling
 - published performance comparisons
 - a stable or published package release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
 # Gluon architecture
 
-Gluon separates its renderer, browser integration, and UI vocabulary so each public entry point can remain small and tree-shakable.
+Gluon separates standalone reactivity, its renderer, browser integration, and
+UI vocabulary so each public package and entry point can remain focused and
+tree-shakable.
 
 ## Source layout
 
@@ -15,6 +17,12 @@ src/
 ├── atoms/              Icon, Button, Input, Label
 ├── molecules/          Card, FormField
 └── organisms/          AppShell
+
+packages/reactivity/
+├── src/effect.ts       Dependency graph, effects, cleanup, debug hooks
+├── src/reactive.ts     Deep/shallow mutable/readonly object and collection proxies
+├── src/ref.ts          Deep and shallow primitive refs
+└── src/computed.ts     Lazy cached readonly and writable computed refs
 ```
 
 The current private package builds separate ESM entry points for `@gluonjs/core`,
@@ -23,6 +31,21 @@ The current private package builds separate ESM entry points for `@gluonjs/core`
 [package governance ADR](adrs/0002-package-release-and-supply-chain-governance.md)
 makes the four UI-layer subpaths transitional and defines their final optional
 packages.
+
+## Standalone reactivity
+
+`@gluonjs/reactivity` is compiled with `lib: ["ES2022"]` and no ambient DOM or
+Node types. Its dependency graph is keyed by raw target and accessed property or
+collection operation. Effects clear and rebuild their subscriptions on every
+run, so conditional dependencies stop receiving updates when they are no longer
+read.
+
+Deep and shallow mutable or readonly proxies cover plain objects, arrays,
+`Map`, and `Set`. Collection dependencies distinguish specific keys, membership,
+size, map-key iteration, and value/entry iteration. Computed refs use an internal
+effect only to mark their cache dirty; their getter executes lazily on the next
+read. Issue #19 owns asynchronous scheduling, batching, `nextTick`, and effect
+scope lifecycles, which are not added by this package foundation.
 
 ## Runtime contract
 
@@ -118,6 +141,8 @@ The machine-readable [`package-contract.json`](../package-contract.json) defines
 the complete planned package graph. `npm run check:packages` validates every
 declared package independently and additionally verifies built exports, types,
 license, changelog, README, and `npm pack` contents for implemented packages.
+Reactivity behavior runs in a Node Vitest configuration; the public generated
+declarations are compiled again through `tests-node/reactivity.types.ts`.
 
 The browser suite verifies DOM identity, nested templates, arrays, all binding forms, spread cleanup, refs, Custom Element properties and reflection, SVG namespaces, Quark factories, layer composition, and stylesheet adoption.
 

--- a/docs/rfcs/0001-gluon-1.0-product-scope.md
+++ b/docs/rfcs/0001-gluon-1.0-product-scope.md
@@ -29,11 +29,13 @@ optional follow-up polish.
 
 ## Why this decision exists
 
-The repository already contains a tested renderer, a reactive Custom Element
-base, adopted stylesheet helpers, typed Quarks, and representative UI layers.
-It does not yet contain standalone reactivity, an application runtime, routing,
-shared state management, Gluon-specific development tooling, SSR, hydration,
-SSG, public packages, a license, or stable APIs.
+At this RFC's decision date, the repository contained a tested renderer, a
+reactive Custom Element base, adopted stylesheet helpers, typed Quarks, and
+representative UI layers. It did not yet contain standalone reactivity, an
+application runtime, routing, shared state management, Gluon-specific
+development tooling, SSR, hydration, SSG, public packages, a license, or stable
+APIs. Later roadmap issues add those capabilities without changing this product
+scope.
 
 Without a product-scope contract, roadmap work could drift toward Vue API
 cloning, expand optional UI packages into framework core, or treat isolated

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -53,14 +53,15 @@ Gluon currently provides:
 - cached `html` and `svg` templates with part-level DOM updates
 - child, attribute, property, boolean, event, directive, ref, and spread bindings
 - nested templates and index-based array rendering
+- standalone DOM-free refs, reactive and readonly proxies, effects, and computed values
 - reactive declared properties through `GluonElement`
 - constructable stylesheet creation and adopted stylesheet management
 - typed Quark factories for native HTML elements
 - representative Atom, Molecule, and Organism packages
 - ESM builds, TypeScript declarations, Chromium tests, and coverage thresholds
 
-The current repository does not provide standalone reactivity, an application
-runtime, routing, shared state management, SSR, hydration, SSG, Gluon-specific
+The current repository does not provide an application runtime, routing, shared
+state management, SSR, hydration, SSG, Gluon-specific
 HMR, language tooling, Devtools, consumer test utilities, or a public release.
 
 ## Product principles
@@ -197,7 +198,7 @@ editing, testing, debugging, and production building.
 | [#30](https://github.com/marcmalerei/gluon/issues/30) | Build the Gluon Vite plugin and state-preserving HMR. |
 | [#31](https://github.com/marcmalerei/gluon/issues/31) | Build the Gluon language server and editor extension. |
 | [#32](https://github.com/marcmalerei/gluon/issues/32) | Build Gluon Devtools. |
-| [#33](https://github.com/marcmalerei/gluon/issues/33) | Build `@gluon/test-utils`. |
+| [#33](https://github.com/marcmalerei/gluon/issues/33) | Build `@gluonjs/test-utils`. |
 | [#34](https://github.com/marcmalerei/gluon/issues/34) | Build the Gluon playground and diagnostic reference. |
 
 ### Exit gate

--- a/package-contract.json
+++ b/package-contract.json
@@ -15,7 +15,7 @@
     {
       "name": "@gluonjs/reactivity",
       "directory": "packages/reactivity",
-      "state": "planned",
+      "state": "current",
       "environment": "universal",
       "exports": ["."],
       "dependencies": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@gluonjs/core",
       "version": "0.0.0",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "devDependencies": {
         "@types/node": "^22.10.0",
         "@vitest/browser-playwright": "^4.0.18",
@@ -121,6 +124,10 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@gluonjs/reactivity": {
+      "resolved": "packages/reactivity",
+      "link": true
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -1769,6 +1776,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "packages/reactivity": {
+      "name": "@gluonjs/reactivity",
+      "version": "0.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "A native-first UI system built on Custom Elements, HTML template literals, and adopted stylesheets.",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,13 +59,22 @@
     "provenance": true
   },
   "scripts": {
-    "build": "vite build && tsc -p tsconfig.build.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "build": "npm run build:core && npm run build:reactivity",
+    "build:core": "vite build && tsc -p tsconfig.build.json",
+    "build:reactivity": "npm run build --workspace @gluonjs/reactivity",
+    "typecheck": "npm run typecheck:core && npm run typecheck:reactivity",
+    "typecheck:core": "tsc -p tsconfig.json --noEmit",
+    "typecheck:reactivity": "npm run typecheck --workspace @gluonjs/reactivity",
+    "typecheck:reactivity-api": "tsc -p tests-node/tsconfig.reactivity-types.json",
+    "test": "npm run test:browser && npm run test:reactivity",
+    "test:browser": "vitest run",
+    "test:reactivity": "vitest run --config vitest.reactivity.config.ts",
+    "test:coverage": "npm run test:browser:coverage && npm run test:reactivity:coverage",
+    "test:browser:coverage": "vitest run --coverage",
+    "test:reactivity:coverage": "vitest run --config vitest.reactivity.config.ts --coverage",
     "test:watch": "vitest",
     "check:packages": "node scripts/validate-package-contract.mjs",
-    "check": "npm run typecheck && npm run test:coverage && npm run build && npm run check:packages"
+    "check": "npm run typecheck && npm run test:coverage && npm run build && npm run typecheck:reactivity-api && npm run check:packages"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/reactivity/CHANGELOG.md
+++ b/packages/reactivity/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Standalone refs, object and collection proxies, effects, computed values, and
+  development dependency-debugging hooks.

--- a/packages/reactivity/LICENSE
+++ b/packages/reactivity/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2026 Marc Malerei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/reactivity/README.md
+++ b/packages/reactivity/README.md
@@ -1,0 +1,34 @@
+# `@gluonjs/reactivity`
+
+DOM-free reactive state primitives for Gluon. The package is private and
+unpublished while the Gluon 1.0 contracts are being implemented.
+
+```ts
+import { computed, effect, reactive, ref } from '@gluonjs/reactivity';
+
+const count = ref(1);
+const state = reactive({ multiplier: 2 });
+const total = computed(() => count.value * state.multiplier);
+
+effect(() => {
+  console.log(total.value);
+});
+
+count.value = 2;
+```
+
+## API
+
+- `ref`, `shallowRef`, `isRef`, and `unref`
+- `reactive`, `shallowReactive`, `readonly`, and `shallowReadonly`
+- `isReactive`, `isReadonly`, `isProxy`, and `toRaw`
+- `effect`, `stop`, and development-only `onTrack`/`onTrigger` callbacks
+- lazy, cached readonly and writable `computed` values
+
+Deep reactive proxies support plain objects, arrays, `Map`, and `Set`. The
+package source compiles with the ES2022 library and no DOM or Node ambient
+types.
+
+## License
+
+[MIT](LICENSE) — Copyright © 2026 Marc Malerei.

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@gluonjs/reactivity",
+  "version": "0.0.0",
+  "description": "DOM-free reactive state primitives for Gluon.",
+  "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marcmalerei/gluon.git",
+    "directory": "packages/reactivity"
+  },
+  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/reactivity#readme",
+  "bugs": {
+    "url": "https://github.com/marcmalerei/gluon/issues"
+  },
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "engines": {
+    "node": "^22.12.0 || ^24.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/reactivity/src/computed.ts
+++ b/packages/reactivity/src/computed.ts
@@ -1,0 +1,55 @@
+import { createReactiveEffect, track, trigger } from './effect.js';
+import { markRef, type Ref } from './ref.js';
+
+export interface ComputedRef<T> extends Readonly<Ref<T>> {
+  readonly value: T;
+}
+
+export interface WritableComputedRef<T> extends Ref<T> {}
+
+export interface WritableComputedOptions<T> {
+  readonly get: () => T;
+  readonly set: (value: T) => void;
+}
+
+class ComputedValue<T> implements Ref<T> {
+  private readonly runner;
+  private dirty = true;
+  private cachedValue!: T;
+
+  constructor(
+    getter: () => T,
+    private readonly setter: ((value: T) => void) | undefined,
+  ) {
+    markRef(this);
+    this.runner = createReactiveEffect(getter, () => {
+      if (this.dirty) return;
+      this.dirty = true;
+      trigger(this, 'set', 'value');
+    });
+  }
+
+  get value(): T {
+    track(this, 'get', 'value');
+    if (this.dirty) {
+      this.cachedValue = this.runner();
+      this.dirty = false;
+    }
+    return this.cachedValue;
+  }
+
+  set value(value: T) {
+    if (!this.setter) return;
+    this.setter(value);
+  }
+}
+
+export function computed<T>(getter: () => T): ComputedRef<T>;
+export function computed<T>(options: WritableComputedOptions<T>): WritableComputedRef<T>;
+export function computed<T>(
+  source: (() => T) | WritableComputedOptions<T>,
+): ComputedRef<T> | WritableComputedRef<T> {
+  const getter = typeof source === 'function' ? source : source.get;
+  const setter = typeof source === 'function' ? undefined : source.set;
+  return new ComputedValue(getter, setter);
+}

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -1,0 +1,258 @@
+export type TrackOperation = 'get' | 'has' | 'iterate';
+export type TriggerOperation = 'set' | 'add' | 'delete' | 'clear';
+
+export type ReactiveEffectRunner<T = unknown> = () => T;
+
+export interface EffectDebuggerEvent {
+  readonly effect: ReactiveEffectRunner;
+  readonly target: object;
+  readonly type: TrackOperation | TriggerOperation;
+  readonly key?: unknown;
+  readonly newValue?: unknown;
+  readonly oldValue?: unknown;
+}
+
+export interface EffectOptions {
+  readonly onTrack?: (event: EffectDebuggerEvent) => void;
+  readonly onTrigger?: (event: EffectDebuggerEvent) => void;
+  readonly onStop?: () => void;
+}
+
+type Dependency = Set<ReactiveEffect>;
+type Scheduler = () => void;
+
+export const ITERATE_KEY = Symbol('gluon iterate');
+export const MAP_KEY_ITERATE_KEY = Symbol('gluon map key iterate');
+export const ARRAY_ITERATE_KEY = Symbol('gluon array iterate');
+export const COLLECTION_SIZE_KEY = Symbol('gluon collection size');
+
+const targetDependencies = new WeakMap<object, Map<unknown, Dependency>>();
+const hasDependencyKeys = new WeakMap<object, Map<unknown, symbol>>();
+const runnerEffects = new WeakMap<ReactiveEffectRunner, ReactiveEffect>();
+const effectStack: ReactiveEffect[] = [];
+const trackingStack: boolean[] = [];
+let activeEffect: ReactiveEffect | undefined;
+let trackingEnabled = true;
+
+function isDevelopment(): boolean {
+  return (
+    globalThis as { process?: { env?: { NODE_ENV?: string } } }
+  ).process?.env?.NODE_ENV !== 'production';
+}
+
+class ReactiveEffect {
+  readonly dependencies = new Set<Dependency>();
+  active = true;
+  runner!: ReactiveEffectRunner;
+  private lastValue: unknown;
+
+  constructor(
+    private readonly callback: () => unknown,
+    readonly scheduler?: Scheduler,
+    readonly options: EffectOptions = {},
+  ) {}
+
+  run(): unknown {
+    if (!this.active) {
+      trackingStack.push(trackingEnabled);
+      trackingEnabled = false;
+      try {
+        return this.callback();
+      } finally {
+        trackingEnabled = trackingStack.pop() ?? true;
+      }
+    }
+    if (effectStack.includes(this)) return this.lastValue;
+
+    cleanupEffect(this);
+    effectStack.push(this);
+    trackingStack.push(trackingEnabled);
+    trackingEnabled = true;
+    activeEffect = this;
+
+    try {
+      this.lastValue = this.callback();
+      return this.lastValue;
+    } finally {
+      effectStack.pop();
+      trackingEnabled = trackingStack.pop() ?? true;
+      activeEffect = effectStack.at(-1);
+    }
+  }
+
+  stop(): void {
+    if (!this.active) return;
+    cleanupEffect(this);
+    this.active = false;
+    this.options.onStop?.();
+  }
+}
+
+function cleanupEffect(effect: ReactiveEffect): void {
+  for (const dependency of effect.dependencies) dependency.delete(effect);
+  effect.dependencies.clear();
+}
+
+export function createReactiveEffect<T>(
+  callback: () => T,
+  scheduler?: Scheduler,
+  options: EffectOptions = {},
+): ReactiveEffectRunner<T> {
+  const reactiveEffect = new ReactiveEffect(callback, scheduler, options);
+  const runner = (() => reactiveEffect.run()) as ReactiveEffectRunner<T>;
+  reactiveEffect.runner = runner;
+  runnerEffects.set(runner, reactiveEffect);
+  return runner;
+}
+
+export function effect<T>(
+  callback: () => T,
+  options: EffectOptions = {},
+): ReactiveEffectRunner<T> {
+  const runner = createReactiveEffect(callback, undefined, options);
+  runner();
+  return runner;
+}
+
+export function stop(runner: ReactiveEffectRunner): void {
+  runnerEffects.get(runner)?.stop();
+}
+
+export function track(
+  target: object,
+  type: TrackOperation,
+  key: unknown,
+): void {
+  const reactiveEffect = activeEffect;
+  if (!trackingEnabled || !reactiveEffect?.active) return;
+
+  let dependencies = targetDependencies.get(target);
+  if (!dependencies) {
+    dependencies = new Map();
+    targetDependencies.set(target, dependencies);
+  }
+
+  const dependencyKey = type === 'has' ? getHasDependencyKey(target, key) : key;
+  let dependency = dependencies.get(dependencyKey);
+  if (!dependency) {
+    dependency = new Set();
+    dependencies.set(dependencyKey, dependency);
+  }
+
+  if (dependency.has(reactiveEffect)) return;
+  dependency.add(reactiveEffect);
+  reactiveEffect.dependencies.add(dependency);
+
+  if (isDevelopment()) {
+    reactiveEffect.options.onTrack?.({
+      effect: reactiveEffect.runner,
+      target,
+      type,
+      key,
+    });
+  }
+}
+
+function getHasDependencyKey(target: object, key: unknown): symbol {
+  let keys = hasDependencyKeys.get(target);
+  if (!keys) {
+    keys = new Map();
+    hasDependencyKeys.set(target, keys);
+  }
+  let dependencyKey = keys.get(key);
+  if (!dependencyKey) {
+    dependencyKey = Symbol('gluon has');
+    keys.set(key, dependencyKey);
+  }
+  return dependencyKey;
+}
+
+function getExistingHasDependencyKey(target: object, key: unknown): symbol | undefined {
+  return hasDependencyKeys.get(target)?.get(key);
+}
+
+export function isArrayIndex(key: unknown): key is string {
+  if (typeof key !== 'string' || key === '') return false;
+  const index = Number(key);
+  return Number.isInteger(index)
+    && index >= 0
+    && index < 4_294_967_295
+    && String(index) === key;
+}
+
+export function trigger(
+  target: object,
+  type: TriggerOperation,
+  key?: unknown,
+  newValue?: unknown,
+  oldValue?: unknown,
+): void {
+  const dependencies = targetDependencies.get(target);
+  if (!dependencies) return;
+
+  const effects = new Set<ReactiveEffect>();
+  const collect = (dependencyKey: unknown): void => {
+    for (const reactiveEffect of dependencies.get(dependencyKey) ?? []) {
+      effects.add(reactiveEffect);
+    }
+  };
+
+  if (type === 'clear') {
+    for (const dependency of dependencies.values()) {
+      for (const reactiveEffect of dependency) effects.add(reactiveEffect);
+    }
+  } else if (Array.isArray(target) && key === 'length') {
+    const length = Number(newValue);
+    for (const [dependencyKey, dependency] of dependencies) {
+      if (
+        dependencyKey === 'length'
+        || dependencyKey === ARRAY_ITERATE_KEY
+        || (isArrayIndex(dependencyKey) && Number(dependencyKey) >= length)
+      ) {
+        for (const reactiveEffect of dependency) effects.add(reactiveEffect);
+      }
+    }
+  } else {
+    if (key !== undefined) collect(key);
+    if ((type === 'add' || type === 'delete') && key !== undefined) {
+      const hasDependencyKey = getExistingHasDependencyKey(target, key);
+      if (hasDependencyKey) collect(hasDependencyKey);
+    }
+
+    if (Array.isArray(target)) {
+      if (type === 'add' && isArrayIndex(key ?? '')) collect('length');
+      if (type === 'add' || type === 'delete') collect(ARRAY_ITERATE_KEY);
+    } else if (target instanceof Map) {
+      if (type === 'add' || type === 'delete') {
+        collect(ITERATE_KEY);
+        collect(MAP_KEY_ITERATE_KEY);
+        collect(COLLECTION_SIZE_KEY);
+      } else if (type === 'set') {
+        collect(ITERATE_KEY);
+      }
+    } else if (target instanceof Set) {
+      if (type === 'add' || type === 'delete') {
+        collect(ITERATE_KEY);
+        collect(COLLECTION_SIZE_KEY);
+      }
+    } else if (type === 'add' || type === 'delete') {
+      collect(ITERATE_KEY);
+    }
+  }
+
+  for (const reactiveEffect of effects) {
+    if (reactiveEffect === activeEffect) continue;
+    if (isDevelopment()) {
+      reactiveEffect.options.onTrigger?.({
+        effect: reactiveEffect.runner,
+        target,
+        type,
+        key,
+        newValue,
+        oldValue,
+      });
+    }
+    if (reactiveEffect.scheduler) reactiveEffect.scheduler();
+    else reactiveEffect.run();
+  }
+}

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -1,0 +1,36 @@
+export {
+  effect,
+  stop,
+  type EffectDebuggerEvent,
+  type EffectOptions,
+  type ReactiveEffectRunner,
+  type TrackOperation,
+  type TriggerOperation,
+} from './effect.js';
+
+export {
+  isProxy,
+  isReactive,
+  isReadonly,
+  reactive,
+  readonly,
+  shallowReactive,
+  shallowReadonly,
+  toRaw,
+  type DeepReadonly,
+} from './reactive.js';
+
+export {
+  isRef,
+  ref,
+  shallowRef,
+  unref,
+  type Ref,
+} from './ref.js';
+
+export {
+  computed,
+  type ComputedRef,
+  type WritableComputedOptions,
+  type WritableComputedRef,
+} from './computed.js';

--- a/packages/reactivity/src/reactive.ts
+++ b/packages/reactivity/src/reactive.ts
@@ -1,0 +1,356 @@
+import {
+  ARRAY_ITERATE_KEY,
+  COLLECTION_SIZE_KEY,
+  ITERATE_KEY,
+  MAP_KEY_ITERATE_KEY,
+  isArrayIndex,
+  track,
+  trigger,
+} from './effect.js';
+import { refTargets } from './shared.js';
+
+const ReactiveFlag = {
+  IsReactive: Symbol('gluon reactive'),
+  IsReadonly: Symbol('gluon readonly'),
+  IsShallow: Symbol('gluon shallow'),
+  Raw: Symbol('gluon raw'),
+} as const;
+
+type Collection = Map<unknown, unknown> | Set<unknown>;
+type ProxyMode = 'reactive' | 'shallowReactive' | 'readonly' | 'shallowReadonly';
+
+export type DeepReadonly<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly (infer Value)[]
+    ? ReadonlyArray<DeepReadonly<Value>>
+  : T extends Map<infer Key, infer Value>
+    ? ReadonlyMap<DeepReadonly<Key>, DeepReadonly<Value>>
+    : T extends Set<infer Value>
+      ? ReadonlySet<DeepReadonly<Value>>
+      : T extends object
+        ? { readonly [Key in keyof T]: DeepReadonly<T[Key]> }
+        : T;
+
+const proxyCaches: Record<ProxyMode, WeakMap<object, object>> = {
+  reactive: new WeakMap(),
+  shallowReactive: new WeakMap(),
+  readonly: new WeakMap(),
+  shallowReadonly: new WeakMap(),
+};
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+function canObserve(value: object): boolean {
+  if (refTargets.has(value)) return false;
+  return Array.isArray(value)
+    || value instanceof Map
+    || value instanceof Set
+    || Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function resolveCollectionKey(
+  target: Collection,
+  key: unknown,
+): { readonly rawKey: unknown; readonly targetKey: unknown } {
+  const rawKey = toRaw(key);
+  const targetKey = target.has(rawKey)
+    ? rawKey
+    : target.has(key)
+      ? key
+      : rawKey;
+  return { rawKey, targetKey };
+}
+
+function hasOwn(target: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(target, key);
+}
+
+function wrapValue(value: unknown, readonlyMode: boolean, shallow: boolean): unknown {
+  if (shallow || !isObject(value)) return value;
+  return readonlyMode ? readonly(value) : reactive(value);
+}
+
+function createObjectHandlers(
+  mode: ProxyMode,
+  readonlyMode: boolean,
+  shallow: boolean,
+): ProxyHandler<object> {
+  return {
+    get(target, key, receiver) {
+      if (key === ReactiveFlag.IsReactive) return !readonlyMode;
+      if (key === ReactiveFlag.IsReadonly) return readonlyMode;
+      if (key === ReactiveFlag.IsShallow) return shallow;
+      if (key === ReactiveFlag.Raw) {
+        return receiver === proxyCaches[mode].get(target) ? target : undefined;
+      }
+
+      const value = Reflect.get(target, key, receiver);
+      if (!readonlyMode) track(target, 'get', key);
+      return wrapValue(value, readonlyMode, shallow);
+    },
+
+    set(target, key, value, receiver) {
+      if (readonlyMode) return true;
+
+      const oldValue = Reflect.get(target, key, receiver);
+      const oldLength = Array.isArray(target) ? target.length : undefined;
+      const existed = Array.isArray(target) && isArrayIndex(key)
+        ? Number(key) < (oldLength ?? 0)
+        : hasOwn(target, key);
+      const rawValue = toRaw(value);
+      const result = Reflect.set(target, key, rawValue, receiver);
+
+      if (target !== toRaw(receiver)) return result;
+      if (!existed) trigger(target, 'add', key, rawValue);
+      else if (!Object.is(rawValue, toRaw(oldValue))) {
+        trigger(target, 'set', key, rawValue, oldValue);
+      }
+      return result;
+    },
+
+    deleteProperty(target, key) {
+      if (readonlyMode) return true;
+      const existed = hasOwn(target, key);
+      const oldValue = Reflect.get(target, key);
+      const result = Reflect.deleteProperty(target, key);
+      if (result && existed) trigger(target, 'delete', key, undefined, oldValue);
+      return result;
+    },
+
+    has(target, key) {
+      const result = Reflect.has(target, key);
+      if (!readonlyMode) track(target, 'has', key);
+      return result;
+    },
+
+    ownKeys(target) {
+      if (!readonlyMode) {
+        track(target, 'iterate', Array.isArray(target) ? ARRAY_ITERATE_KEY : ITERATE_KEY);
+      }
+      return Reflect.ownKeys(target);
+    },
+  };
+}
+
+function createIterable(
+  target: Collection,
+  method: PropertyKey,
+  readonlyMode: boolean,
+  shallow: boolean,
+): IterableIterator<unknown> {
+  const map = target instanceof Map;
+  const pair = method === 'entries' || (method === Symbol.iterator && map);
+  const keyOnly = method === 'keys' && map;
+  if (!readonlyMode) track(target, 'iterate', keyOnly ? MAP_KEY_ITERATE_KEY : ITERATE_KEY);
+
+  const iterator = Reflect.apply(
+    Reflect.get(target, method) as (...args: never[]) => Iterator<unknown>,
+    target,
+    [],
+  );
+
+  return {
+    next() {
+      const result = iterator.next();
+      if (result.done) return result;
+      if (pair) {
+        const [key, value] = result.value as [unknown, unknown];
+        return {
+          done: false,
+          value: [
+            wrapValue(key, readonlyMode, shallow),
+            wrapValue(value, readonlyMode, shallow),
+          ],
+        };
+      }
+      return {
+        done: false,
+        value: wrapValue(result.value, readonlyMode, shallow),
+      };
+    },
+    [Symbol.iterator]() {
+      return this;
+    },
+  };
+}
+
+function createCollectionHandlers(
+  mode: ProxyMode,
+  readonlyMode: boolean,
+  shallow: boolean,
+): ProxyHandler<Collection> {
+  return {
+    get(target, key, receiver) {
+      if (key === ReactiveFlag.IsReactive) return !readonlyMode;
+      if (key === ReactiveFlag.IsReadonly) return readonlyMode;
+      if (key === ReactiveFlag.IsShallow) return shallow;
+      if (key === ReactiveFlag.Raw) {
+        return receiver === proxyCaches[mode].get(target) ? target : undefined;
+      }
+
+      if (key === 'size') {
+        if (!readonlyMode) track(target, 'iterate', COLLECTION_SIZE_KEY);
+        return Reflect.get(target, 'size', target);
+      }
+
+      if (key === 'get' && target instanceof Map) {
+        return (lookupKey: unknown) => {
+          const { targetKey } = resolveCollectionKey(target, lookupKey);
+          if (!readonlyMode) track(target, 'get', targetKey);
+          return wrapValue(target.get(targetKey), readonlyMode, shallow);
+        };
+      }
+
+      if (key === 'has') {
+        return (lookupKey: unknown) => {
+          const { targetKey } = resolveCollectionKey(target, lookupKey);
+          if (!readonlyMode) track(target, 'has', targetKey);
+          return target.has(targetKey);
+        };
+      }
+
+      if (key === 'set' && target instanceof Map) {
+        return (mapKey: unknown, value: unknown) => {
+          if (readonlyMode) return receiver;
+          const { rawKey, targetKey } = resolveCollectionKey(target, mapKey);
+          const rawValue = toRaw(value);
+          const existed = target.has(targetKey);
+          const oldValue = target.get(targetKey);
+          const storedKey = existed ? targetKey : rawKey;
+          target.set(storedKey, rawValue);
+          if (!existed) trigger(target, 'add', storedKey, rawValue);
+          else if (!Object.is(rawValue, oldValue)) {
+            trigger(target, 'set', storedKey, rawValue, oldValue);
+          }
+          return receiver;
+        };
+      }
+
+      if (key === 'add' && target instanceof Set) {
+        return (value: unknown) => {
+          if (readonlyMode) return receiver;
+          const { rawKey, targetKey } = resolveCollectionKey(target, value);
+          const existed = target.has(targetKey);
+          const storedValue = existed ? targetKey : rawKey;
+          target.add(storedValue);
+          if (!existed) trigger(target, 'add', storedValue, storedValue);
+          return receiver;
+        };
+      }
+
+      if (key === 'delete') {
+        return (lookupKey: unknown) => {
+          if (readonlyMode) return false;
+          const { targetKey } = resolveCollectionKey(target, lookupKey);
+          const existed = target.has(targetKey);
+          const oldValue = target instanceof Map ? target.get(targetKey) : targetKey;
+          const result = target.delete(targetKey);
+          if (result && existed) {
+            trigger(target, 'delete', targetKey, undefined, oldValue);
+          }
+          return result;
+        };
+      }
+
+      if (key === 'clear') {
+        return () => {
+          if (readonlyMode) return undefined;
+          const hadItems = target.size > 0;
+          const result = target.clear();
+          if (hadItems) trigger(target, 'clear');
+          return result;
+        };
+      }
+
+      if (key === 'forEach') {
+        return (callback: (value: unknown, key: unknown, collection: unknown) => void, thisArg?: unknown) => {
+          if (!readonlyMode) track(target, 'iterate', ITERATE_KEY);
+          target.forEach((value, entryKey) => {
+            callback.call(
+              thisArg,
+              wrapValue(value, readonlyMode, shallow),
+              wrapValue(entryKey, readonlyMode, shallow),
+              receiver,
+            );
+          });
+        };
+      }
+
+      if (
+        key === Symbol.iterator
+        || key === 'entries'
+        || key === 'keys'
+        || key === 'values'
+      ) {
+        return () => createIterable(target, key, readonlyMode, shallow);
+      }
+
+      return Reflect.get(target, key, target);
+    },
+  };
+}
+
+function createProxy<T extends object>(target: T, mode: ProxyMode): T {
+  if (isReadonly(target) && (mode === 'reactive' || mode === 'shallowReactive')) {
+    return target;
+  }
+
+  const readonlyMode = mode === 'readonly' || mode === 'shallowReadonly';
+  const shallow = mode === 'shallowReactive' || mode === 'shallowReadonly';
+  if (
+    isProxy(target)
+    && isReadonly(target) === readonlyMode
+    && Boolean(Reflect.get(target, ReactiveFlag.IsShallow)) === shallow
+  ) {
+    return target;
+  }
+
+  const rawTarget = toRaw(target);
+  if (!canObserve(rawTarget)) return target;
+
+  const cached = proxyCaches[mode].get(rawTarget);
+  if (cached) return cached as T;
+
+  const handlers = rawTarget instanceof Map || rawTarget instanceof Set
+    ? createCollectionHandlers(mode, readonlyMode, shallow)
+    : createObjectHandlers(mode, readonlyMode, shallow);
+  const proxy = new Proxy(rawTarget as Collection & object, handlers as ProxyHandler<Collection & object>);
+  proxyCaches[mode].set(rawTarget, proxy);
+  return proxy as T;
+}
+
+export function reactive<T extends object>(target: T): T {
+  return createProxy(target, 'reactive');
+}
+
+export function shallowReactive<T extends object>(target: T): T {
+  return createProxy(target, 'shallowReactive');
+}
+
+export function readonly<T extends object>(target: T): DeepReadonly<T> {
+  return createProxy(target, 'readonly') as DeepReadonly<T>;
+}
+
+export function shallowReadonly<T extends object>(target: T): Readonly<T> {
+  return createProxy(target, 'shallowReadonly') as Readonly<T>;
+}
+
+export function isReactive(value: unknown): boolean {
+  return Boolean(isObject(value) && Reflect.get(value, ReactiveFlag.IsReactive));
+}
+
+export function isReadonly(value: unknown): boolean {
+  return Boolean(isObject(value) && Reflect.get(value, ReactiveFlag.IsReadonly));
+}
+
+export function isProxy(value: unknown): boolean {
+  return isReactive(value) || isReadonly(value);
+}
+
+export function toRaw<T>(value: T): T {
+  if (!isObject(value)) return value;
+  const raw = Reflect.get(value, ReactiveFlag.Raw) as T | undefined;
+  return raw === undefined ? value : toRaw(raw);
+}

--- a/packages/reactivity/src/ref.ts
+++ b/packages/reactivity/src/ref.ts
@@ -1,0 +1,67 @@
+import { reactive, toRaw } from './reactive.js';
+import { track, trigger } from './effect.js';
+import { refTargets } from './shared.js';
+
+export interface Ref<T = unknown> {
+  value: T;
+}
+
+export function markRef(value: object): void {
+  refTargets.add(value);
+}
+
+class RefValue<T> implements Ref<T> {
+  private storedValue: T;
+  private readonly shallow: boolean;
+
+  constructor(value: T, shallow: boolean) {
+    markRef(this);
+    this.shallow = shallow;
+    this.storedValue = this.convert(value);
+  }
+
+  get value(): T {
+    track(this, 'get', 'value');
+    return this.storedValue;
+  }
+
+  set value(value: T) {
+    const rawValue = this.shallow ? value : unwrapReactiveValue(value);
+    const oldValue = this.shallow
+      ? this.storedValue
+      : unwrapReactiveValue(this.storedValue);
+    if (Object.is(rawValue, oldValue)) return;
+
+    const previous = this.storedValue;
+    this.storedValue = this.convert(value);
+    trigger(this, 'set', 'value', this.storedValue, previous);
+  }
+
+  private convert(value: T): T {
+    return this.shallow || !isObject(value) ? value : reactive(value) as T;
+  }
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
+}
+
+function unwrapReactiveValue<T>(value: T): T {
+  return isObject(value) ? toRaw(value) : value;
+}
+
+export function ref<T>(value: T): Ref<T> {
+  return isRef<T>(value) ? value : new RefValue(value, false);
+}
+
+export function shallowRef<T>(value: T): Ref<T> {
+  return isRef<T>(value) ? value : new RefValue(value, true);
+}
+
+export function isRef<T = unknown>(value: unknown): value is Ref<T> {
+  return typeof value === 'object' && value !== null && refTargets.has(toRaw(value));
+}
+
+export function unref<T>(value: T | Ref<T>): T {
+  return isRef<T>(value) ? value.value : value;
+}

--- a/packages/reactivity/src/shared.ts
+++ b/packages/reactivity/src/shared.ts
@@ -1,0 +1,1 @@
+export const refTargets = new WeakSet<object>();

--- a/packages/reactivity/tsconfig.build.json
+++ b/packages/reactivity/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "stripInternal": true
+  }
+}

--- a/packages/reactivity/tsconfig.json
+++ b/packages/reactivity/tsconfig.json
@@ -1,22 +1,15 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["node"],
+    "types": [],
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true
   },
-  "include": [
-    "src/**/*.ts",
-    "tests/**/*.ts",
-    "tests-node/reactivity.spec.ts",
-    "examples/**/*.ts",
-    "vite.config.ts",
-    "vitest.reactivity.config.ts"
-  ]
+  "include": ["src/**/*.ts"]
 }

--- a/tests-node/reactivity.spec.ts
+++ b/tests-node/reactivity.spec.ts
@@ -1,0 +1,511 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  computed,
+  effect,
+  isProxy,
+  isReactive,
+  isReadonly,
+  isRef,
+  reactive,
+  readonly,
+  ref,
+  shallowReactive,
+  shallowReadonly,
+  shallowRef,
+  stop,
+  toRaw,
+  unref,
+} from '../packages/reactivity/src/index.js';
+
+describe('@gluonjs/reactivity', () => {
+  it('runs in Node without a DOM global', () => {
+    expect('document' in globalThis).toBe(false);
+  });
+
+  it('tracks only effects subscribed to the changed property', () => {
+    const state = reactive({ first: 1, second: 2 });
+    const firstEffect = vi.fn(() => state.first);
+    const secondEffect = vi.fn(() => state.second);
+
+    effect(firstEffect);
+    effect(secondEffect);
+    state.first = 3;
+
+    expect(firstEffect).toHaveBeenCalledTimes(2);
+    expect(secondEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates repeated reads and prevents active effects from recursing', () => {
+    const state = reactive({ count: 0 });
+    const repeated = vi.fn(() => state.count + state.count);
+    effect(repeated);
+    state.count = 1;
+    expect(repeated).toHaveBeenCalledTimes(2);
+
+    const selfUpdating = vi.fn(() => {
+      if (state.count < 2) state.count += 1;
+    });
+    effect(selfUpdating);
+    expect(state.count).toBe(2);
+    expect(selfUpdating).toHaveBeenCalledOnce();
+  });
+
+  it('handles explicit nested calls to the same effect runner', () => {
+    let recurse = false;
+    let runner!: () => number;
+    const callback = vi.fn(() => {
+      if (recurse) {
+        recurse = false;
+        return runner();
+      }
+      return 1;
+    });
+    runner = effect(callback);
+    recurse = true;
+    expect(runner()).toBe(1);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans stale conditional dependencies and supports manual runners', () => {
+    const state = reactive({ enabled: true, primary: 1, fallback: 2 });
+    let value = 0;
+    const runner = effect(() => {
+      value = state.enabled ? state.primary : state.fallback;
+      return value;
+    });
+
+    state.enabled = false;
+    expect(value).toBe(2);
+    state.primary = 10;
+    expect(value).toBe(2);
+    state.fallback = 20;
+    expect(value).toBe(20);
+    expect(runner()).toBe(20);
+  });
+
+  it('restores the parent effect after nested runner execution', () => {
+    const state = reactive({ outer: 1, inner: 2, after: 3 });
+    const inner = effect(() => state.inner);
+    const outer = vi.fn(() => {
+      state.outer;
+      inner();
+      state.after;
+    });
+    effect(outer);
+
+    state.after = 4;
+    expect(outer).toHaveBeenCalledTimes(2);
+    state.inner = 5;
+    expect(outer).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops effects once and lets stopped runners execute without tracking', () => {
+    const state = reactive({ count: 0 });
+    const onStop = vi.fn();
+    const callback = vi.fn(() => state.count);
+    const runner = effect(callback, { onStop });
+
+    stop(runner);
+    stop(runner);
+    state.count += 1;
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(onStop).toHaveBeenCalledOnce();
+
+    runner();
+    state.count += 1;
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not leak reads from a stopped runner into an active parent effect', () => {
+    const state = reactive({ parent: 1, child: 1 });
+    const child = effect(() => state.child);
+    stop(child);
+    const parent = vi.fn(() => {
+      state.parent;
+      child();
+    });
+    effect(parent);
+
+    state.child = 2;
+    expect(parent).toHaveBeenCalledOnce();
+    state.parent = 2;
+    expect(parent).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports development tracking and triggering events', () => {
+    const state = reactive({ count: 0 });
+    const onTrack = vi.fn();
+    const onTrigger = vi.fn();
+    effect(() => state.count, { onTrack, onTrigger });
+
+    state.count = 1;
+
+    expect(onTrack).toHaveBeenCalledWith(expect.objectContaining({
+      target: toRaw(state),
+      type: 'get',
+      key: 'count',
+    }));
+    expect(onTrigger).toHaveBeenCalledWith(expect.objectContaining({
+      target: toRaw(state),
+      type: 'set',
+      key: 'count',
+      newValue: 1,
+      oldValue: 0,
+    }));
+  });
+
+  it('disables dependency debugger callbacks in production mode', () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const state = reactive({ count: 0 });
+      const onTrack = vi.fn();
+      const onTrigger = vi.fn();
+      effect(() => state.count, { onTrack, onTrigger });
+      state.count = 1;
+      expect(onTrack).not.toHaveBeenCalled();
+      expect(onTrigger).not.toHaveBeenCalled();
+    } finally {
+      if (previous === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previous;
+    }
+  });
+
+  it('creates deep proxies and preserves proxy identity', () => {
+    const raw = { nested: { count: 1 }, list: [{ label: 'one' }] };
+    const state = reactive(raw);
+
+    expect(isReactive(state)).toBe(true);
+    expect(isProxy(state.nested)).toBe(true);
+    expect(state.nested).toBe(state.nested);
+    expect(state.list[0]).toBe(state.list[0]);
+    expect(reactive(raw)).toBe(state);
+    expect(reactive(state)).toBe(state);
+    expect(toRaw(state)).toBe(raw);
+    const date = new Date(0);
+    expect(reactive(date)).toBe(date);
+  });
+
+  it('cannot confuse user string properties with internal identity markers', () => {
+    const raw = {
+      __gluon_raw: 'user-value',
+      __gluon_isReactive: true,
+      count: 1,
+    };
+    const state = reactive(raw);
+    const refLike = { __gluon_isRef: true, value: 1 };
+
+    expect(state).not.toBe(raw);
+    expect(toRaw(raw)).toBe(raw);
+    expect(toRaw(state)).toBe(raw);
+    expect(isProxy(raw)).toBe(false);
+    expect(isRef(refLike)).toBe(false);
+    expect(ref(refLike)).not.toBe(refLike);
+  });
+
+  it('keeps nested values raw in shallow reactive and shallow readonly modes', () => {
+    const nested = { count: 1 };
+    const shallowState = shallowReactive({ nested });
+    const shallowView = shallowReadonly({ nested });
+
+    expect(isReactive(shallowState)).toBe(true);
+    expect(isReactive(shallowState.nested)).toBe(false);
+    expect(isReadonly(shallowView)).toBe(true);
+    expect(isReadonly(shallowView.nested)).toBe(false);
+    expect(shallowReactive(shallowState)).toBe(shallowState);
+    expect(shallowReadonly(shallowView)).toBe(shallowView);
+  });
+
+  it('prevents deep readonly object and collection mutations', () => {
+    const raw = {
+      nested: { count: 1 },
+      map: new Map([['count', 1]]),
+      set: new Set([1]),
+    };
+    const view = readonly(raw);
+
+    Reflect.set(view.nested, 'count', 2);
+    (view.map as Map<string, number>).set('count', 2);
+    (view.set as Set<number>).add(2);
+    Reflect.deleteProperty(view.nested, 'count');
+    (view.map as Map<string, number>).clear();
+
+    expect(raw.nested.count).toBe(1);
+    expect(raw.map.get('count')).toBe(1);
+    expect([...raw.set]).toEqual([1]);
+    expect(isReadonly(view.nested)).toBe(true);
+    expect(reactive(view)).toBe(view);
+    expect(readonly(view)).toBe(view);
+    expect('nested' in view).toBe(true);
+    expect(Object.keys(view)).toContain('nested');
+  });
+
+  it('does not trigger through prototype receiver writes or missing deletes', () => {
+    const base = reactive({ count: 1 });
+    const callback = vi.fn(() => base.count);
+    effect(callback);
+    const child = Object.create(base) as { count: number };
+
+    child.count = 2;
+    delete (base as { missing?: number }).missing;
+    expect(callback).toHaveBeenCalledOnce();
+    expect(base.count).toBe(1);
+  });
+
+  it('tracks property existence and object key iteration', () => {
+    const state = reactive<Record<string, number>>({ first: 1 });
+    const hasSecond = vi.fn(() => 'second' in state);
+    const keys = vi.fn(() => Object.keys(state));
+    effect(hasSecond);
+    effect(keys);
+
+    state.second = 2;
+    state.second = 3;
+    delete state.second;
+
+    expect(hasSecond).toHaveBeenCalledTimes(3);
+    expect(keys).toHaveBeenCalledTimes(3);
+  });
+
+  it('tracks array indices, length changes, and structural iteration', () => {
+    const list = reactive<string[]>(['a']);
+    const length = vi.fn(() => list.length);
+    const second = vi.fn(() => list[1]);
+    const keys = vi.fn(() => Object.keys(list));
+    effect(length);
+    effect(second);
+    effect(keys);
+
+    list.push('b');
+    expect(length).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(keys).toHaveBeenCalledTimes(2);
+
+    list.length = 1;
+    expect(length).toHaveBeenCalledTimes(3);
+    expect(second).toHaveBeenCalledTimes(3);
+    expect(keys).toHaveBeenCalledTimes(3);
+
+    delete list[0];
+    expect(keys).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not treat non-canonical numeric array properties as indices', () => {
+    const list = reactive<string[]>([]);
+    const length = vi.fn(() => list.length);
+    effect(length);
+
+    Reflect.set(list, '01', 'value');
+    Reflect.set(list, '4294967295', 'value');
+    expect(list.length).toBe(0);
+    expect(length).toHaveBeenCalledOnce();
+  });
+
+  it('reacts to nested object changes reached through arrays', () => {
+    const list = reactive([{ count: 1 }]);
+    const callback = vi.fn(() => list[0]?.count);
+    effect(callback);
+    list[0]!.count = 2;
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('tracks Map keys independently and wraps deep values', () => {
+    const rawValue = { count: 1 };
+    const state = reactive(new Map<string, { count: number }>([['first', rawValue]]));
+    const first = vi.fn(() => state.get('first')?.count);
+    const second = vi.fn(() => state.get('second'));
+    effect(first);
+    effect(second);
+
+    state.get('first')!.count = 2;
+    state.set('second', { count: 3 });
+
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(isReactive(state.get('first'))).toBe(true);
+    expect(toRaw(state.get('first'))).toBe(rawValue);
+  });
+
+  it('separates Map key, value, size, and entry iteration dependencies', () => {
+    const state = reactive(new Map([['first', 1]]));
+    const keys = vi.fn(() => [...state.keys()]);
+    const values = vi.fn(() => [...state.values()]);
+    const entries = vi.fn(() => [...state]);
+    const size = vi.fn(() => state.size);
+    effect(keys);
+    effect(values);
+    effect(entries);
+    effect(size);
+
+    state.set('first', 2);
+    expect(keys).toHaveBeenCalledTimes(1);
+    expect(values).toHaveBeenCalledTimes(2);
+    expect(entries).toHaveBeenCalledTimes(2);
+    expect(size).toHaveBeenCalledTimes(1);
+    state.set('first', 2);
+    expect(values).toHaveBeenCalledTimes(2);
+
+    state.set('second', 3);
+    expect(keys).toHaveBeenCalledTimes(2);
+    expect(size).toHaveBeenCalledTimes(2);
+    state.delete('second');
+    expect(keys).toHaveBeenCalledTimes(3);
+    expect(size).toHaveBeenCalledTimes(3);
+  });
+
+  it('supports Map forEach and clear', () => {
+    const state = reactive(new Map([['first', { count: 1 }]]));
+    const callback = vi.fn(() => {
+      let total = 0;
+      state.forEach((value, key, collection) => {
+        expect(collection).toBe(state);
+        expect(key).toBe('first');
+        total += value.count;
+      });
+      return total;
+    });
+    effect(callback);
+
+    state.get('first')!.count = 2;
+    state.clear();
+    state.clear();
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+
+  it('normalizes reactive collection keys and exposes readonly collection reads', () => {
+    const rawKey = { id: 1 };
+    const proxyKey = reactive(rawKey);
+    const state = reactive(new Map<object, { count: number }>());
+    state.set(proxyKey, { count: 1 });
+    expect(state.get(rawKey)?.count).toBe(1);
+
+    const view = readonly(state);
+    expect(view.size).toBe(1);
+    expect(view.has(proxyKey)).toBe(true);
+    expect(view.get(rawKey)?.count).toBe(1);
+    expect([...view.keys()][0]).toBe(readonly(rawKey));
+    let seen = 0;
+    view.forEach((value) => { seen += value.count; });
+    expect(seen).toBe(1);
+    expect((view as Map<object, { count: number }>).delete(rawKey)).toBe(false);
+    expect(Reflect.get(view, Symbol.toStringTag)).toBe('Map');
+  });
+
+  it('supports proxy keys already present in raw Map and Set collections', () => {
+    const rawKey = { id: 1 };
+    const proxyKey = reactive(rawKey);
+    const map = reactive(new Map<object, number>([[proxyKey, 1]]));
+    const callback = vi.fn(() => map.get(proxyKey));
+    effect(callback);
+
+    map.set(proxyKey, 2);
+    expect(map.get(rawKey)).toBeUndefined();
+    expect(map.get(proxyKey)).toBe(2);
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(map.delete(proxyKey)).toBe(true);
+
+    const set = reactive(new Set<object>([proxyKey]));
+    expect(set.has(proxyKey)).toBe(true);
+    expect(set.add(proxyKey)).toBe(set);
+    expect(set.size).toBe(1);
+    expect(set.delete(proxyKey)).toBe(true);
+  });
+
+  it('tracks Set membership, size, values, entries, add, delete, and clear', () => {
+    const state = reactive(new Set<object>());
+    const value = { id: 1 };
+    const hasValue = vi.fn(() => state.has(value));
+    const size = vi.fn(() => state.size);
+    const values = vi.fn(() => [...state.values()]);
+    effect(hasValue);
+    effect(size);
+    effect(values);
+
+    expect(state.add(value)).toBe(state);
+    state.add(value);
+    expect(hasValue).toHaveBeenCalledTimes(2);
+    expect(size).toHaveBeenCalledTimes(2);
+    expect(isReactive([...state][0])).toBe(true);
+    expect([...state.entries()][0]?.[0]).toBe([...state.entries()][0]?.[1]);
+
+    state.delete(value);
+    expect(state.delete(value)).toBe(false);
+    state.clear();
+    expect(hasValue).toHaveBeenCalledTimes(3);
+    expect(size).toHaveBeenCalledTimes(3);
+  });
+
+  it('creates deep and shallow refs and preserves existing refs', () => {
+    const deep = ref({ count: 1 });
+    const shallow = shallowRef({ count: 1 });
+
+    expect(isRef(deep)).toBe(true);
+    expect(isReactive(deep.value)).toBe(true);
+    expect(isReactive(shallow.value)).toBe(false);
+    expect(ref(deep)).toBe(deep);
+    expect(shallowRef(shallow)).toBe(shallow);
+    expect(reactive(deep)).toBe(deep);
+    expect(unref(deep)).toBe(deep.value);
+    expect(unref(3)).toBe(3);
+  });
+
+  it('does not trigger refs for the same raw value', () => {
+    const raw = { count: 1 };
+    const value = ref(raw);
+    const callback = vi.fn(() => value.value);
+    effect(callback);
+
+    value.value = reactive(raw);
+    expect(callback).toHaveBeenCalledTimes(1);
+    value.value = { count: 2 };
+    expect(callback).toHaveBeenCalledTimes(2);
+
+    const shallow = shallowRef(raw);
+    const shallowCallback = vi.fn(() => shallow.value);
+    effect(shallowCallback);
+    shallow.value = { count: 3 };
+    expect(shallowCallback).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps computed values lazy and cached until a dependency invalidates them', () => {
+    const count = ref(1);
+    const getter = vi.fn(() => count.value * 2);
+    const doubled = computed(getter);
+
+    expect(getter).not.toHaveBeenCalled();
+    expect(doubled.value).toBe(2);
+    expect(doubled.value).toBe(2);
+    expect(getter).toHaveBeenCalledOnce();
+
+    count.value = 2;
+    count.value = 3;
+    expect(getter).toHaveBeenCalledOnce();
+    expect(doubled.value).toBe(6);
+    expect(getter).toHaveBeenCalledTimes(2);
+  });
+
+  it('notifies computed subscribers only when invalidated', () => {
+    const count = ref(1);
+    const doubled = computed(() => count.value * 2);
+    const callback = vi.fn(() => doubled.value);
+    effect(callback);
+
+    count.value = 2;
+    count.value = 2;
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports writable computed values and ignores readonly computed writes', () => {
+    const count = ref(1);
+    const writable = computed({
+      get: () => count.value,
+      set: (value: number) => { count.value = value; },
+    });
+    writable.value = 3;
+    expect(count.value).toBe(3);
+
+    const readonlyValue = computed(() => count.value);
+    Reflect.set(readonlyValue, 'value', 4);
+    expect(count.value).toBe(3);
+  });
+});

--- a/tests-node/reactivity.types.ts
+++ b/tests-node/reactivity.types.ts
@@ -1,0 +1,45 @@
+import {
+  computed,
+  effect,
+  reactive,
+  readonly,
+  ref,
+  shallowReadonly,
+  stop,
+  type ComputedRef,
+  type DeepReadonly,
+  type EffectDebuggerEvent,
+  type ReactiveEffectRunner,
+  type Ref,
+  type WritableComputedRef,
+} from '../packages/reactivity/dist/index.js';
+
+const count: Ref<number> = ref(1);
+const state = reactive({ count: 1, nested: { label: 'ready' } });
+const listView = readonly([{ count: 1 }]);
+const view: DeepReadonly<typeof state> = readonly(state);
+const shallow = shallowReadonly(state);
+const doubled: ComputedRef<number> = computed(() => count.value * 2);
+const writable: WritableComputedRef<number> = computed({
+  get: () => count.value,
+  set: (value) => { count.value = value; },
+});
+const runner: ReactiveEffectRunner<number> = effect(() => state.count, {
+  onTrack(event: EffectDebuggerEvent) {
+    event.effect;
+    event.key;
+  },
+});
+
+writable.value = doubled.value;
+shallow.count;
+stop(runner);
+
+// @ts-expect-error deep readonly properties cannot be assigned
+view.nested.label = 'changed';
+// @ts-expect-error readonly computed values cannot be assigned
+doubled.value = 4;
+// @ts-expect-error deep readonly arrays expose no mutable push API
+listView.push({ count: 2 });
+// @ts-expect-error refs preserve their value type
+count.value = 'invalid';

--- a/tests-node/tsconfig.reactivity-types.json
+++ b/tests-node/tsconfig.reactivity-types.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false
+  },
+  "include": ["reactivity.types.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
     },
   },
   test: {
+    include: ['tests/**/*.spec.ts'],
     browser: {
       enabled: true,
       headless: true,

--- a/vitest.reactivity.config.ts
+++ b/vitest.reactivity.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests-node/reactivity.spec.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['packages/reactivity/src/**/*.ts'],
+      reportsDirectory: 'coverage/reactivity',
+      reporter: ['text', 'html'],
+      thresholds: {
+        statements: 95,
+        branches: 90,
+        functions: 95,
+        lines: 95,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add the first real workspace package, `@gluonjs/reactivity`, with refs, deep and shallow reactive/readonly proxies, effects, cleanup, development dependency hooks, and lazy cached computed values
- support nested objects, arrays, `Map`, and `Set` with key-, membership-, size-, and iteration-specific dependency tracking
- add a DOM-free ES2022 type boundary, generated public declarations, Node-only behavioral tests, independent coverage, package archive validation, and package documentation
- update the package contract, root scripts, architecture, roadmap, changelog, and README

## Verification
- `npm run check`
  - Core Chromium suite: 7 files, 26 tests passed
  - Core coverage: 97.07% statements, 93.42% branches, 99.13% functions, 97.94% lines
  - Reactivity Node suite: 1 file, 30 tests passed
  - Reactivity coverage: 99.43% statements, 96.10% branches, 100% functions, 100% lines
  - Core and Reactivity production builds passed
  - public generated declaration contract passed
  - all 16 package contracts passed, including the built `@gluonjs/reactivity` archive
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check`
- independent package/acceptance review: no findings
- semantic review findings for marker collisions, stopped-runner tracking leakage, and non-canonical array indices were fixed and covered by regression tests; follow-up review reported no findings

Closes #18