### PR TITLE
Add deterministic scheduler, batching, and effect scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 - A standalone, DOM-free `@gluonjs/reactivity` package with refs, deep and
   shallow object and collection proxies, effects, computed values, dependency
   debugging hooks, Node tests, and declaration contract tests.
+- A deterministic phased scheduler with batching, `nextTick`, untracked reads,
+  hierarchical effect scopes, scheduled watchers, cleanup, and a contained
+  reactivity error channel.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ count.value = 2;
 Deep and shallow mutable or readonly proxies support plain objects, arrays,
 `Map`, and `Set`. Effects track only the properties and collection operations
 they read; computed values remain lazy and cached until a dependency changes.
+The package also provides deduplicated pre/update/post scheduling, `batch`,
+`nextTick`, untracked reads, effect scopes, scheduled watchers, deterministic
+cleanup, and a contained error channel.
 
 ## Bindings and spreading
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,11 @@ packages/reactivity/
 ├── src/effect.ts       Dependency graph, effects, cleanup, debug hooks
 ├── src/reactive.ts     Deep/shallow mutable/readonly object and collection proxies
 ├── src/ref.ts          Deep and shallow primitive refs
-└── src/computed.ts     Lazy cached readonly and writable computed refs
+├── src/computed.ts     Lazy cached readonly and writable computed refs
+├── src/scheduler.ts    Dedupe, batching, phases, ordering, nextTick
+├── src/scope.ts        Hierarchical effect ownership and cleanup
+├── src/watch.ts        Scheduled source and effect watchers
+└── src/error.ts        Contained low-level reactivity error channel
 ```
 
 The current private package builds separate ESM entry points for `@gluonjs/core`,
@@ -44,8 +48,37 @@ Deep and shallow mutable or readonly proxies cover plain objects, arrays,
 `Map`, and `Set`. Collection dependencies distinguish specific keys, membership,
 size, map-key iteration, and value/entry iteration. Computed refs use an internal
 effect only to mark their cache dirty; their getter executes lazily on the next
-read. Issue #19 owns asynchronous scheduling, batching, `nextTick`, and effect
-scope lifecycles, which are not added by this package foundation.
+read.
+
+### Scheduling and ownership
+
+Scheduler work is deduplicated by function within `pre`, `update`, and `post`
+phases. Each phase sorts ascending numeric IDs before insertion order, providing
+an explicit parent-before-child mechanism. A phase queued after that phase has
+already completed runs in the next cycle; one flush drains all cycles before
+`nextTick` resolves. Promise-returning jobs are awaited within their phase and
+their rejections use the same error channel. A recursion limit routes
+self-queueing failures through the error channel without rejecting the flush
+promise.
+
+Effects remain synchronous unless they select `pre` or `post`. The outermost
+synchronous `batch` deduplicates all affected effects before dispatch. `untracked`
+temporarily suppresses subscription collection while preserving nested active
+effect behavior.
+
+Attached scopes own effects, computed dependency effects, watchers, child
+scopes, and cleanup callbacks. Stop order is reverse-created effects,
+reverse-created child scopes, then reverse-registered cleanup callbacks.
+Detached scopes remain independent. Scope stop invalidates queued work and
+permanently disables scope-owned runners.
+
+Low-level failures select the closest effect, watcher, job, or scope handler;
+the configured global reactivity handler is used when no local handler exists.
+The default uses platform `reportError` or `console.error`; handler failures are
+contained by that default channel. Application-
+specific error ownership remains issue #23. Issue #22 integrates these scheduler
+and scope primitives with `GluonElement`; the element still uses its current
+property-update microtask until that lifecycle integration is implemented.
 
 ## Runtime contract
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,6 +54,7 @@ Gluon currently provides:
 - child, attribute, property, boolean, event, directive, ref, and spread bindings
 - nested templates and index-based array rendering
 - standalone DOM-free refs, reactive and readonly proxies, effects, and computed values
+- deterministic batching, phased scheduling, `nextTick`, effect scopes, and watchers
 - reactive declared properties through `GluonElement`
 - constructable stylesheet creation and adopted stylesheet management
 - typed Quark factories for native HTML elements

--- a/packages/reactivity/CHANGELOG.md
+++ b/packages/reactivity/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 - Standalone refs, object and collection proxies, effects, computed values, and
   development dependency-debugging hooks.
+- A deduplicating pre/update/post scheduler, synchronous batching, `nextTick`,
+  untracked reads, hierarchical effect scopes, watchers, cleanup, and error
+  routing.

--- a/packages/reactivity/README.md
+++ b/packages/reactivity/README.md
@@ -4,7 +4,7 @@ DOM-free reactive state primitives for Gluon. The package is private and
 unpublished while the Gluon 1.0 contracts are being implemented.
 
 ```ts
-import { computed, effect, reactive, ref } from '@gluonjs/reactivity';
+import { computed, effect, nextTick, reactive, ref } from '@gluonjs/reactivity';
 
 const count = ref(1);
 const state = reactive({ multiplier: 2 });
@@ -12,9 +12,10 @@ const total = computed(() => count.value * state.multiplier);
 
 effect(() => {
   console.log(total.value);
-});
+}, { flush: 'pre' });
 
 count.value = 2;
+await nextTick();
 ```
 
 ## API
@@ -24,10 +25,42 @@ count.value = 2;
 - `isReactive`, `isReadonly`, `isProxy`, and `toRaw`
 - `effect`, `stop`, and development-only `onTrack`/`onTrigger` callbacks
 - lazy, cached readonly and writable `computed` values
+- `batch`, `untracked`, phased queue helpers, and `nextTick`
+- attached or detached `effectScope` ownership and `onScopeDispose`
+- scheduled `watch` and `watchEffect` with deterministic cleanup
+- global, scope-local, job-local, and effect-local error handlers
 
 Deep reactive proxies support plain objects, arrays, `Map`, and `Set`. The
 package source compiles with the ES2022 library and no DOM or Node ambient
 types.
+
+## Scheduler contract
+
+Queued work is deduplicated by function within its phase. A flush runs `pre`,
+`update`, and `post` phases in that order. Within a phase, smaller numeric IDs
+run before larger IDs so parent owners can precede children; equal or omitted
+IDs retain insertion order. Work queued for a phase that already completed runs
+in the next cycle of the same flush. `nextTick()` resolves only after every
+cycle, including post-flush work, is complete. A queued job may return a promise;
+the current phase waits for it and routes rejection through the same error
+channel.
+
+Effects are synchronous by default. `flush: 'pre'` and `flush: 'post'` opt into
+the shared microtask queue. `batch()` deduplicates synchronous invalidations
+until the outermost synchronous batch returns; it does not extend across an
+`await` boundary.
+
+An attached scope stops its owned effects in reverse creation order, then child
+scopes in reverse creation order, then cleanup callbacks in reverse registration
+order. A detached scope has independent ownership. Stopping a scope cancels its
+queued effects and watchers and prevents their runners from executing again.
+
+Errors are delivered to the closest explicit effect, watcher, job, or scope
+handler. When no local handler exists, the handler installed by
+`setReactivityErrorHandler` receives them. The default channel uses platform
+`reportError` when present and otherwise `console.error`. Handler failures are
+contained by the default channel so scheduler flushes and `nextTick` do not
+become unhandled promise rejections.
 
 ## License
 

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -1,3 +1,19 @@
+import {
+  containReactivityError,
+  reportReactivityError,
+  type ReactivityErrorHandler,
+} from './error.js';
+import {
+  invalidateJob,
+  scheduleEffect,
+  type EffectFlush,
+} from './scheduler.js';
+import {
+  getCurrentScope,
+  recordEffectScope,
+  type ScopedEffect,
+} from './scope.js';
+
 export type TrackOperation = 'get' | 'has' | 'iterate';
 export type TriggerOperation = 'set' | 'add' | 'delete' | 'clear';
 
@@ -13,9 +29,12 @@ export interface EffectDebuggerEvent {
 }
 
 export interface EffectOptions {
+  readonly flush?: EffectFlush;
+  readonly id?: number;
   readonly onTrack?: (event: EffectDebuggerEvent) => void;
   readonly onTrigger?: (event: EffectDebuggerEvent) => void;
   readonly onStop?: () => void;
+  readonly onError?: ReactivityErrorHandler;
 }
 
 type Dependency = Set<ReactiveEffect>;
@@ -40,24 +59,35 @@ function isDevelopment(): boolean {
   ).process?.env?.NODE_ENV !== 'production';
 }
 
-class ReactiveEffect {
+class ReactiveEffect implements ScopedEffect {
   readonly dependencies = new Set<Dependency>();
   active = true;
   runner!: ReactiveEffectRunner;
   private lastValue: unknown;
+  private scopeStopped = false;
+  removeFromScope: (() => void) | undefined;
 
   constructor(
     private readonly callback: () => unknown,
-    readonly scheduler?: Scheduler,
+    readonly scheduler: Scheduler,
     readonly options: EffectOptions = {},
   ) {}
 
   run(): unknown {
+    if (this.scopeStopped) return this.lastValue;
     if (!this.active) {
       trackingStack.push(trackingEnabled);
       trackingEnabled = false;
       try {
-        return this.callback();
+        return containReactivityError(
+          this.callback(),
+          'effect',
+          this.runner,
+          this.options.onError,
+        );
+      } catch (error) {
+        reportReactivityError(error, 'effect', this.runner, this.options.onError);
+        return this.lastValue;
       } finally {
         trackingEnabled = trackingStack.pop() ?? true;
       }
@@ -71,7 +101,15 @@ class ReactiveEffect {
     activeEffect = this;
 
     try {
-      this.lastValue = this.callback();
+      this.lastValue = containReactivityError(
+        this.callback(),
+        'effect',
+        this.runner,
+        this.options.onError,
+      );
+      return this.lastValue;
+    } catch (error) {
+      reportReactivityError(error, 'effect', this.runner, this.options.onError);
       return this.lastValue;
     } finally {
       effectStack.pop();
@@ -80,10 +118,14 @@ class ReactiveEffect {
     }
   }
 
-  stop(): void {
+  stop(fromScope = false): void {
+    if (fromScope) this.scopeStopped = true;
+    invalidateJob(this.runner);
     if (!this.active) return;
     cleanupEffect(this);
     this.active = false;
+    this.removeFromScope?.();
+    this.removeFromScope = undefined;
     this.options.onStop?.();
   }
 }
@@ -95,13 +137,18 @@ function cleanupEffect(effect: ReactiveEffect): void {
 
 export function createReactiveEffect<T>(
   callback: () => T,
-  scheduler?: Scheduler,
+  scheduler: Scheduler,
   options: EffectOptions = {},
 ): ReactiveEffectRunner<T> {
-  const reactiveEffect = new ReactiveEffect(callback, scheduler, options);
+  const scopeErrorHandler = getCurrentScope()?.onError;
+  const resolvedOptions = options.onError || !scopeErrorHandler
+    ? options
+    : { ...options, onError: scopeErrorHandler };
+  const reactiveEffect = new ReactiveEffect(callback, scheduler, resolvedOptions);
   const runner = (() => reactiveEffect.run()) as ReactiveEffectRunner<T>;
   reactiveEffect.runner = runner;
   runnerEffects.set(runner, reactiveEffect);
+  reactiveEffect.removeFromScope = recordEffectScope(reactiveEffect);
   return runner;
 }
 
@@ -109,13 +156,33 @@ export function effect<T>(
   callback: () => T,
   options: EffectOptions = {},
 ): ReactiveEffectRunner<T> {
-  const runner = createReactiveEffect(callback, undefined, options);
+  let runner!: ReactiveEffectRunner<T>;
+  const onError = options.onError ?? getCurrentScope()?.onError;
+  const scheduler = () => {
+    scheduleEffect(
+      runner,
+      options.flush ?? 'sync',
+      options.id,
+      onError,
+    );
+  };
+  runner = createReactiveEffect(callback, scheduler, { ...options, onError });
   runner();
   return runner;
 }
 
 export function stop(runner: ReactiveEffectRunner): void {
   runnerEffects.get(runner)?.stop();
+}
+
+export function untracked<T>(callback: () => T): T {
+  trackingStack.push(trackingEnabled);
+  trackingEnabled = false;
+  try {
+    return callback();
+  } finally {
+    trackingEnabled = trackingStack.pop() ?? true;
+  }
 }
 
 export function track(
@@ -252,7 +319,15 @@ export function trigger(
         oldValue,
       });
     }
-    if (reactiveEffect.scheduler) reactiveEffect.scheduler();
-    else reactiveEffect.run();
+    try {
+      reactiveEffect.scheduler();
+    } catch (error) {
+      reportReactivityError(
+        error,
+        'scheduler',
+        reactiveEffect.runner,
+        reactiveEffect.options.onError,
+      );
+    }
   }
 }

--- a/packages/reactivity/src/error.ts
+++ b/packages/reactivity/src/error.ts
@@ -1,0 +1,87 @@
+export type ReactivityErrorPhase = 'effect' | 'scheduler' | 'cleanup' | 'error-handler';
+
+export interface ReactivityErrorContext {
+  readonly error: unknown;
+  readonly phase: ReactivityErrorPhase;
+  readonly source?: unknown;
+}
+
+export type ReactivityErrorHandler = (
+  context: ReactivityErrorContext,
+) => void | PromiseLike<void>;
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  ) && typeof Reflect.get(value, 'then') === 'function';
+}
+
+function defaultErrorHandler(context: ReactivityErrorContext): void {
+  const environment = globalThis as {
+    reportError?: (error: unknown) => void;
+    console?: { error?: (...values: unknown[]) => void };
+  };
+
+  try {
+    if (typeof environment.reportError === 'function') {
+      environment.reportError(context.error);
+      return;
+    }
+    environment.console?.error?.(context.error);
+  } catch {
+    // The error channel must not turn scheduler failures into rejected flush promises.
+  }
+}
+
+let globalErrorHandler: ReactivityErrorHandler = defaultErrorHandler;
+
+export function setReactivityErrorHandler(
+  handler: ReactivityErrorHandler | undefined,
+): () => void {
+  const previous = globalErrorHandler;
+  globalErrorHandler = handler ?? defaultErrorHandler;
+  return () => {
+    globalErrorHandler = previous;
+  };
+}
+
+export function reportReactivityError(
+  error: unknown,
+  phase: ReactivityErrorPhase,
+  source?: unknown,
+  handler?: ReactivityErrorHandler,
+): void {
+  const context = { error, phase, source } satisfies ReactivityErrorContext;
+  try {
+    const result = (handler ?? globalErrorHandler)(context);
+    if (isPromiseLike(result)) {
+      void Promise.resolve(result).catch((handlerError: unknown) => {
+        defaultErrorHandler({
+          error: handlerError,
+          phase: 'error-handler',
+          source: context,
+        });
+      });
+    }
+  } catch (handlerError) {
+    defaultErrorHandler({
+      error: handlerError,
+      phase: 'error-handler',
+      source: context,
+    });
+  }
+}
+
+/** @internal */
+export function containReactivityError(
+  value: unknown,
+  phase: ReactivityErrorPhase,
+  source?: unknown,
+  handler?: ReactivityErrorHandler,
+): unknown {
+  if (!isPromiseLike(value)) return value;
+  return Promise.resolve(value).catch((error: unknown) => {
+    reportReactivityError(error, phase, source, handler);
+    return undefined;
+  });
+}

--- a/packages/reactivity/src/index.ts
+++ b/packages/reactivity/src/index.ts
@@ -1,12 +1,53 @@
 export {
   effect,
   stop,
+  untracked,
   type EffectDebuggerEvent,
   type EffectOptions,
   type ReactiveEffectRunner,
   type TrackOperation,
   type TriggerOperation,
 } from './effect.js';
+
+export {
+  setReactivityErrorHandler,
+  type ReactivityErrorContext,
+  type ReactivityErrorHandler,
+  type ReactivityErrorPhase,
+} from './error.js';
+
+export {
+  batch,
+  invalidateJob,
+  nextTick,
+  queueJob,
+  queuePostFlushCallback,
+  queuePreFlushCallback,
+  type EffectFlush,
+  type FlushPhase,
+  type SchedulerJob,
+  type SchedulerJobOptions,
+} from './scheduler.js';
+
+export {
+  EffectScope,
+  effectScope,
+  getCurrentScope,
+  onScopeDispose,
+  type EffectScopeOptions,
+} from './scope.js';
+
+export {
+  watch,
+  watchEffect,
+  type WatchCallback,
+  type WatchCleanup,
+  type WatchCleanupRegistrar,
+  type WatchEffectCallback,
+  type WatchOptions,
+  type WatchSource,
+  type WatchStopHandle,
+} from './watch.js';
 
 export {
   isProxy,

--- a/packages/reactivity/src/scheduler.ts
+++ b/packages/reactivity/src/scheduler.ts
@@ -1,0 +1,216 @@
+import {
+  reportReactivityError,
+  type ReactivityErrorHandler,
+} from './error.js';
+import { getCurrentScope } from './scope.js';
+
+export type FlushPhase = 'pre' | 'update' | 'post';
+export type EffectFlush = 'sync' | 'pre' | 'post';
+export type SchedulerJob = () => unknown;
+
+export interface SchedulerJobOptions {
+  readonly phase?: FlushPhase;
+  readonly id?: number;
+  readonly onError?: ReactivityErrorHandler;
+}
+
+interface QueuedJob extends Required<Pick<SchedulerJobOptions, 'phase'>> {
+  readonly job: SchedulerJob;
+  readonly id: number;
+  readonly order: number;
+  readonly onError?: ReactivityErrorHandler;
+}
+
+const phaseOrder = ['pre', 'update', 'post'] as const;
+const queues: Record<FlushPhase, Map<SchedulerJob, QueuedJob>> = {
+  pre: new Map(),
+  update: new Map(),
+  post: new Map(),
+};
+const batchedJobs = new Map<SchedulerJob, QueuedJob & { readonly flush: EffectFlush }>();
+const invalidatedJobs = new Set<SchedulerJob>();
+const pendingSnapshotJobs = new Set<SchedulerJob>();
+const pendingBatchJobs = new Set<SchedulerJob>();
+const resolvedPromise = Promise.resolve();
+const recursionLimit = 100;
+let currentFlushPromise: Promise<void> | undefined;
+let sequence = 0;
+let batchDepth = 0;
+let flushingBatch = false;
+
+function compareJobs(first: QueuedJob, second: QueuedJob): number {
+  return first.id - second.id || first.order - second.order;
+}
+
+function hasQueuedJobs(): boolean {
+  return phaseOrder.some((phase) => queues[phase].size > 0);
+}
+
+function ensureFlush(): void {
+  currentFlushPromise ??= resolvedPromise.then(flushJobs);
+}
+
+async function runJob(entry: QueuedJob): Promise<void> {
+  try {
+    await entry.job();
+  } catch (error) {
+    reportReactivityError(error, 'scheduler', entry.job, entry.onError);
+  }
+}
+
+async function flushPhase(
+  phase: FlushPhase,
+  executions: Map<SchedulerJob, number>,
+): Promise<void> {
+  const queue = queues[phase];
+  while (queue.size > 0) {
+    const jobs = [...queue.values()].sort(compareJobs);
+    queue.clear();
+    for (const entry of jobs) pendingSnapshotJobs.add(entry.job);
+    for (const entry of jobs) {
+      const invalidated = invalidatedJobs.delete(entry.job);
+      pendingSnapshotJobs.delete(entry.job);
+      if (invalidated) continue;
+      const executionCount = (executions.get(entry.job) ?? 0) + 1;
+      executions.set(entry.job, executionCount);
+      if (executionCount > recursionLimit) {
+        reportReactivityError(
+          new Error('Scheduler recursion limit exceeded.'),
+          'scheduler',
+          entry.job,
+          entry.onError,
+        );
+        continue;
+      }
+      await runJob(entry);
+    }
+  }
+}
+
+async function flushJobs(): Promise<void> {
+  const executions = new Map<SchedulerJob, number>();
+  try {
+    do {
+      for (const phase of phaseOrder) await flushPhase(phase, executions);
+    } while (hasQueuedJobs());
+  } finally {
+    currentFlushPromise = undefined;
+    if (hasQueuedJobs()) ensureFlush();
+  }
+}
+
+export function queueJob(
+  job: SchedulerJob,
+  options: SchedulerJobOptions = {},
+): void {
+  const phase = options.phase ?? 'update';
+  const queue = queues[phase];
+  const onError = options.onError ?? getCurrentScope()?.onError;
+  invalidatedJobs.delete(job);
+  if (!queue.has(job)) {
+    queue.set(job, {
+      job,
+      phase,
+      id: options.id ?? Number.POSITIVE_INFINITY,
+      order: sequence,
+      onError,
+    });
+    sequence += 1;
+  }
+  ensureFlush();
+}
+
+export function queuePreFlushCallback(
+  callback: SchedulerJob,
+  options: Omit<SchedulerJobOptions, 'phase'> = {},
+): void {
+  queueJob(callback, { ...options, phase: 'pre' });
+}
+
+export function queuePostFlushCallback(
+  callback: SchedulerJob,
+  options: Omit<SchedulerJobOptions, 'phase'> = {},
+): void {
+  queueJob(callback, { ...options, phase: 'post' });
+}
+
+export function invalidateJob(job: SchedulerJob): void {
+  if (pendingSnapshotJobs.has(job)) invalidatedJobs.add(job);
+  for (const phase of phaseOrder) queues[phase].delete(job);
+  batchedJobs.delete(job);
+}
+
+export function nextTick(): Promise<void>;
+export function nextTick<T>(callback: () => T | PromiseLike<T>): Promise<T>;
+export function nextTick<T>(callback?: () => T | PromiseLike<T>): Promise<void | T> {
+  const promise = currentFlushPromise ?? resolvedPromise;
+  return callback ? promise.then(callback) : promise;
+}
+
+export function batch<T>(callback: () => T): T {
+  batchDepth += 1;
+  try {
+    return callback();
+  } finally {
+    batchDepth -= 1;
+    if (batchDepth === 0) flushBatchedJobs();
+  }
+}
+
+function flushBatchedJobs(): void {
+  flushingBatch = true;
+  try {
+    while (batchedJobs.size > 0) {
+      const jobs = [...batchedJobs.values()].sort(compareJobs);
+      batchedJobs.clear();
+      for (const entry of jobs) pendingBatchJobs.add(entry.job);
+      for (const entry of jobs) {
+        pendingBatchJobs.delete(entry.job);
+        dispatchEffect(entry.job, entry.flush, entry.id, entry.onError);
+      }
+    }
+  } finally {
+    pendingBatchJobs.clear();
+    flushingBatch = false;
+  }
+}
+
+function dispatchEffect(
+  job: SchedulerJob,
+  flush: EffectFlush,
+  id: number,
+  onError?: ReactivityErrorHandler,
+): void {
+  if (flush === 'sync') {
+    void runJob({ job, phase: 'update', id, order: sequence, onError });
+    sequence += 1;
+  } else {
+    queueJob(job, { phase: flush, id, onError });
+  }
+}
+
+/** @internal */
+export function scheduleEffect(
+  job: SchedulerJob,
+  flush: EffectFlush,
+  id = Number.POSITIVE_INFINITY,
+  onError?: ReactivityErrorHandler,
+): void {
+  if (batchDepth > 0 || flushingBatch) {
+    if (pendingBatchJobs.has(job)) return;
+    if (!batchedJobs.has(job)) {
+      batchedJobs.set(job, {
+        job,
+        flush,
+        phase: flush === 'sync' ? 'update' : flush,
+        id,
+        order: sequence,
+        onError,
+      });
+      sequence += 1;
+    }
+    return;
+  }
+
+  dispatchEffect(job, flush, id, onError);
+}

--- a/packages/reactivity/src/scope.ts
+++ b/packages/reactivity/src/scope.ts
@@ -1,0 +1,135 @@
+import {
+  containReactivityError,
+  reportReactivityError,
+  type ReactivityErrorHandler,
+} from './error.js';
+
+export interface EffectScopeOptions {
+  readonly detached?: boolean;
+  readonly onError?: ReactivityErrorHandler;
+}
+
+/** @internal */
+export interface ScopedEffect {
+  stop(fromScope?: boolean): void;
+}
+
+interface ScopeCleanup {
+  readonly callback: () => void;
+}
+
+let activeScope: EffectScope | undefined;
+
+export class EffectScope {
+  private readonly effects: ScopedEffect[] = [];
+  private readonly childScopes: EffectScope[] = [];
+  private readonly cleanups: ScopeCleanup[] = [];
+  private parent: EffectScope | undefined;
+  private stopped = false;
+  readonly onError: ReactivityErrorHandler | undefined;
+
+  constructor(options: EffectScopeOptions = {}) {
+    this.onError = options.onError;
+    const requestedParent = options.detached ? undefined : activeScope;
+    this.parent = requestedParent?.active ? requestedParent : undefined;
+    if (requestedParent && !requestedParent.active) this.stopped = true;
+    this.parent?.childScopes.push(this);
+  }
+
+  get active(): boolean {
+    return !this.stopped;
+  }
+
+  run<T>(callback: () => T): T | undefined {
+    if (this.stopped) return undefined;
+    const previous = activeScope;
+    activeScope = this;
+    try {
+      return callback();
+    } finally {
+      activeScope = previous;
+    }
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+
+    for (let index = this.effects.length - 1; index >= 0; index -= 1) {
+      this.effects[index]?.stop(true);
+    }
+    for (let index = this.childScopes.length - 1; index >= 0; index -= 1) {
+      this.childScopes[index]?.stop();
+    }
+    for (let index = this.cleanups.length - 1; index >= 0; index -= 1) {
+      try {
+        containReactivityError(
+          this.cleanups[index]?.callback(),
+          'cleanup',
+          this,
+          this.onError,
+        );
+      } catch (error) {
+        reportReactivityError(error, 'cleanup', this, this.onError);
+      }
+    }
+
+    this.effects.length = 0;
+    this.childScopes.length = 0;
+    this.cleanups.length = 0;
+    const parentIndex = this.parent?.childScopes.indexOf(this) ?? -1;
+    if (parentIndex >= 0) this.parent?.childScopes.splice(parentIndex, 1);
+    this.parent = undefined;
+  }
+
+  /** @internal */
+  recordEffect(effect: ScopedEffect): void {
+    if (this.stopped) effect.stop(true);
+    else this.effects.push(effect);
+  }
+
+  /** @internal */
+  removeEffect(effect: ScopedEffect): void {
+    const index = this.effects.indexOf(effect);
+    if (index >= 0) this.effects.splice(index, 1);
+  }
+
+  /** @internal */
+  recordCleanup(cleanup: () => void): (() => void) | undefined {
+    if (this.stopped) return undefined;
+    const entry = { callback: cleanup } satisfies ScopeCleanup;
+    this.cleanups.push(entry);
+    return () => {
+      const index = this.cleanups.indexOf(entry);
+      if (index >= 0) this.cleanups.splice(index, 1);
+    };
+  }
+}
+
+export function effectScope(options?: boolean | EffectScopeOptions): EffectScope {
+  return new EffectScope(
+    typeof options === 'boolean' ? { detached: options } : options,
+  );
+}
+
+export function getCurrentScope(): EffectScope | undefined {
+  return activeScope;
+}
+
+export function onScopeDispose(cleanup: () => void): boolean {
+  return recordScopeCleanup(cleanup) !== undefined;
+}
+
+/** @internal */
+export function recordScopeCleanup(cleanup: () => void): (() => void) | undefined {
+  return activeScope?.recordCleanup(cleanup);
+}
+
+/** @internal */
+export function recordEffectScope(effect: ScopedEffect): (() => void) | undefined {
+  const scope = activeScope;
+  if (!scope) return undefined;
+  scope.recordEffect(effect);
+  if (!scope.active) return undefined;
+  return () => scope.removeEffect(effect);
+}

--- a/packages/reactivity/src/watch.ts
+++ b/packages/reactivity/src/watch.ts
@@ -1,0 +1,188 @@
+import {
+  createReactiveEffect,
+  stop,
+  type ReactiveEffectRunner,
+} from './effect.js';
+import {
+  containReactivityError,
+  reportReactivityError,
+  type ReactivityErrorHandler,
+} from './error.js';
+import { isRef, type Ref } from './ref.js';
+import {
+  invalidateJob,
+  scheduleEffect,
+  type EffectFlush,
+} from './scheduler.js';
+import { getCurrentScope, recordScopeCleanup } from './scope.js';
+
+export type WatchCleanup = () => void | PromiseLike<void>;
+export type WatchCleanupRegistrar = (cleanup: WatchCleanup) => void;
+export type WatchStopHandle = () => void;
+
+export interface WatchOptions {
+  readonly flush?: EffectFlush;
+  readonly id?: number;
+  readonly immediate?: boolean;
+  readonly deep?: boolean;
+  readonly onError?: ReactivityErrorHandler;
+}
+
+export type WatchSource<T> = Ref<T> | (() => T);
+export type WatchCallback<T> = (
+  value: T,
+  oldValue: T | undefined,
+  onCleanup: WatchCleanupRegistrar,
+) => void | PromiseLike<void>;
+export type WatchEffectCallback = (
+  onCleanup: WatchCleanupRegistrar,
+) => void | PromiseLike<void>;
+
+function runCleanups(
+  cleanups: WatchCleanup[],
+  source: unknown,
+  onError?: ReactivityErrorHandler,
+): void {
+  for (let index = cleanups.length - 1; index >= 0; index -= 1) {
+    try {
+      containReactivityError(
+        cleanups[index]?.(),
+        'cleanup',
+        source,
+        onError,
+      );
+    } catch (error) {
+      reportReactivityError(error, 'cleanup', source, onError);
+    }
+  }
+  cleanups.length = 0;
+}
+
+function traverse(value: unknown, seen = new WeakSet<object>()): void {
+  if (typeof value !== 'object' || value === null || seen.has(value)) return;
+  seen.add(value);
+
+  if (value instanceof Map) {
+    for (const [key, entryValue] of value) {
+      traverse(key, seen);
+      traverse(entryValue, seen);
+    }
+    return;
+  }
+  if (value instanceof Set) {
+    for (const entryValue of value) traverse(entryValue, seen);
+    return;
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    traverse(Reflect.get(value, key), seen);
+  }
+}
+
+export function watchEffect(
+  callback: WatchEffectCallback,
+  options: WatchOptions = {},
+): WatchStopHandle {
+  const cleanups: WatchCleanup[] = [];
+  const onError = options.onError ?? getCurrentScope()?.onError;
+  const onCleanup: WatchCleanupRegistrar = (cleanup) => cleanups.push(cleanup);
+  let stopped = false;
+  let removeScopeCleanup: (() => void) | undefined;
+  let runner!: ReactiveEffectRunner<void>;
+  const wrapped = () => {
+    runCleanups(cleanups, callback, onError);
+    return callback(onCleanup);
+  };
+  const scheduler = () => {
+    scheduleEffect(
+      runner,
+      options.flush ?? 'pre',
+      options.id,
+      onError,
+    );
+  };
+  runner = createReactiveEffect(wrapped, scheduler, { ...options, onError });
+
+  const stopHandle = () => {
+    if (stopped) return;
+    stopped = true;
+    removeScopeCleanup?.();
+    removeScopeCleanup = undefined;
+    invalidateJob(runner);
+    stop(runner);
+    runCleanups(cleanups, callback, onError);
+  };
+  removeScopeCleanup = recordScopeCleanup(stopHandle);
+  runner();
+  return stopHandle;
+}
+
+export function watch<T>(
+  source: WatchSource<T>,
+  callback: WatchCallback<T>,
+  options: WatchOptions = {},
+): WatchStopHandle {
+  const cleanups: WatchCleanup[] = [];
+  const onError = options.onError ?? getCurrentScope()?.onError;
+  const onCleanup: WatchCleanupRegistrar = (cleanup) => cleanups.push(cleanup);
+  const read = isRef<T>(source) ? () => source.value : source;
+  const getter = () => {
+    const value = read();
+    if (options.deep) traverse(value);
+    return value;
+  };
+  let stopped = false;
+  let removeScopeCleanup: (() => void) | undefined;
+  let initialized = false;
+  let oldValue: T | undefined;
+  let runner!: ReactiveEffectRunner<T>;
+
+  const job = () => {
+    if (stopped) return;
+    const value = runner();
+    if (!initialized || options.deep || !Object.is(value, oldValue)) {
+      runCleanups(cleanups, callback, onError);
+      try {
+        const result = containReactivityError(
+          callback(value, oldValue, onCleanup),
+          'effect',
+          callback,
+          onError,
+        );
+        oldValue = value;
+        initialized = true;
+        return result;
+      } catch (error) {
+        reportReactivityError(error, 'effect', callback, onError);
+      }
+      oldValue = value;
+      initialized = true;
+    }
+  };
+  const scheduler = () => {
+    scheduleEffect(
+      job,
+      options.flush ?? 'pre',
+      options.id,
+      onError,
+    );
+  };
+  runner = createReactiveEffect(getter, scheduler, { ...options, onError });
+
+  const stopHandle = () => {
+    if (stopped) return;
+    stopped = true;
+    removeScopeCleanup?.();
+    removeScopeCleanup = undefined;
+    invalidateJob(job);
+    stop(runner);
+    runCleanups(cleanups, callback, onError);
+  };
+  removeScopeCleanup = recordScopeCleanup(stopHandle);
+
+  if (options.immediate) job();
+  else {
+    oldValue = runner();
+    initialized = true;
+  }
+  return stopHandle;
+}

--- a/tests-node/reactivity.types.ts
+++ b/tests-node/reactivity.types.ts
@@ -1,16 +1,28 @@
 import {
+  batch,
   computed,
   effect,
+  effectScope,
+  nextTick,
+  onScopeDispose,
+  queueJob,
   reactive,
   readonly,
   ref,
+  setReactivityErrorHandler,
   shallowReadonly,
   stop,
+  untracked,
+  watch,
+  watchEffect,
   type ComputedRef,
   type DeepReadonly,
   type EffectDebuggerEvent,
+  type FlushPhase,
+  type ReactivityErrorHandler,
   type ReactiveEffectRunner,
   type Ref,
+  type WatchStopHandle,
   type WritableComputedRef,
 } from '../packages/reactivity/dist/index.js';
 
@@ -25,14 +37,42 @@ const writable: WritableComputedRef<number> = computed({
   set: (value) => { count.value = value; },
 });
 const runner: ReactiveEffectRunner<number> = effect(() => state.count, {
+  flush: 'pre',
+  id: 1,
   onTrack(event: EffectDebuggerEvent) {
     event.effect;
     event.key;
   },
 });
+const phase: FlushPhase = 'update';
+const scope = effectScope({
+  onError(context) {
+    context.phase;
+  },
+});
+const stopWatch: WatchStopHandle = watch(count, (value, oldValue, onCleanup) => {
+  value.toFixed();
+  oldValue?.toFixed();
+  onCleanup(() => undefined);
+});
+const stopWatchEffect = watchEffect((onCleanup) => {
+  count.value;
+  onCleanup(() => undefined);
+});
+const errorHandler: ReactivityErrorHandler = ({ error }) => { void error; };
+const restoreErrorHandler = setReactivityErrorHandler(errorHandler);
 
 writable.value = doubled.value;
 shallow.count;
+phase;
+scope.run(() => onScopeDispose(() => undefined));
+queueJob(() => undefined, { phase: 'update', id: 1, onError: errorHandler });
+const batched: number = batch(() => untracked(() => count.value));
+const tick: Promise<number> = nextTick(() => batched);
+void tick;
+stopWatch();
+stopWatchEffect();
+restoreErrorHandler();
 stop(runner);
 
 // @ts-expect-error deep readonly properties cannot be assigned

--- a/tests-node/scheduler.spec.ts
+++ b/tests-node/scheduler.spec.ts
@@ -1,0 +1,643 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  batch,
+  computed,
+  effect,
+  effectScope,
+  getCurrentScope,
+  invalidateJob,
+  nextTick,
+  onScopeDispose,
+  queueJob,
+  queuePostFlushCallback,
+  queuePreFlushCallback,
+  reactive,
+  ref,
+  setReactivityErrorHandler,
+  stop,
+  untracked,
+  watch,
+  watchEffect,
+  type ReactivityErrorContext,
+} from '../packages/reactivity/src/index.js';
+
+describe('reactivity scheduler', () => {
+  it('deduplicates scheduled effects across synchronous writes', async () => {
+    const state = reactive({ count: 0 });
+    const values: number[] = [];
+    effect(() => values.push(state.count), { flush: 'pre' });
+
+    state.count = 1;
+    state.count = 2;
+    state.count = 3;
+    expect(values).toEqual([0]);
+
+    await nextTick();
+    expect(values).toEqual([0, 3]);
+  });
+
+  it('orders phases and parent ids deterministically while deduplicating jobs', async () => {
+    const order: string[] = [];
+    const preParent = () => order.push('pre-parent');
+    const preChild = () => order.push('pre-child');
+    const updateParent = () => order.push('update-parent');
+    const updateChild = () => order.push('update-child');
+
+    queuePostFlushCallback(() => order.push('post'));
+    queueJob(updateChild, { id: 20 });
+    queuePreFlushCallback(preChild, { id: 20 });
+    queueJob(updateParent, { id: 10 });
+    queuePreFlushCallback(preParent, { id: 10 });
+    queuePreFlushCallback(preParent, { id: 10 });
+
+    await nextTick();
+    expect(order).toEqual([
+      'pre-parent',
+      'pre-child',
+      'update-parent',
+      'update-child',
+      'post',
+    ]);
+  });
+
+  it('runs work queued for a completed phase in the next deterministic cycle', async () => {
+    const order: string[] = [];
+    queuePreFlushCallback(() => order.push('pre'));
+    queueJob(() => {
+      order.push('update');
+      queuePreFlushCallback(() => order.push('late-pre'));
+    });
+    queuePostFlushCallback(() => order.push('post'));
+
+    await nextTick();
+    expect(order).toEqual(['pre', 'update', 'post', 'late-pre']);
+  });
+
+  it('resolves nextTick after post-flush work and immediately without pending work', async () => {
+    const order: string[] = [];
+    queuePostFlushCallback(() => order.push('post'));
+    await nextTick(() => order.push('tick'));
+    expect(order).toEqual(['post', 'tick']);
+
+    await expect(nextTick(() => 42)).resolves.toBe(42);
+  });
+
+  it('invalidates queued generic jobs before they flush', async () => {
+    const job = vi.fn();
+    queueJob(job);
+    invalidateJob(job);
+    await nextTick();
+    expect(job).not.toHaveBeenCalled();
+  });
+
+  it('invalidates a later job from the active queue snapshot', async () => {
+    const later = vi.fn();
+    queueJob(() => invalidateJob(later), { id: 1 });
+    queueJob(later, { id: 2 });
+    await nextTick();
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it('batches synchronous effects once and preserves deterministic ids', () => {
+    const state = reactive({ count: 0 });
+    const order: string[] = [];
+    effect(() => {
+      state.count;
+      order.push('child');
+    }, { id: 20 });
+    effect(() => {
+      state.count;
+      order.push('parent');
+    }, { id: 10 });
+    order.length = 0;
+
+    const result = batch(() => {
+      state.count = 1;
+      batch(() => { state.count = 2; });
+      state.count = 3;
+      expect(order).toEqual([]);
+      return 'complete';
+    });
+
+    expect(result).toBe('complete');
+    expect(order).toEqual(['parent', 'child']);
+  });
+
+  it('flushes a batch in finally while preserving callback errors', () => {
+    const state = reactive({ count: 0 });
+    const callback = vi.fn(() => state.count);
+    effect(callback);
+
+    expect(() => batch(() => {
+      state.count = 1;
+      throw new Error('batch failed');
+    })).toThrow('batch failed');
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not double-run a still-pending batch effect invalidated by an earlier effect', () => {
+    const state = reactive({ first: 0, second: 0 });
+    const first = vi.fn(() => {
+      if (state.first === 1) state.second = 1;
+    });
+    const second = vi.fn(() => state.second);
+    effect(first, { id: 1 });
+    effect(second, { id: 2 });
+
+    batch(() => {
+      state.first = 1;
+      state.second = 2;
+    });
+
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(state.second).toBe(1);
+  });
+
+  it('untracked reads do not subscribe the active effect', () => {
+    const state = reactive({ tracked: 1, ignored: 1 });
+    const callback = vi.fn(() => {
+      state.tracked;
+      return untracked(() => state.ignored);
+    });
+    effect(callback);
+
+    state.ignored = 2;
+    expect(callback).toHaveBeenCalledOnce();
+    state.tracked = 2;
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('orders scheduled effects by parent id', async () => {
+    const state = reactive({ count: 0 });
+    const order: string[] = [];
+    effect(() => {
+      state.count;
+      order.push('child');
+    }, { flush: 'pre', id: 20 });
+    effect(() => {
+      state.count;
+      order.push('parent');
+    }, { flush: 'pre', id: 10 });
+    order.length = 0;
+
+    state.count = 1;
+    await nextTick();
+    expect(order).toEqual(['parent', 'child']);
+  });
+
+  it('limits recursively queued jobs and reports through the error channel', async () => {
+    const errors: ReactivityErrorContext[] = [];
+    const restore = setReactivityErrorHandler((context) => errors.push(context));
+    let calls = 0;
+    const job = () => {
+      calls += 1;
+      queueJob(job);
+    };
+
+    try {
+      queueJob(job);
+      await nextTick();
+      expect(calls).toBe(100);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatchObject({ phase: 'scheduler', source: job });
+      expect(errors[0]?.error).toBeInstanceOf(Error);
+    } finally {
+      restore();
+    }
+  });
+
+  it('awaits asynchronous jobs and routes their rejection before nextTick resolves', async () => {
+    const errors: ReactivityErrorContext[] = [];
+    const order: string[] = [];
+    const restore = setReactivityErrorHandler((context) => errors.push(context));
+    try {
+      queueJob(async () => {
+        order.push('start');
+        await Promise.resolve();
+        order.push('end');
+        throw new Error('async job failed');
+      });
+      await nextTick(() => order.push('tick'));
+      expect(order).toEqual(['start', 'end', 'tick']);
+      expect(errors).toEqual([
+        expect.objectContaining({ phase: 'scheduler' }),
+      ]);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('effect scopes and error routing', () => {
+  it('cancels queued effects and manual runners when a scope stops', async () => {
+    const state = reactive({ count: 0 });
+    const scope = effectScope();
+    const callback = vi.fn(() => state.count);
+    const runner = scope.run(() => effect(callback, { flush: 'pre' }));
+
+    state.count = 1;
+    scope.stop();
+    await nextTick();
+    expect(callback).toHaveBeenCalledOnce();
+    expect(runner?.()).toBe(0);
+    expect(callback).toHaveBeenCalledOnce();
+
+    state.count = 2;
+    await nextTick();
+    expect(callback).toHaveBeenCalledOnce();
+    expect(scope.active).toBe(false);
+    expect(scope.run(() => 'never')).toBeUndefined();
+  });
+
+  it('stops effects, child scopes, and cleanups in documented reverse order', () => {
+    const order: string[] = [];
+    const parent = effectScope();
+    parent.run(() => {
+      effect(() => undefined, { onStop: () => order.push('parent-effect-1') });
+      effect(() => undefined, { onStop: () => order.push('parent-effect-2') });
+      const child = effectScope();
+      child.run(() => {
+        effect(() => undefined, { onStop: () => order.push('child-effect') });
+        onScopeDispose(() => order.push('child-cleanup'));
+      });
+      onScopeDispose(() => order.push('parent-cleanup-1'));
+      onScopeDispose(() => order.push('parent-cleanup-2'));
+    });
+
+    parent.stop();
+    parent.stop();
+    expect(order).toEqual([
+      'parent-effect-2',
+      'parent-effect-1',
+      'child-effect',
+      'child-cleanup',
+      'parent-cleanup-2',
+      'parent-cleanup-1',
+    ]);
+  });
+
+  it('keeps detached scopes alive when their creating scope stops', () => {
+    const state = ref(0);
+    const parent = effectScope();
+    let detached!: ReturnType<typeof effectScope>;
+    const callback = vi.fn(() => state.value);
+    parent.run(() => {
+      detached = effectScope(true);
+      detached.run(() => effect(callback));
+    });
+
+    parent.stop();
+    state.value = 1;
+    expect(callback).toHaveBeenCalledTimes(2);
+    detached.stop();
+    state.value = 2;
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('restores current scopes and rejects disposal registration outside a scope', () => {
+    const outer = effectScope();
+    const inner = effectScope(true);
+    expect(getCurrentScope()).toBeUndefined();
+    outer.run(() => {
+      expect(getCurrentScope()).toBe(outer);
+      inner.run(() => expect(getCurrentScope()).toBe(inner));
+      expect(getCurrentScope()).toBe(outer);
+    });
+    expect(getCurrentScope()).toBeUndefined();
+    expect(onScopeDispose(() => undefined)).toBe(false);
+  });
+
+  it('prevents new child scopes and resources after an active scope stops', () => {
+    const parent = effectScope();
+    const callback = vi.fn();
+    let child!: ReturnType<typeof effectScope>;
+    parent.run(() => {
+      parent.stop();
+      child = effectScope();
+      effect(callback);
+      expect(onScopeDispose(callback)).toBe(false);
+    });
+
+    expect(child.active).toBe(false);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('stops computed dependency effects owned by a scope', () => {
+    const state = ref(1);
+    const getter = vi.fn(() => state.value * 2);
+    const scope = effectScope();
+    const value = scope.run(() => computed(getter));
+    expect(value?.value).toBe(2);
+
+    scope.stop();
+    state.value = 2;
+    expect(value?.value).toBe(2);
+    expect(getter).toHaveBeenCalledOnce();
+  });
+
+  it('routes effect, scheduler, and cleanup errors without rejected flushes', async () => {
+    const errors: ReactivityErrorContext[] = [];
+    const unhandled: unknown[] = [];
+    const listener = (error: unknown) => unhandled.push(error);
+    process.on('unhandledRejection', listener);
+    const restore = setReactivityErrorHandler((context) => errors.push(context));
+    const state = reactive({ fail: false });
+    const scope = effectScope();
+
+    try {
+      scope.run(() => {
+        effect(() => {
+          if (state.fail) throw new Error('effect failed');
+        }, { flush: 'pre' });
+        onScopeDispose(() => { throw new Error('cleanup failed'); });
+      });
+      queueJob(() => { throw new Error('job failed'); });
+      state.fail = true;
+
+      await expect(nextTick()).resolves.toBeUndefined();
+      scope.stop();
+      await Promise.resolve();
+
+      expect(errors.map(({ phase }) => phase)).toEqual([
+        'effect',
+        'scheduler',
+        'cleanup',
+      ]);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', listener);
+      restore();
+    }
+  });
+
+  it('contains asynchronous effect failures inside the effect error channel', async () => {
+    const state = reactive({ fail: false });
+    const errors: ReactivityErrorContext[] = [];
+    effect(async () => {
+      const fail = state.fail;
+      await Promise.resolve();
+      if (fail) throw new Error('async effect failed');
+    }, { flush: 'pre', onError: (context) => errors.push(context) });
+    await Promise.resolve();
+
+    state.fail = true;
+    await expect(nextTick()).resolves.toBeUndefined();
+    expect(errors).toEqual([
+      expect.objectContaining({ phase: 'effect' }),
+    ]);
+  });
+
+  it('routes failures from manually invoked stopped runners', async () => {
+    const errors: ReactivityErrorContext[] = [];
+    let fail = false;
+    const runner = effect(async () => {
+      await Promise.resolve();
+      if (fail) throw new Error('stopped runner failed');
+    }, { onError: (context) => errors.push(context) });
+    await Promise.resolve();
+    stop(runner);
+    fail = true;
+
+    await expect(runner()).resolves.toBeUndefined();
+    expect(errors).toEqual([
+      expect.objectContaining({ phase: 'effect' }),
+    ]);
+
+    const syncErrors: ReactivityErrorContext[] = [];
+    let syncFail = false;
+    const syncRunner = effect(() => {
+      if (syncFail) throw new Error('sync stopped runner failed');
+      return 'ready';
+    }, { onError: (context) => syncErrors.push(context) });
+    stop(syncRunner);
+    syncFail = true;
+    expect(syncRunner()).toBe('ready');
+    expect(syncErrors).toEqual([
+      expect.objectContaining({ phase: 'effect' }),
+    ]);
+  });
+
+  it('uses a scope-local error handler before the global channel', () => {
+    const globalHandler = vi.fn();
+    const localHandler = vi.fn();
+    const restore = setReactivityErrorHandler(globalHandler);
+    const scope = effectScope({ onError: localHandler });
+
+    try {
+      scope.run(() => effect(() => { throw new Error('local'); }));
+      expect(localHandler).toHaveBeenCalledWith(expect.objectContaining({ phase: 'effect' }));
+      expect(globalHandler).not.toHaveBeenCalled();
+    } finally {
+      scope.stop();
+      restore();
+    }
+  });
+
+  it('uses reportError as the default channel when the platform provides it', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'reportError');
+    const reporter = vi.fn();
+    Object.defineProperty(globalThis, 'reportError', {
+      configurable: true,
+      value: reporter,
+    });
+    const restore = setReactivityErrorHandler(undefined);
+    try {
+      effect(() => { throw new Error('reported'); });
+      expect(reporter).toHaveBeenCalledWith(expect.objectContaining({ message: 'reported' }));
+    } finally {
+      restore();
+      if (descriptor) Object.defineProperty(globalThis, 'reportError', descriptor);
+      else Reflect.deleteProperty(globalThis, 'reportError');
+    }
+  });
+
+  it('falls back to console and contains failures from error handlers', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'reportError');
+    Reflect.deleteProperty(globalThis, 'reportError');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const restoreDefault = setReactivityErrorHandler(undefined);
+    try {
+      effect(() => { throw new Error('console fallback'); });
+      expect(consoleError).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'console fallback',
+      }));
+
+      const restoreThrowing = setReactivityErrorHandler(() => {
+        throw new Error('handler failed');
+      });
+      effect(() => { throw new Error('source failed'); });
+      expect(consoleError).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'handler failed',
+      }));
+      restoreThrowing();
+    } finally {
+      restoreDefault();
+      consoleError.mockRestore();
+      if (descriptor) Object.defineProperty(globalThis, 'reportError', descriptor);
+    }
+  });
+
+  it('contains failures thrown by the platform reportError function', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'reportError');
+    Object.defineProperty(globalThis, 'reportError', {
+      configurable: true,
+      value: () => { throw new Error('platform reporter failed'); },
+    });
+    const restore = setReactivityErrorHandler(undefined);
+    try {
+      expect(() => effect(() => { throw new Error('source'); })).not.toThrow();
+    } finally {
+      restore();
+      if (descriptor) Object.defineProperty(globalThis, 'reportError', descriptor);
+      else Reflect.deleteProperty(globalThis, 'reportError');
+    }
+  });
+
+  it('contains asynchronous rejection from a configured error handler', async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'reportError');
+    const reporter = vi.fn();
+    Object.defineProperty(globalThis, 'reportError', {
+      configurable: true,
+      value: reporter,
+    });
+    const restore = setReactivityErrorHandler(async () => {
+      throw new Error('async handler failed');
+    });
+    try {
+      effect(() => { throw new Error('source'); });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(reporter).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'async handler failed',
+      }));
+    } finally {
+      restore();
+      if (descriptor) Object.defineProperty(globalThis, 'reportError', descriptor);
+      else Reflect.deleteProperty(globalThis, 'reportError');
+    }
+  });
+});
+
+describe('scheduled watchers', () => {
+  it('deduplicates watch callbacks and runs cleanup before the next value', async () => {
+    const source = ref(0);
+    const events: string[] = [];
+    const stopWatch = watch(source, (value, oldValue, onCleanup) => {
+      events.push(`${oldValue}->${value}`);
+      onCleanup(() => events.push(`cleanup:${value}`));
+    });
+
+    source.value = 1;
+    source.value = 2;
+    await nextTick();
+    expect(events).toEqual(['0->2']);
+
+    source.value = 3;
+    await nextTick();
+    expect(events).toEqual(['0->2', 'cleanup:2', '2->3']);
+    stopWatch();
+    stopWatch();
+    expect(events).toEqual(['0->2', 'cleanup:2', '2->3', 'cleanup:3']);
+  });
+
+  it('supports immediate and deep watch sources', async () => {
+    const state = reactive({ nested: { count: 0 } });
+    const immediate = vi.fn();
+    const deep = vi.fn();
+    const stopImmediate = watch(() => state.nested.count, immediate, { immediate: true });
+    const stopDeep = watch(() => state, deep, { deep: true });
+
+    expect(immediate).toHaveBeenCalledWith(0, undefined, expect.any(Function));
+    state.nested.count = 1;
+    await nextTick();
+    expect(immediate).toHaveBeenLastCalledWith(1, 0, expect.any(Function));
+    expect(deep).toHaveBeenCalledOnce();
+    stopImmediate();
+    stopDeep();
+  });
+
+  it('deeply traverses cyclic objects, Map values, and Set values', async () => {
+    const nested = reactive({ count: 0 });
+    const state = reactive({
+      map: new Map([['nested', nested]]),
+      set: new Set<object>([nested]),
+      self: undefined as unknown,
+    });
+    state.self = state;
+    const callback = vi.fn();
+    const stopWatch = watch(() => state, callback, { deep: true });
+
+    nested.count = 1;
+    await nextTick();
+    state.set.add({ added: true });
+    await nextTick();
+    expect(callback).toHaveBeenCalledTimes(2);
+    stopWatch();
+  });
+
+  it('does not run a watch callback when its derived value is unchanged', async () => {
+    const state = reactive({ count: 0 });
+    const callback = vi.fn();
+    const stopWatch = watch(() => state.count % 2, callback);
+
+    state.count = 2;
+    await nextTick();
+    expect(callback).not.toHaveBeenCalled();
+    stopWatch();
+  });
+
+  it('stops queued watch effects and their cleanup with the owning scope', async () => {
+    const source = ref(0);
+    const events: string[] = [];
+    const scope = effectScope();
+    scope.run(() => watchEffect((onCleanup) => {
+      events.push(`run:${source.value}`);
+      onCleanup(() => events.push('cleanup'));
+    }, { flush: 'post' }));
+
+    source.value = 1;
+    scope.stop();
+    await nextTick();
+    source.value = 2;
+    await nextTick();
+    expect(events).toEqual(['run:0', 'cleanup']);
+  });
+
+  it('routes watcher callback and cleanup failures without rejecting nextTick', async () => {
+    const errors: ReactivityErrorContext[] = [];
+    const source = ref(0);
+    const stopWatch = watch(source, (value, _oldValue, onCleanup) => {
+      onCleanup(() => { throw new Error(`cleanup:${value}`); });
+      if (value === 1) throw new Error('watch failed');
+    }, { onError: (context) => errors.push(context) });
+
+    source.value = 1;
+    await expect(nextTick()).resolves.toBeUndefined();
+    source.value = 2;
+    await expect(nextTick()).resolves.toBeUndefined();
+    stopWatch();
+
+    expect(errors.map(({ phase }) => phase)).toEqual([
+      'effect',
+      'cleanup',
+      'cleanup',
+    ]);
+  });
+
+  it('awaits and contains asynchronous watcher callback failures', async () => {
+    const errors: ReactivityErrorContext[] = [];
+    const source = ref(0);
+    const stopWatch = watch(source, async () => {
+      await Promise.resolve();
+      throw new Error('async watch failed');
+    }, { onError: (context) => errors.push(context) });
+
+    source.value = 1;
+    await expect(nextTick()).resolves.toBeUndefined();
+    expect(errors).toEqual([
+      expect.objectContaining({ phase: 'effect' }),
+    ]);
+    stopWatch();
+  });
+});

--- a/vitest.reactivity.config.ts
+++ b/vitest.reactivity.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['tests-node/reactivity.spec.ts'],
+    include: ['tests-node/*.spec.ts'],
     coverage: {
       provider: 'v8',
       include: ['packages/reactivity/src/**/*.ts'],


### PR DESCRIPTION
## Summary
- add a deduplicating `pre`/`update`/`post` scheduler with deterministic owner-id ordering, phase cycling, invalidation, recursion protection, promise-returning jobs, and `nextTick`
- add synchronous nested `batch`, `untracked`, sync/pre/post effect flush modes, and asynchronous failure containment
- add attached and detached effect scopes with reverse deterministic teardown, queued-work cancellation, manual-runner disabling after scope stop, and cleanup deregistration
- add `watch` and `watchEffect` with scheduling, deep traversal, cleanup, scope ownership, and error routing
- add global, scope-local, effect-local, watcher-local, and job-local error channels without rejected scheduler flush promises
- document the scheduler, ownership, watcher, and error contracts and extend public declaration tests

## Verification
- `npm run check`
  - Core Chromium suite: 7 files, 26 tests passed
  - Core coverage: 97.07% statements, 93.42% branches, 99.13% functions, 97.94% lines
  - Reactivity Node suite: 2 files, 64 tests passed
  - Reactivity coverage: 99.06% statements, 95.28% branches, 100% functions, 99.81% lines
  - both production builds, generated declaration contract, and all 16 package contracts passed
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `git diff --check`
- independent acceptance review: no findings
- semantic review findings for batch reentrancy, watcher scope-cleanup retention, and stopped-runner error bypass were fixed with regression tests; final follow-up review reported no findings

Closes #19