### PR TITLE
Complete DOM, form, directive, and cleanup semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 - Keyed `repeat()` reconciliation with stable DOM and Custom Element identity,
   deterministic invalid-key diagnostics, renderer conformance coverage, and a
   1,000-row Chromium benchmark harness.
+- Production DOM semantics for controlled and uncontrolled forms, lifecycle
+  directives, native event options, qualified namespaces, explicit unsafe HTML
+  and URL escapes, reversible render suspension, permanent unmount, external
+  DOM recovery, and pre-upgrade property precedence.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ html`<input ...=${{
 
 Each expression must occupy a complete child or attribute value. Compose partial attribute strings before binding them.
 
+Controlled form state uses property bindings such as `.value` and `.checked`;
+uncontrolled initial/default state uses attributes such as `value` and
+`?checked`. Multi-select controls accept an array through `.value`. Native event
+options use `event(listener, options)`. Dynamic raw markup is text unless it is
+explicitly wrapped with `unsafeHTML()`, and unsafe URL protocols are blocked
+unless reviewed code opts out with `unsafeURL()`. The complete behavior,
+including directives, namespaces, file inputs, form-associated elements,
+suspension, and unmount cleanup, is defined in the
+[DOM runtime contract](docs/dom-runtime.md).
+
 ## Custom Elements
 
 `GluonElement` turns the renderer and stylesheet contract into a small reactive Custom Element base:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,11 @@ The runtime currently has three Part types:
 
 Event listeners and refs are disconnected when a binding changes or a template is replaced. Spread sub-maps remove only attributes or style properties previously owned by that Part.
 
+The production binding semantics for forms, lifecycle directives, event
+options, qualified namespaces, unsafe-content boundaries, root suspension,
+permanent unmount, and external DOM recovery are specified by the
+[DOM runtime contract](dom-runtime.md).
+
 ### List identity
 
 Ordinary arrays retain the original index-based behavior: a compatible template

--- a/docs/dom-runtime.md
+++ b/docs/dom-runtime.md
@@ -1,0 +1,166 @@
+# DOM, form, directive, and cleanup contract
+
+This document defines the browser-runtime behavior implemented by
+`@gluonjs/core`. The current conformance target is the configured Playwright
+Chromium instance. Cross-browser support is a separate release gate in issue
+#38.
+
+## Form controls
+
+Property bindings are controlled bindings. Gluon compares the requested value
+with the live DOM property on every render, so a render restores state changed
+by the user or by external code. Attribute and boolean-attribute bindings are
+uncontrolled initialization/default-state bindings: when the bound value is
+unchanged, Gluon does not reset a dirty live property.
+
+| Control | Controlled binding | Uncontrolled binding | Contract |
+| --- | --- | --- | --- |
+| Text-like `input` | `.value=${value}` | `value=${initial}` | A render restores the controlled value; a user edit survives an unchanged uncontrolled render. |
+| `textarea` | `.value=${value}` | `.defaultValue=${initial}` | Dynamic textarea child interpolation is unsupported because the HTML parser treats its contents as raw text. |
+| Checkbox | `.checked=${boolean}` | `?checked=${initial}` | Controlled state is restored; uncontrolled dirty state is preserved. |
+| Radio group | `.checked=${boolean}` on every member | `?checked=${initial}` | Native name/group exclusivity remains browser behavior. |
+| Single select | `.value=${string}` | `?selected=${initial}` on options | Controlled selection is restored; dirty uncontrolled selection is preserved. |
+| Multi-select | `.value=${readonlyValues}` | `?selected=${initial}` on options | An array selects options whose string values occur in the array. An array on a non-`multiple` select throws. |
+| File input | `.value=${''}` to clear | no value/files binding | Browsers prohibit assigning a non-empty file value; Gluon preserves that platform exception. An uncontrolled `FileList` survives an unchanged render. |
+
+Spread property keys such as `'.value'` and `'.checked'` use the same rules.
+Gluon does not synthesize `input` or `change` events when it writes a controlled
+property. Native form-control properties commit after normal attributes and
+dynamic children, so an initial controlled select can target options created by
+the same render.
+
+Form-associated Gluon elements use the platform contract directly: the class
+declares `static formAssociated = true`, acquires `ElementInternals`, and owns
+`setFormValue`, validity, reset, state-restore, disabled, focus, label, and event
+behavior. The browser suite includes a submitting, validating, resetting,
+restoring, label-aware, focusable fixture. Issue #24 owns the later typed public
+component/form authoring contract; there is no hidden-input fallback.
+
+## Directive lifecycle
+
+`directive()` accepts either the original function factory or a lifecycle
+object. A lifecycle object receives the current `PartController` and a typed
+argument tuple:
+
+```ts
+const resource = directive<[string]>({
+  mount(part, [value]) {
+    part.setValue(value);
+  },
+  update(part, [value], [previous]) {
+    part.setValue(`${previous} -> ${value}`);
+  },
+  cleanup(_part, [value]) {
+    releaseVersion(value);
+  },
+  disconnect() {
+    releaseOwner();
+  },
+});
+```
+
+The sequence is deterministic:
+
+1. `mount` runs when the lifecycle definition first owns a Part.
+2. Before a later `update`, `cleanup` runs for the previous argument tuple.
+3. `update` receives both the new and previous tuple.
+4. Replacement, temporary render suspension, and permanent unmount run
+   `cleanup` once for the active tuple and then `disconnect` once.
+5. Reconnection mounts the directive again against the retained Part.
+
+If `update` throws, the previous tuple has already been cleaned. Gluon
+disconnects that previous tuple once, deactivates the directive, and rethrows
+the update error; it does not promote the failed arguments to active state.
+
+The legacy factory form remains supported and runs its returned function on
+each application. It has no lifecycle hooks.
+
+## Event options
+
+Plain `@event=${listener}` and spread `onEvent`/`@event` values use native
+listeners without options. `event(listener, options)` forwards a boolean
+capture flag or the complete `AddEventListenerOptions` object, including
+`capture`, `once`, `passive`, and `signal`:
+
+```ts
+html`<button @click=${event(save, { once: true, signal })}>Save</button>`;
+```
+
+Gluon retains the listener and the exact options value so replacement,
+suspension, and unmount call `removeEventListener` with matching capture
+semantics. Browser behavior remains authoritative for once, passive, and abort
+signals.
+
+## Namespaces
+
+The HTML parser establishes HTML, SVG, and MathML element namespaces. Dynamic
+qualified attributes additionally use the platform namespace APIs:
+
+| Prefix | Namespace |
+| --- | --- |
+| `xlink:` | `http://www.w3.org/1999/xlink` |
+| `xml:` | `http://www.w3.org/XML/1998/namespace` |
+| `xmlns` / `xmlns:` | `http://www.w3.org/2000/xmlns/` |
+
+Removal uses the same namespace and local name. `unsafeHTML()` uses contextual
+fragment parsing, so explicit raw markup inside an SVG or MathML parent receives
+that surrounding namespace.
+
+## Dynamic content and URL safety
+
+Ordinary child strings always create text nodes. Dynamic raw markup requires
+the visibly unsafe `unsafeHTML(trustedMarkup)` API. It is also required for
+`srcdoc`. `.innerHTML`, `.outerHTML`, and `.textContent` property bindings are
+rejected because they can destroy renderer-owned marker nodes. Gluon does not
+sanitize an `unsafeHTML` value. Only reviewed, trusted input may use it.
+
+String `on*` attributes are rejected. Native listeners must use `@event` or a
+spread event key.
+
+For URL-valued attributes and their corresponding property bindings, Gluon
+normalizes ASCII whitespace/control characters for protocol inspection and
+blocks `javascript:`, `vbscript:`, and `data:`.
+The covered names are `action`, `archive`, `background`, `cite`, `codebase`,
+`data`, `formaction`, `href`, `icon`, `longdesc`, `manifest`, `ping`, `poster`,
+`profile`, `src`, `srcset`, `usemap`, and `xlink:href`. Relative URLs and other
+protocols pass through unchanged. `unsafeURL(reviewedValue)` is the explicit
+escape hatch and is accepted only by those URL-valued bindings. It performs no
+safety check. A `.data` property is treated as a URL only on `<object>`; custom
+element data properties remain ordinary structured property inputs.
+
+These checks are a narrow DOM-sink boundary, not an application content
+sanitizer, URL allowlist, navigation policy, or Content Security Policy.
+Static literal markup is author-controlled source and is not passed through the
+dynamic binding guard.
+
+## Ownership, suspension, and external DOM
+
+`render(result, container)` owns the complete contents of its container.
+`unmount(container)` permanently disconnects directive resources, listeners,
+and refs, deletes the retained root instance, and removes the owned DOM.
+
+`suspendRender(container)` is the reversible operation used by
+`GluonElement.disconnectedCallback()`. It releases active directive resources,
+listeners, and refs while retaining properties, state, bindings, and matching
+DOM nodes. Reconnection renders the current state, remounts resources, and
+reuses intact nodes. A queued element update checks connection state again
+before commit and therefore cannot render after disconnection.
+
+The renderer validates its owned root-node sequence on every render. If
+external code replaces or reorders root nodes, Gluon disconnects the stale
+bindings and remounts the root. Dynamic Part node sequences are likewise
+restored around their marker. Static descendants inside a retained compiled
+node are not diffed individually; external code must not mutate renderer-owned
+static internals and expect that mutation to be preserved.
+
+The browser retention test performs 100 render/unmount cycles, verifies every
+ref is cleared, and verifies detached nodes no longer invoke their former
+listeners.
+
+## Upgrade precedence
+
+For an undefined element upgraded later, an own JavaScript property captured by
+`GluonElement` takes precedence over the corresponding initial markup
+attribute. The upgrade-time attribute callback is ignored only for that exact
+initial attribute value. Reflection then serializes the captured property.
+Later attribute or property writes are authoritative in normal callback order.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,7 +51,8 @@ be added through a superseding RFC.
 Gluon currently provides:
 
 - cached `html` and `svg` templates with part-level DOM updates
-- child, attribute, property, boolean, event, directive, ref, and spread bindings
+- production child, attribute, property, boolean, event-option, lifecycle-directive,
+  ref, spread, form-control, namespace, and explicit unsafe-content bindings
 - nested templates, index-based array rendering, and keyed `repeat()` reconciliation
 - standalone DOM-free refs, reactive and readonly proxies, effects, and computed values
 - deterministic batching, phased scheduling, `nextTick`, effect scopes, and watchers

--- a/src/element.ts
+++ b/src/element.ts
@@ -1,4 +1,4 @@
-import { render, type TemplateResult } from './runtime.js';
+import { render, suspendRender, type TemplateResult } from './runtime.js';
 import { adoptStyles } from './styles/index.js';
 
 export type PropertyType =
@@ -45,6 +45,7 @@ export abstract class GluonElement extends HTMLElement {
   private updatePending = false;
   private connected = false;
   private reflectingAttribute?: string;
+  private readonly initialAttributePrecedence = new Map<string, string>();
   private updatePromise: Promise<void> = Promise.resolve();
 
   constructor() {
@@ -74,6 +75,7 @@ export abstract class GluonElement extends HTMLElement {
 
   disconnectedCallback(): void {
     this.connected = false;
+    suspendRender(this.renderRoot);
   }
 
   attributeChangedCallback(
@@ -87,6 +89,11 @@ export abstract class GluonElement extends HTMLElement {
     for (const [property, definition] of Object.entries(declarations)) {
       const declaration = normalizeDeclaration(definition);
       if (getAttributeName(property, declaration) !== name) continue;
+      const initialAttribute = this.initialAttributePrecedence.get(name);
+      if (initialAttribute !== undefined) {
+        this.initialAttributePrecedence.delete(name);
+        if (oldValue === null && value === initialAttribute) return;
+      }
       const converted = declaration.converter?.fromAttribute
         ? declaration.converter.fromAttribute(value, declaration.type)
         : fromAttribute(value, declaration.type);
@@ -109,6 +116,10 @@ export abstract class GluonElement extends HTMLElement {
     this.updatePromise = new Promise((resolve, reject) => {
       queueMicrotask(() => {
         this.updatePending = false;
+        if (!this.connected) {
+          resolve();
+          return;
+        }
         try {
           this.update();
           resolve();
@@ -162,7 +173,12 @@ export abstract class GluonElement extends HTMLElement {
       if (!Object.prototype.hasOwnProperty.call(this, name)) continue;
       const value = (this as unknown as Record<string, unknown>)[name];
       delete (this as unknown as Record<string, unknown>)[name];
-      this[setProperty](name, value, normalizeDeclaration(definition));
+      const declaration = normalizeDeclaration(definition);
+      const attribute = getAttributeName(name, declaration);
+      if (attribute && this.hasAttribute(attribute)) {
+        this.initialAttributePrecedence.set(attribute, this.getAttribute(attribute)!);
+      }
+      this[setProperty](name, value, declaration);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,23 @@
 export {
   TemplateResult,
   directive,
+  event,
   html,
   isTemplateResult,
   nothing,
   repeat,
   render,
+  suspendRender,
   svg,
+  unmount,
+  unsafeHTML,
+  unsafeURL,
+  type DirectiveDefinition,
   type DirectiveFactory,
+  type DirectiveLifecycle,
   type DirectiveRunner,
   type DirectiveValue,
+  type EventBinding,
   type Key,
   type KeyedItem,
   type PartController,
@@ -17,6 +25,8 @@ export {
   type RepeatResult,
   type TemplateType,
   type TemplateValue,
+  type UnsafeHtmlResult,
+  type UnsafeUrlResult,
 } from './runtime.js';
 
 export {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,9 @@
 const templateResultBrand = Symbol('gluon.template-result');
 const directiveBrand = Symbol('gluon.directive');
 const repeatResultBrand = Symbol('gluon.repeat-result');
+const eventBindingBrand = Symbol('gluon.event-binding');
+const unsafeHtmlBrand = Symbol('gluon.unsafe-html');
+const unsafeUrlBrand = Symbol('gluon.unsafe-url');
 const unsetValue = Symbol('gluon.unset');
 
 /** Explicitly renders no child content or removes an attribute value. */
@@ -12,9 +15,13 @@ export type PrimitiveValue = string | number | bigint | boolean | null | undefin
 export type TemplateValue =
   | PrimitiveValue
   | Node
+  | URL
   | TemplateResult
   | RepeatResult
   | DirectiveValue
+  | EventBinding
+  | UnsafeHtmlResult
+  | UnsafeUrlResult
   | EventListenerOrEventListenerObject
   | typeof nothing
   | Readonly<Record<string, unknown>>
@@ -108,6 +115,60 @@ export function repeat<Item>(
   });
 }
 
+export interface EventBinding {
+  readonly [eventBindingBrand]: true;
+  readonly listener: EventListenerOrEventListenerObject;
+  readonly options?: boolean | AddEventListenerOptions;
+}
+
+/** Associates native addEventListener options with an event binding. */
+export function event(
+  listener: EventListenerOrEventListenerObject,
+  options?: boolean | AddEventListenerOptions,
+): EventBinding {
+  const retainedOptions = typeof options === 'object'
+    ? Object.freeze({
+        capture: options.capture,
+        once: options.once,
+        passive: options.passive,
+        signal: options.signal,
+      })
+    : options;
+  return Object.freeze({
+    [eventBindingBrand]: true as const,
+    listener,
+    options: retainedOptions,
+  });
+}
+
+export interface UnsafeHtmlResult {
+  readonly [unsafeHtmlBrand]: true;
+  readonly markup: string;
+}
+
+/**
+ * Opts a trusted string into raw HTML parsing. Gluon performs no sanitization.
+ */
+export function unsafeHTML(markup: string): UnsafeHtmlResult {
+  return Object.freeze({
+    [unsafeHtmlBrand]: true as const,
+    markup,
+  });
+}
+
+export interface UnsafeUrlResult {
+  readonly [unsafeUrlBrand]: true;
+  readonly value: string;
+}
+
+/** Bypasses Gluon's unsafe-protocol check for one URL-valued binding. */
+export function unsafeURL(value: string | URL): UnsafeUrlResult {
+  return Object.freeze({
+    [unsafeUrlBrand]: true as const,
+    value: String(value),
+  });
+}
+
 function isRepeatResult(value: unknown): value is RepeatResult {
   return Boolean(
     value
@@ -121,7 +182,9 @@ export interface PartController {
 }
 
 interface Part extends PartController {
+  readonly commitPriority?: number;
   disconnect(): void;
+  suspend(): void;
 }
 
 export type DirectiveRunner = (part: PartController) => void;
@@ -129,17 +192,28 @@ export type DirectiveFactory<Args extends readonly unknown[] = readonly unknown[
   ...args: Args
 ) => DirectiveRunner;
 
+export interface DirectiveLifecycle<Args extends readonly unknown[] = readonly unknown[]> {
+  mount(part: PartController, args: Args): void;
+  update(part: PartController, args: Args, previousArgs: Args): void;
+  cleanup?(part: PartController, args: Args): void;
+  disconnect?(part: PartController, args: Args): void;
+}
+
+export type DirectiveDefinition<Args extends readonly unknown[] = readonly unknown[]> =
+  | DirectiveFactory<Args>
+  | DirectiveLifecycle<Args>;
+
 export interface DirectiveValue {
-  readonly [directiveBrand]: DirectiveFactory;
+  readonly [directiveBrand]: DirectiveDefinition;
   readonly args: readonly unknown[];
 }
 
 export function directive<Args extends readonly unknown[]>(
-  factory: DirectiveFactory<Args>,
+  definition: DirectiveDefinition<Args>,
 ): (...args: Args) => DirectiveValue {
-  return (...args: Args) => ({
-    [directiveBrand]: factory as DirectiveFactory,
-    args,
+  return (...args: Args) => Object.freeze({
+    [directiveBrand]: definition as DirectiveDefinition,
+    args: Object.freeze(args),
   });
 }
 
@@ -151,6 +225,17 @@ function isDirectiveValue(value: unknown): value is DirectiveValue {
   );
 }
 
+function isDirectiveLifecycle(
+  definition: DirectiveDefinition,
+): definition is DirectiveLifecycle {
+  return Boolean(
+    definition
+      && typeof definition === 'object'
+      && typeof definition.mount === 'function'
+      && typeof definition.update === 'function',
+  );
+}
+
 type PartDescriptor =
   | { readonly kind: 'node'; readonly index: number; readonly path: readonly number[] }
   | { readonly kind: 'attribute'; readonly index: number; readonly path: readonly number[]; readonly name: string }
@@ -159,6 +244,13 @@ type PartDescriptor =
 interface Binding {
   readonly index: number;
   readonly part: Part;
+  directive?: ActiveDirective;
+}
+
+interface ActiveDirective {
+  readonly definition: DirectiveLifecycle;
+  args: readonly unknown[];
+  cleaned: boolean;
 }
 
 interface CompiledTemplate {
@@ -173,10 +265,14 @@ interface ChildInstance {
   readonly nodes: readonly Node[];
 }
 
-interface KeyedChild {
-  readonly key: Key;
+interface PartChild {
   readonly marker: Comment;
   readonly part: NodePart;
+  readonly binding: Binding;
+}
+
+interface KeyedChild extends PartChild {
+  readonly key: Key;
 }
 
 class NodePart implements Part {
@@ -184,10 +280,14 @@ class NodePart implements Part {
   private textNode?: Text;
   private lastPrimitive: PrimitiveValue | typeof unsetValue = unsetValue;
   private child?: ChildInstance;
-  private arrayChildren: Array<ChildInstance | undefined> = [];
+  private arrayChildren: Array<PartChild | undefined> = [];
   private keyedChildren: KeyedChild[] = [];
+  private unsafeMarkup?: string;
 
-  constructor(private readonly marker: Comment) {}
+  constructor(
+    private readonly marker: Comment,
+    private readonly contextMarker: Comment = marker,
+  ) {}
 
   setValue(value: TemplateValue): void {
     if (isEmptyValue(value)) {
@@ -197,10 +297,21 @@ class NodePart implements Part {
     }
 
     if (isRenderablePrimitive(value) && this.textNode) {
-      if (Object.is(value, this.lastPrimitive)) return;
-      this.textNode.data = String(value);
-      this.lastPrimitive = value;
+      if (!Object.is(value, this.lastPrimitive)) {
+        this.textNode.data = String(value);
+        this.lastPrimitive = value;
+      }
+      this.replaceNodes([this.textNode]);
       return;
+    }
+
+    if (isUnsafeHtmlResult(value)) {
+      this.setUnsafeHTML(value);
+      return;
+    }
+
+    if (isUnsafeUrlResult(value) || isEventBinding(value)) {
+      throw new TypeError('URL and event binding helpers can only be used in matching attribute bindings.');
     }
 
     if (Array.isArray(value)) {
@@ -240,15 +351,25 @@ class NodePart implements Part {
     this.lastPrimitive = unsetValue;
   }
 
+  suspend(): void {
+    if (this.child) suspendBindings(this.child.bindings);
+    for (const child of this.arrayChildren) {
+      if (child) suspendBindings([child.binding]);
+    }
+    for (const child of this.keyedChildren) suspendBindings([child.binding]);
+  }
+
   private setTemplate(result: TemplateResult): void {
     this.disconnectArrayChildren();
     this.disconnectKeyedChildren();
+    this.unsafeMarkup = undefined;
     const compiled = getCompiledTemplate(result);
 
     if (this.child?.template === compiled) {
       applyBindings(this.child.bindings, result.values);
       this.textNode = undefined;
       this.lastPrimitive = unsetValue;
+      this.replaceNodes([...this.child.nodes]);
       return;
     }
 
@@ -265,40 +386,26 @@ class NodePart implements Part {
       this.child = undefined;
     }
     this.disconnectKeyedChildren();
+    this.unsafeMarkup = undefined;
 
     const flatValues = flattenValues(values);
     const nextNodes: Node[] = [];
-    const nextChildren: Array<ChildInstance | undefined> = [];
-    const reused = new Set<ChildInstance>();
+    const nextChildren: Array<PartChild | undefined> = [];
+    const reused = new Set<PartChild>();
 
     for (let index = 0; index < flatValues.length; index += 1) {
       const value = flatValues[index]!;
       if (isEmptyValue(value)) continue;
-
-      if (isTemplateResult(value)) {
-        const compiled = getCompiledTemplate(value);
-        const cached = this.arrayChildren[index];
-        const instance = cached?.template === compiled
-          ? cached
-          : createChildInstance(value, compiled);
-
-        if (instance === cached) applyBindings(instance.bindings, value.values);
-        reused.add(instance);
-        nextChildren[index] = instance;
-        nextNodes.push(...instance.nodes);
-        continue;
-      }
-
-      if (value instanceof Node) {
-        nextNodes.push(value);
-        continue;
-      }
-
-      nextNodes.push(document.createTextNode(String(value)));
+      const cached = this.arrayChildren[index];
+      const instance = cached ?? this.createPartChild(value);
+      if (cached) applyBindings([cached.binding], [value]);
+      reused.add(instance);
+      nextChildren[index] = instance;
+      nextNodes.push(instance.marker, ...instance.part.nodes);
     }
 
     for (const previous of this.arrayChildren) {
-      if (previous && !reused.has(previous)) disconnectBindings(previous.bindings);
+      if (previous && !reused.has(previous)) disconnectBindings([previous.binding]);
     }
 
     this.arrayChildren = nextChildren;
@@ -313,6 +420,7 @@ class NodePart implements Part {
       this.child = undefined;
     }
     this.disconnectArrayChildren();
+    this.unsafeMarkup = undefined;
 
     const previousByKey = new Map(
       this.keyedChildren.map((child) => [child.key, child] as const),
@@ -323,7 +431,7 @@ class NodePart implements Part {
 
     for (const [key, removed] of previousByKey) {
       if (!nextKeys.has(key)) {
-        removed.part.disconnect();
+        disconnectBindings([removed.binding]);
         previousByKey.delete(key);
       }
     }
@@ -334,7 +442,7 @@ class NodePart implements Part {
 
       if (previous) {
         previousByKey.delete(item.key);
-        child.part.setValue(item.value);
+        applyBindings([child.binding], [item.value]);
       }
 
       nextChildren.push(child);
@@ -348,12 +456,30 @@ class NodePart implements Part {
   }
 
   private createKeyedChild(item: KeyedItem): KeyedChild {
+    return { key: item.key, ...this.createPartChild(item.value, 'gluon:key') };
+  }
+
+  private createPartChild(value: TemplateValue, markerData = 'gluon:item'): PartChild {
     const fragment = document.createDocumentFragment();
-    const marker = document.createComment('gluon:key');
+    const marker = document.createComment(markerData);
     fragment.append(marker);
-    const part = new NodePart(marker);
-    part.setValue(item.value);
-    return { key: item.key, marker, part };
+    const part = new NodePart(marker, this.contextMarker);
+    const binding: Binding = { index: 0, part };
+    applyBindings([binding], [value]);
+    return { marker, part, binding };
+  }
+
+  private setUnsafeHTML(result: UnsafeHtmlResult): void {
+    if (this.unsafeMarkup === result.markup) {
+      this.replaceNodes([...this.nodes]);
+      return;
+    }
+
+    this.resetChildren();
+    const fragment = createContextualFragment(this.contextMarker, result.markup);
+    const nodes = [...fragment.childNodes];
+    this.unsafeMarkup = result.markup;
+    this.replaceNodes(nodes);
   }
 
   private replaceNodes(nextNodes: Node[]): void {
@@ -366,6 +492,7 @@ class NodePart implements Part {
     if (
       nextNodes.length === this.nodes.length
       && nextNodes.every((node, index) => node === this.nodes[index])
+      && nodesAreInPlace(this.marker, nextNodes)
     ) {
       return;
     }
@@ -395,76 +522,106 @@ class NodePart implements Part {
     }
     this.disconnectArrayChildren();
     this.disconnectKeyedChildren();
+    this.unsafeMarkup = undefined;
     this.textNode = undefined;
     this.lastPrimitive = unsetValue;
   }
 
   private disconnectArrayChildren(): void {
     for (const child of this.arrayChildren) {
-      if (child) disconnectBindings(child.bindings);
+      if (child) disconnectBindings([child.binding]);
     }
     this.arrayChildren = [];
   }
 
   private disconnectKeyedChildren(): void {
-    for (const child of this.keyedChildren) child.part.disconnect();
+    for (const child of this.keyedChildren) disconnectBindings([child.binding]);
     this.keyedChildren = [];
   }
 }
 
 class AttributePart implements Part {
   private lastValue: unknown = unsetValue;
-  private listener?: EventListenerOrEventListenerObject;
+  private event?: ResolvedEvent;
 
   constructor(
     private readonly element: Element,
     private readonly name: string,
   ) {}
 
+  get commitPriority(): number {
+    return this.name.startsWith('.') && isNativeFormControl(this.element) ? 1 : 0;
+  }
+
   setValue(value: TemplateValue): void {
-    if (Object.is(value, this.lastValue)) return;
+    if (this.name.startsWith('.')) {
+      setElementProperty(this.element, this.name.slice(1), value);
+      this.lastValue = value;
+      return;
+    }
 
     if (this.name.startsWith('@')) {
+      if (Object.is(value, this.lastValue)) return;
       this.setEvent(value);
       this.lastValue = value;
       return;
     }
 
-    this.lastValue = value;
-
-    if (this.name.startsWith('.')) {
-      (this.element as unknown as Record<string, unknown>)[this.name.slice(1)] = value;
-      return;
-    }
-
     if (this.name.startsWith('?')) {
       const attribute = this.name.slice(1);
-      if (value) this.element.setAttribute(attribute, '');
-      else this.element.removeAttribute(attribute);
+      const enabled = !isEmptyValue(value) && Boolean(value);
+      if (enabled !== this.element.hasAttribute(attribute)) {
+        if (enabled) this.element.setAttribute(attribute, '');
+        else this.element.removeAttribute(attribute);
+      }
+      this.lastValue = value;
       return;
     }
 
     if (isEmptyValue(value)) {
-      this.element.removeAttribute(this.name);
+      if (getOwnedAttribute(this.element, this.name) !== null) {
+        removeOwnedAttribute(this.element, this.name);
+      }
     } else {
-      this.element.setAttribute(this.name, String(value));
+      const serialized = serializeAttributeValue(this.name, value);
+      if (getOwnedAttribute(this.element, this.name) !== serialized) {
+        setOwnedAttribute(this.element, this.name, serialized);
+      }
     }
+    this.lastValue = value;
   }
 
   disconnect(): void {
-    if (this.listener && this.name.startsWith('@')) {
-      this.element.removeEventListener(this.name.slice(1), this.listener);
-    }
-    this.listener = undefined;
+    this.suspend();
+    this.lastValue = unsetValue;
+  }
+
+  suspend(): void {
+    if (!this.event || !this.name.startsWith('@')) return;
+    this.element.removeEventListener(
+      this.name.slice(1),
+      this.event.listener,
+      this.event.options,
+    );
+    this.event = undefined;
     this.lastValue = unsetValue;
   }
 
   private setEvent(value: TemplateValue): void {
     const eventName = this.name.slice(1);
-    if (this.listener) this.element.removeEventListener(eventName, this.listener);
-    this.listener = isEventListener(value) ? value : undefined;
-    if (this.listener) this.element.addEventListener(eventName, this.listener);
+    if (this.event) {
+      this.element.removeEventListener(eventName, this.event.listener, this.event.options);
+    }
+    this.event = resolveEvent(value);
+    if (this.event) {
+      this.element.addEventListener(eventName, this.event.listener, this.event.options);
+    }
   }
+}
+
+interface ResolvedEvent {
+  readonly listener: EventListenerOrEventListenerObject;
+  readonly options?: boolean | AddEventListenerOptions;
 }
 
 type RefTarget =
@@ -473,7 +630,7 @@ type RefTarget =
 
 class SpreadPart implements Part {
   private readonly keys = new Set<string>();
-  private readonly events = new Map<string, { eventName: string; listener: EventListenerOrEventListenerObject }>();
+  private readonly events = new Map<string, ResolvedEvent & { readonly eventName: string }>();
   private readonly dataAttributes = new Set<string>();
   private readonly ariaAttributes = new Set<string>();
   private readonly styleProperties = new Set<string>();
@@ -481,6 +638,10 @@ class SpreadPart implements Part {
   private ref?: RefTarget;
 
   constructor(private readonly element: Element) {}
+
+  get commitPriority(): number {
+    return isNativeFormControl(this.element) ? 1 : 0;
+  }
 
   setValue(value: TemplateValue): void {
     const props = isObjectRecord(value) ? value : undefined;
@@ -505,6 +666,14 @@ class SpreadPart implements Part {
     this.keys.clear();
   }
 
+  suspend(): void {
+    for (const { eventName, listener, options } of this.events.values()) {
+      this.element.removeEventListener(eventName, listener, options);
+    }
+    this.events.clear();
+    this.setRef(undefined);
+  }
+
   private applyKey(key: string, value: unknown): void {
     if (key === 'ref') {
       this.setRef(isRefTarget(value) ? value : undefined);
@@ -512,18 +681,18 @@ class SpreadPart implements Part {
     }
 
     if (key.startsWith('@') || /^on[A-Z]|^on[a-z]/.test(key)) {
-      this.setEvent(key, isEventListener(value) ? value : undefined);
+      this.setEvent(key, resolveEvent(value));
       return;
     }
 
     if (key.startsWith('.') && key.length > 1) {
-      (this.element as unknown as Record<string, unknown>)[key.slice(1)] = value;
+      setElementProperty(this.element, key.slice(1), value);
       return;
     }
 
     if (key.startsWith('?') && key.length > 1) {
       const attribute = key.slice(1);
-      if (value) this.element.setAttribute(attribute, '');
+      if (!isEmptyValue(value) && value) this.element.setAttribute(attribute, '');
       else this.element.removeAttribute(attribute);
       return;
     }
@@ -551,9 +720,9 @@ class SpreadPart implements Part {
     }
 
     if (value == null || value === false || value === nothing) {
-      this.element.removeAttribute(key);
+      removeOwnedAttribute(this.element, key);
     } else {
-      this.element.setAttribute(key, String(value));
+      setOwnedAttribute(this.element, key, serializeAttributeValue(key, value));
     }
   }
 
@@ -569,7 +738,7 @@ class SpreadPart implements Part {
     }
 
     if (key.startsWith('.') && key.length > 1) {
-      (this.element as unknown as Record<string, unknown>)[key.slice(1)] = undefined;
+      setElementProperty(this.element, key.slice(1), undefined);
       return;
     }
 
@@ -598,24 +767,29 @@ class SpreadPart implements Part {
       return;
     }
 
-    this.element.removeAttribute(key);
+    removeOwnedAttribute(this.element, key);
   }
 
   private setEvent(
     key: string,
-    listener: EventListenerOrEventListenerObject | undefined,
+    event: ResolvedEvent | undefined,
   ): void {
     const eventName = key.startsWith('@')
       ? key.slice(1)
       : key.slice(2).toLowerCase();
     const previous = this.events.get(key);
 
-    if (previous?.listener === listener) return;
-    if (previous) this.element.removeEventListener(previous.eventName, previous.listener);
+    if (
+      previous?.listener === event?.listener
+      && previous?.options === event?.options
+    ) return;
+    if (previous) {
+      this.element.removeEventListener(previous.eventName, previous.listener, previous.options);
+    }
 
-    if (listener) {
-      this.element.addEventListener(eventName, listener);
-      this.events.set(key, { eventName, listener });
+    if (event) {
+      this.element.addEventListener(eventName, event.listener, event.options);
+      this.events.set(key, { eventName, ...event });
     } else {
       this.events.delete(key);
     }
@@ -711,6 +885,8 @@ class SpreadPart implements Part {
 interface RootInstance {
   readonly template: CompiledTemplate;
   readonly bindings: readonly Binding[];
+  readonly nodes: readonly Node[];
+  suspended: boolean;
 }
 
 const templateCache = new WeakMap<TemplateStringsArray, CompiledTemplate>();
@@ -728,18 +904,54 @@ export function render(
   const compiled = getCompiledTemplate(result);
   const current = containerInstances.get(container);
 
-  if (current?.template === compiled) {
+  if (
+    current?.template === compiled
+    && rootNodesAreInPlace(container, current.nodes)
+  ) {
     applyBindings(current.bindings, result.values);
+    current.suspended = false;
     return;
   }
 
-  if (current) disconnectBindings(current.bindings);
+  if (current) {
+    containerInstances.delete(container);
+    disconnectBindings(current.bindings);
+  }
 
   const fragment = compiled.element.content.cloneNode(true) as DocumentFragment;
   const bindings = instantiateBindings(fragment, compiled.descriptors);
   applyBindings(bindings, result.values);
+  const nodes = [...fragment.childNodes];
   container.replaceChildren(fragment);
-  containerInstances.set(container, { template: compiled, bindings });
+  containerInstances.set(container, {
+    template: compiled,
+    bindings,
+    nodes,
+    suspended: false,
+  });
+}
+
+/** Temporarily releases active listeners, refs, and directive resources. */
+export function suspendRender(container: Element | DocumentFragment | null): void {
+  if (!container) return;
+  const current = containerInstances.get(container);
+  if (!current || current.suspended) return;
+  current.suspended = true;
+  suspendBindings(current.bindings);
+}
+
+/** Permanently releases a render root and removes its renderer-owned DOM. */
+export function unmount(container: Element | DocumentFragment | null): void {
+  if (!container) return;
+  const current = containerInstances.get(container);
+  try {
+    if (current) {
+      containerInstances.delete(container);
+      disconnectBindings(current.bindings);
+    }
+  } finally {
+    container.replaceChildren();
+  }
 }
 
 function getCompiledTemplate(result: TemplateResult): CompiledTemplate {
@@ -870,19 +1082,142 @@ function applyBindings(
   bindings: readonly Binding[],
   values: readonly TemplateValue[],
 ): void {
-  for (const binding of bindings) {
-    const value = values[binding.index] ?? nothing;
-    if (isDirectiveValue(value)) {
-      const runner = value[directiveBrand](...value.args);
-      runner(binding.part);
-    } else {
-      binding.part.setValue(value);
+  for (const priority of [0, 1]) {
+    for (const binding of bindings) {
+      if ((binding.part.commitPriority ?? 0) !== priority) continue;
+      const value = binding.index < values.length
+        ? values[binding.index]!
+        : nothing;
+      if (isDirectiveValue(value)) {
+        applyDirective(binding, value);
+      } else {
+        deactivateDirective(binding);
+        binding.part.setValue(value);
+      }
     }
   }
 }
 
 function disconnectBindings(bindings: readonly Binding[]): void {
-  for (const binding of bindings) binding.part.disconnect();
+  runBindingCleanup(bindings, (binding) => {
+    let error: unknown;
+    try {
+      deactivateDirective(binding);
+    } catch (cause) {
+      error = cause;
+    }
+    try {
+      binding.part.disconnect();
+    } catch (cause) {
+      error ??= cause;
+    }
+    if (error) throw error;
+  });
+}
+
+function suspendBindings(bindings: readonly Binding[]): void {
+  runBindingCleanup(bindings, (binding) => {
+    let error: unknown;
+    try {
+      deactivateDirective(binding);
+    } catch (cause) {
+      error = cause;
+    }
+    try {
+      binding.part.suspend();
+    } catch (cause) {
+      error ??= cause;
+    }
+    if (error) throw error;
+  });
+}
+
+function applyDirective(binding: Binding, value: DirectiveValue): void {
+  const definition = value[directiveBrand];
+
+  if (!isDirectiveLifecycle(definition)) {
+    deactivateDirective(binding);
+    definition(...value.args)(binding.part);
+    return;
+  }
+
+  const current = binding.directive;
+  if (current?.definition === definition) {
+    cleanupDirective(current, binding.part);
+    const previousArgs = current.args;
+    try {
+      definition.update(binding.part, value.args, previousArgs);
+    } catch (error) {
+      binding.directive = undefined;
+      try {
+        definition.disconnect?.(binding.part, previousArgs);
+      } catch {
+        // Preserve the update failure while still attempting lifecycle disconnection.
+      }
+      throw error;
+    }
+    current.args = value.args;
+    current.cleaned = false;
+    return;
+  }
+
+  deactivateDirective(binding);
+  const active: ActiveDirective = {
+    definition,
+    args: value.args,
+    cleaned: false,
+  };
+  binding.directive = active;
+  try {
+    definition.mount(binding.part, value.args);
+  } catch (error) {
+    try {
+      deactivateDirective(binding);
+    } catch {
+      // Preserve the mount failure while still attempting lifecycle cleanup.
+    }
+    throw error;
+  }
+}
+
+function deactivateDirective(binding: Binding): void {
+  const active = binding.directive;
+  if (!active) return;
+  binding.directive = undefined;
+
+  let error: unknown;
+  try {
+    cleanupDirective(active, binding.part);
+  } catch (cause) {
+    error = cause;
+  }
+  try {
+    active.definition.disconnect?.(binding.part, active.args);
+  } catch (cause) {
+    error ??= cause;
+  }
+  if (error) throw error;
+}
+
+function cleanupDirective(active: ActiveDirective, part: PartController): void {
+  if (active.cleaned) return;
+  active.cleaned = true;
+  active.definition.cleanup?.(part, active.args);
+}
+
+function runBindingCleanup(
+  bindings: readonly Binding[],
+  cleanup: (binding: Binding) => void,
+): void {
+  let error: unknown;
+  for (const binding of bindings) {
+    try {
+      cleanup(binding);
+    } catch (cause) {
+      error ??= cause;
+    }
+  }
+  if (error) throw error;
 }
 
 function pathFromRoot(root: Node, descendant: Node): number[] {
@@ -955,6 +1290,40 @@ function isRenderablePrimitive(value: unknown): value is string | number | bigin
     || value === true;
 }
 
+function isEventBinding(value: unknown): value is EventBinding {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && eventBindingBrand in value,
+  );
+}
+
+function resolveEvent(value: unknown): ResolvedEvent | undefined {
+  if (isEventBinding(value)) {
+    return {
+      listener: value.listener,
+      options: value.options,
+    };
+  }
+  return isEventListener(value) ? { listener: value } : undefined;
+}
+
+function isUnsafeHtmlResult(value: unknown): value is UnsafeHtmlResult {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && unsafeHtmlBrand in value,
+  );
+}
+
+function isUnsafeUrlResult(value: unknown): value is UnsafeUrlResult {
+  return Boolean(
+    value
+      && typeof value === 'object'
+      && unsafeUrlBrand in value,
+  );
+}
+
 function isKey(value: unknown): value is Key {
   return typeof value === 'string'
     || typeof value === 'number'
@@ -967,6 +1336,187 @@ function formatKey(key: Key): string {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function isNativeFormControl(element: Element): boolean {
+  return element instanceof HTMLInputElement
+    || element instanceof HTMLTextAreaElement
+    || element instanceof HTMLSelectElement
+    || element instanceof HTMLOptionElement
+    || element instanceof HTMLButtonElement;
+}
+
+const attributeNamespaces = new Map<string, string>([
+  ['xlink', 'http://www.w3.org/1999/xlink'],
+  ['xml', 'http://www.w3.org/XML/1998/namespace'],
+  ['xmlns', 'http://www.w3.org/2000/xmlns/'],
+]);
+
+const urlAttributes = new Set([
+  'action',
+  'archive',
+  'background',
+  'cite',
+  'codebase',
+  'data',
+  'formaction',
+  'href',
+  'icon',
+  'longdesc',
+  'manifest',
+  'ping',
+  'poster',
+  'profile',
+  'src',
+  'srcset',
+  'usemap',
+  'xlink:href',
+]);
+
+function setElementProperty(element: Element, property: string, value: unknown): void {
+  if (property === 'innerHTML' || property === 'outerHTML' || property === 'textContent') {
+    throw new TypeError(`.${property} is not supported because it replaces renderer-owned DOM.`);
+  }
+
+  let nextValue = value;
+  if (property === 'srcdoc') {
+    if (!isUnsafeHtmlResult(value)) {
+      throw new TypeError(`.${property} requires an explicit unsafeHTML() value.`);
+    }
+    nextValue = value.markup;
+  }
+
+  const urlProperty = property.toLowerCase();
+  if (
+    urlAttributes.has(urlProperty)
+    && (urlProperty !== 'data' || element instanceof HTMLObjectElement)
+  ) {
+    nextValue = serializeAttributeValue(urlProperty, value);
+  }
+
+  if (element instanceof HTMLSelectElement && property === 'value' && Array.isArray(nextValue)) {
+    if (!element.multiple) {
+      throw new TypeError('An array .value binding requires a <select multiple> element.');
+    }
+    const selectedValues = new Set(nextValue.map((item) => String(item)));
+    for (const option of element.options) {
+      option.selected = selectedValues.has(option.value);
+    }
+    return;
+  }
+
+  const target = element as unknown as Record<string, unknown>;
+  if (!Object.is(target[property], nextValue)) target[property] = nextValue;
+}
+
+function serializeAttributeValue(name: string, value: unknown): string {
+  const normalizedName = name.toLowerCase();
+
+  if (normalizedName === 'srcdoc') {
+    if (!isUnsafeHtmlResult(value)) {
+      throw new TypeError('The srcdoc attribute requires an explicit unsafeHTML() value.');
+    }
+    return value.markup;
+  }
+
+  if (isUnsafeHtmlResult(value)) {
+    throw new TypeError('unsafeHTML() can only be used in child content or srcdoc.');
+  }
+
+  if (isUnsafeUrlResult(value)) {
+    if (!urlAttributes.has(normalizedName)) {
+      throw new TypeError('unsafeURL() can only be used with a URL-valued attribute.');
+    }
+    return value.value;
+  }
+
+  const serialized = String(value);
+  if (urlAttributes.has(normalizedName)) assertSafeUrl(normalizedName, serialized);
+  return serialized;
+}
+
+function assertSafeUrl(name: string, value: string): void {
+  const candidates = name === 'srcset'
+    ? value.split(',')
+    : name === 'ping'
+      ? value.split(/\s+/)
+      : [value];
+
+  for (const candidate of candidates) {
+    const normalized = candidate
+      .trimStart()
+      .replace(/[\u0000-\u0020\u007f-\u009f]+/g, '')
+      .toLowerCase();
+    if (/^(?:javascript|vbscript|data):/.test(normalized)) {
+      throw new TypeError(
+        `Blocked unsafe URL protocol in ${name}; use unsafeURL() only for reviewed trusted input.`,
+      );
+    }
+  }
+}
+
+function setOwnedAttribute(element: Element, name: string, value: string): void {
+  if (/^on/i.test(name)) {
+    throw new TypeError('String event-handler attributes are not supported; use an event binding.');
+  }
+  const namespace = getAttributeNamespace(name);
+  if (namespace) element.setAttributeNS(namespace.uri, name, value);
+  else element.setAttribute(name, value);
+}
+
+function removeOwnedAttribute(element: Element, name: string): void {
+  const namespace = getAttributeNamespace(name);
+  if (namespace) element.removeAttributeNS(namespace.uri, namespace.localName);
+  else element.removeAttribute(name);
+}
+
+function getOwnedAttribute(element: Element, name: string): string | null {
+  const namespace = getAttributeNamespace(name);
+  return namespace
+    ? element.getAttributeNS(namespace.uri, namespace.localName)
+    : element.getAttribute(name);
+}
+
+function getAttributeNamespace(
+  name: string,
+): { readonly uri: string; readonly localName: string } | undefined {
+  const separator = name.indexOf(':');
+  if (separator < 0 && name !== 'xmlns') return undefined;
+  const prefix = (separator < 0 ? name : name.slice(0, separator)).toLowerCase();
+  const uri = attributeNamespaces.get(prefix);
+  if (!uri) return undefined;
+  return {
+    uri,
+    localName: separator < 0 ? name : name.slice(separator + 1),
+  };
+}
+
+function createContextualFragment(marker: Comment, markup: string): DocumentFragment {
+  if (marker.parentNode) {
+    const range = document.createRange();
+    range.selectNode(marker);
+    return range.createContextualFragment(markup);
+  }
+  const template = document.createElement('template');
+  template.innerHTML = markup;
+  return template.content;
+}
+
+function nodesAreInPlace(marker: Comment, nodes: readonly Node[]): boolean {
+  let cursor = marker.nextSibling;
+  for (const node of nodes) {
+    if (node !== cursor) return false;
+    cursor = cursor.nextSibling;
+  }
+  return true;
+}
+
+function rootNodesAreInPlace(
+  container: Element | DocumentFragment,
+  nodes: readonly Node[],
+): boolean {
+  return container.childNodes.length === nodes.length
+    && nodes.every((node, index) => container.childNodes.item(index) === node);
 }
 
 function isEventListener(value: unknown): value is EventListenerOrEventListenerObject {

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -1,6 +1,14 @@
 import {
+  directive,
+  event,
   html,
   repeat,
+  suspendRender,
+  unmount,
+  unsafeHTML,
+  unsafeURL,
+  type DirectiveLifecycle,
+  type EventBinding,
   type Key,
   type RepeatResult,
   type TemplateValue,
@@ -20,8 +28,30 @@ const keyed: RepeatResult = repeat(
 
 html`<section>${keyed}</section>`;
 
+const lifecycleDefinition: DirectiveLifecycle<[string]> = {
+  mount(part, [value]) {
+    part.setValue(value);
+  },
+  update(part, [value]) {
+    part.setValue(value);
+  },
+};
+const lifecycle = directive(lifecycleDefinition);
+const click: EventBinding = event(() => undefined, { capture: true, once: true });
+html`<button @click=${click}>${lifecycle('ready')}</button>`;
+html`<div>${unsafeHTML('<strong>trusted</strong>')}</div>`;
+html`<a href=${unsafeURL('data:text/plain,reviewed')}>Reviewed</a>`;
+suspendRender(null);
+unmount(null);
+
 // @ts-expect-error keys cannot be null
 repeat(rows, () => null, (row) => row.label);
 
 // @ts-expect-error item renderers must return a TemplateValue
 repeat(rows, (row) => row.id, () => new Date());
+
+// @ts-expect-error event options follow AddEventListenerOptions
+event(() => undefined, { capture: 'yes' });
+
+// @ts-expect-error unsafe URLs accept strings or URL objects
+unsafeURL(42);

--- a/tests/dom-runtime-contract.spec.ts
+++ b/tests/dom-runtime-contract.spec.ts
@@ -1,0 +1,586 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GluonElement,
+  defineElement,
+  directive,
+  event,
+  html,
+  nothing,
+  repeat,
+  render,
+  suspendRender,
+  svg,
+  unmount,
+  unsafeHTML,
+  unsafeURL,
+} from '../src/index.js';
+
+let lifecycleElementSequence = 0;
+
+describe('DOM runtime contract', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('runs lifecycle directives through mount, update, cleanup, and disconnect', () => {
+    const root = document.createElement('div');
+    const calls: string[] = [];
+    const lifecycle = directive<[string]>({
+      mount(part, [value]) {
+        calls.push(`mount:${value}`);
+        part.setValue(value);
+      },
+      update(part, [value], [previous]) {
+        calls.push(`update:${previous}->${value}`);
+        part.setValue(value);
+      },
+      cleanup(_part, [value]) {
+        calls.push(`cleanup:${value}`);
+      },
+      disconnect(_part, [value]) {
+        calls.push(`disconnect:${value}`);
+      },
+    });
+    const view = (value: string | null) => html`<p>${value === null ? 'plain' : lifecycle(value)}</p>`;
+
+    render(view('first'), root);
+    render(view('second'), root);
+    render(view(null), root);
+    render(view('third'), root);
+    unmount(root);
+
+    expect(calls).toEqual([
+      'mount:first',
+      'cleanup:first',
+      'update:first->second',
+      'cleanup:second',
+      'disconnect:second',
+      'mount:third',
+      'cleanup:third',
+      'disconnect:third',
+    ]);
+    expect(root.childNodes).toHaveLength(0);
+  });
+
+  it('disconnects a lifecycle directive on suspension and mounts it on resume', () => {
+    const root = document.createElement('div');
+    const calls: string[] = [];
+    const lifecycle = directive<[string]>({
+      mount(part, [value]) {
+        calls.push(`mount:${value}`);
+        part.setValue(value);
+      },
+      update(part, [value]) {
+        calls.push(`update:${value}`);
+        part.setValue(value);
+      },
+      cleanup(_part, [value]) {
+        calls.push(`cleanup:${value}`);
+      },
+      disconnect(_part, [value]) {
+        calls.push(`disconnect:${value}`);
+      },
+    });
+    const view = () => html`<p>${lifecycle('retained')}</p>`;
+
+    render(view(), root);
+    const paragraph = root.querySelector('p');
+    suspendRender(root);
+    render(view(), root);
+
+    expect(root.querySelector('p')).toBe(paragraph);
+    expect(calls).toEqual([
+      'mount:retained',
+      'cleanup:retained',
+      'disconnect:retained',
+      'mount:retained',
+    ]);
+  });
+
+  it('disconnects a failed directive update with the last active arguments', () => {
+    const root = document.createElement('div');
+    const calls: string[] = [];
+    const lifecycle = directive<[string]>({
+      mount(part, [value]) {
+        calls.push(`mount:${value}`);
+        part.setValue(value);
+      },
+      update(_part, [value], [previous]) {
+        calls.push(`update:${previous}->${value}`);
+        throw new Error('update failed');
+      },
+      cleanup(_part, [value]) {
+        calls.push(`cleanup:${value}`);
+      },
+      disconnect(_part, [value]) {
+        calls.push(`disconnect:${value}`);
+      },
+    });
+    const view = (value: string) => html`<p>${lifecycle(value)}</p>`;
+
+    render(view('active'), root);
+    expect(() => render(view('failed'), root)).toThrow('update failed');
+    unmount(root);
+
+    expect(calls).toEqual([
+      'mount:active',
+      'cleanup:active',
+      'update:active->failed',
+      'disconnect:active',
+    ]);
+  });
+
+  it('supports lifecycle directives and raw markup inside array and keyed items', () => {
+    const root = document.createElement('div');
+    const calls: string[] = [];
+    const lifecycle = directive<[string]>({
+      mount(part, [value]) {
+        calls.push(`mount:${value}`);
+        part.setValue(value);
+      },
+      update(part, [value], [previous]) {
+        calls.push(`update:${previous}->${value}`);
+        part.setValue(value);
+      },
+      cleanup(_part, [value]) {
+        calls.push(`cleanup:${value}`);
+      },
+      disconnect(_part, [value]) {
+        calls.push(`disconnect:${value}`);
+      },
+    });
+    const arrayView = (value: string, visible: boolean) => html`
+      <div>${visible ? [lifecycle(value), unsafeHTML('<b>raw</b>')] : []}</div>
+    `;
+
+    render(arrayView('array-a', true), root);
+    const raw = root.querySelector('b');
+    render(arrayView('array-b', true), root);
+    expect(root.querySelector('b')).toBe(raw);
+    render(arrayView('array-b', false), root);
+
+    const keyedView = (value: string, visible: boolean) => html`
+      <div>${repeat(
+        visible ? [{ id: 'stable', value }] : [],
+        (item) => item.id,
+        (item) => lifecycle(item.value),
+      )}</div>
+    `;
+    render(keyedView('keyed-a', true), root);
+    render(keyedView('keyed-b', true), root);
+    render(keyedView('keyed-b', false), root);
+
+    expect(calls).toEqual([
+      'mount:array-a',
+      'cleanup:array-a',
+      'update:array-a->array-b',
+      'cleanup:array-b',
+      'disconnect:array-b',
+      'mount:keyed-a',
+      'cleanup:keyed-a',
+      'update:keyed-a->keyed-b',
+      'cleanup:keyed-b',
+      'disconnect:keyed-b',
+    ]);
+  });
+
+  it('continues directive cleanup and clears DOM when one cleanup hook throws', () => {
+    const root = document.createElement('div');
+    const calls: string[] = [];
+    const failing = directive<[]>({
+      mount(part) {
+        part.setValue('failing');
+      },
+      update() {},
+      cleanup() {
+        calls.push('cleanup:failing');
+        throw new Error('cleanup failed');
+      },
+      disconnect() {
+        calls.push('disconnect:failing');
+      },
+    });
+    const surviving = directive<[]>({
+      mount(part) {
+        part.setValue('surviving');
+      },
+      update() {},
+      cleanup() {
+        calls.push('cleanup:surviving');
+      },
+      disconnect() {
+        calls.push('disconnect:surviving');
+      },
+    });
+
+    render(html`<p>${failing()}</p><p>${surviving()}</p>`, root);
+
+    expect(() => unmount(root)).toThrow('cleanup failed');
+    expect(calls).toEqual([
+      'cleanup:failing',
+      'disconnect:failing',
+      'cleanup:surviving',
+      'disconnect:surviving',
+    ]);
+    expect(root.childNodes).toHaveLength(0);
+  });
+
+  it('supports capture, once, passive, signal, and spread event options', () => {
+    const root = document.createElement('div');
+    const order: string[] = [];
+    const abortController = new AbortController();
+    const aborted = vi.fn();
+    const spreadOnce = vi.fn();
+    const passive = vi.fn((passiveEvent: Event) => passiveEvent.preventDefault());
+
+    render(html`
+      <div @click=${event(() => order.push('capture'), true)}>
+        <button id="once" @click=${event(() => order.push('once'), { once: true })}>Once</button>
+      </div>
+      <button id="aborted" @click=${event(aborted, { signal: abortController.signal })}>Abort</button>
+      <button id="spread" ...=${{ onClick: event(spreadOnce, { once: true }) }}>Spread</button>
+      <button id="passive" @wheel=${event(passive, { passive: true })}>Passive</button>
+    `, root);
+
+    const once = root.querySelector('#once') as HTMLButtonElement;
+    once.click();
+    once.click();
+    expect(order).toEqual(['capture', 'once', 'capture']);
+
+    abortController.abort();
+    (root.querySelector('#aborted') as HTMLButtonElement).click();
+    expect(aborted).not.toHaveBeenCalled();
+
+    const spread = root.querySelector('#spread') as HTMLButtonElement;
+    spread.click();
+    spread.click();
+    expect(spreadOnce).toHaveBeenCalledOnce();
+
+    const wheel = new WheelEvent('wheel', { cancelable: true });
+    (root.querySelector('#passive') as HTMLButtonElement).dispatchEvent(wheel);
+    expect(passive).toHaveBeenCalledOnce();
+    expect(wheel.defaultPrevented).toBe(false);
+  });
+
+  it('sets dynamic SVG/XML namespaces and preserves MathML namespaces', () => {
+    const root = document.createElement('div');
+    const graphic = (href: string | null, language: string | null) => svg`
+      <svg>
+        <use xlink:href=${href} xml:lang=${language}></use>
+      </svg>
+    `;
+
+    render(graphic('#shape', 'en'), root);
+    const use = root.querySelector('use') as SVGUseElement;
+    expect(use.getAttributeNS('http://www.w3.org/1999/xlink', 'href')).toBe('#shape');
+    expect(use.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBe('en');
+    render(graphic(null, null), root);
+    expect(use.hasAttributeNS('http://www.w3.org/1999/xlink', 'href')).toBe(false);
+    expect(use.hasAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')).toBe(false);
+
+    render(svg`<svg xmlns=${'http://www.w3.org/2000/svg'}><g custom:value=${'plain'}></g></svg>`, root);
+    const svgRoot = root.querySelector('svg') as SVGSVGElement;
+    expect(svgRoot.getAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns')).toBe(
+      'http://www.w3.org/2000/svg',
+    );
+    expect(root.querySelector('g')?.getAttribute('custom:value')).toBe('plain');
+
+    render(html`<math><mi data-value=${'x'}>x</mi></math>`, root);
+    expect(root.querySelector('math')?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+    expect(root.querySelector('mi')?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+  });
+
+  it('keeps dynamic strings inert and requires explicit raw HTML and URL escapes', () => {
+    const root = document.createElement('div');
+    const content = (value: string | ReturnType<typeof unsafeHTML>) => html`<section>${value}</section>`;
+
+    render(content('<strong id="inert">text</strong>'), root);
+    expect(root.querySelector('#inert')).toBeNull();
+    expect(root.querySelector('section')?.textContent).toBe('<strong id="inert">text</strong>');
+
+    const trusted = unsafeHTML('<strong id="trusted">trusted</strong>');
+    render(content(trusted), root);
+    const strong = root.querySelector('#trusted');
+    render(content(trusted), root);
+    expect(root.querySelector('#trusted')).toBe(strong);
+
+    const propertyRoot = document.createElement('div');
+    expect(() => render(html`<div .innerHTML=${'<em>blocked</em>'}></div>`, propertyRoot)).toThrow(
+      /replaces renderer-owned DOM/i,
+    );
+    expect(() => render(
+      html`<div .innerHTML=${unsafeHTML('<em>still blocked</em>')}></div>`,
+      propertyRoot,
+    )).toThrow(/replaces renderer-owned DOM/i);
+
+    const frameRoot = document.createElement('div');
+    expect(() => render(html`<iframe srcdoc=${'<p>blocked</p>'}></iframe>`, frameRoot)).toThrow(
+      /srcdoc attribute requires an explicit unsafeHTML/i,
+    );
+    render(html`<iframe srcdoc=${unsafeHTML('<p>allowed</p>')}></iframe>`, frameRoot);
+    expect(frameRoot.querySelector('iframe')?.getAttribute('srcdoc')).toBe('<p>allowed</p>');
+
+    const propertyFrameRoot = document.createElement('div');
+    expect(() => render(
+      html`<iframe .srcdoc=${'<p>blocked</p>'}></iframe>`,
+      propertyFrameRoot,
+    )).toThrow(/srcdoc requires an explicit unsafeHTML/i);
+    render(
+      html`<iframe .srcdoc=${unsafeHTML('<p>allowed property</p>')}></iframe>`,
+      propertyFrameRoot,
+    );
+    expect((propertyFrameRoot.querySelector('iframe') as HTMLIFrameElement).srcdoc).toBe(
+      '<p>allowed property</p>',
+    );
+
+    const link = (href: string | ReturnType<typeof unsafeURL>) => html`<a href=${href}>Link</a>`;
+    render(link('/safe'), root);
+    const originalHref = root.querySelector('a')?.getAttribute('href');
+    expect(() => render(link('java\nscript:alert(1)'), root)).toThrow(/blocked unsafe url protocol/i);
+    expect(root.querySelector('a')?.getAttribute('href')).toBe(originalHref);
+    render(link(unsafeURL('data:text/plain,reviewed')), root);
+    expect(root.querySelector('a')?.getAttribute('href')).toBe('data:text/plain,reviewed');
+
+    expect(() => render(html`<a .href=${'javascript:alert(1)'}>Blocked</a>`, propertyRoot)).toThrow(
+      /blocked unsafe url protocol/i,
+    );
+    render(html`<a .href=${unsafeURL('data:text/plain,reviewed')}>Reviewed</a>`, propertyRoot);
+    expect((propertyRoot.querySelector('a') as HTMLAnchorElement).href).toContain('data:text/plain');
+
+    expect(() => render(html`<button onclick=${'alert(1)'}>Blocked</button>`, propertyRoot)).toThrow(
+      /string event-handler attributes/i,
+    );
+  });
+
+  it('parses explicit raw markup in the surrounding SVG namespace', () => {
+    const root = document.createElement('div');
+    render(svg`<svg>${unsafeHTML('<circle cx="5" cy="5" r="4"></circle>')}</svg>`, root);
+    expect(root.querySelector('circle')?.namespaceURI).toBe('http://www.w3.org/2000/svg');
+  });
+
+  it('preserves contextual namespaces for raw markup inside arrays and keyed items', () => {
+    const root = document.createElement('div');
+    render(svg`
+      <svg>
+        ${[
+          unsafeHTML('<circle id="array-circle"></circle>'),
+          repeat(
+            [{ id: 'keyed-circle' }],
+            (item) => item.id,
+            (item) => unsafeHTML(`<circle id="${item.id}"></circle>`),
+          ),
+        ]}
+      </svg>
+    `, root);
+
+    expect(root.querySelector('#array-circle')?.namespaceURI).toBe('http://www.w3.org/2000/svg');
+    expect(root.querySelector('#keyed-circle')?.namespaceURI).toBe('http://www.w3.org/2000/svg');
+
+    render(html`
+      <math>
+        ${[
+          unsafeHTML('<mi id="array-mi">a</mi>'),
+          repeat(
+            [{ id: 'keyed-mi', value: 'b' }],
+            (item) => item.id,
+            (item) => unsafeHTML(`<mi id="${item.id}">${item.value}</mi>`),
+          ),
+        ]}
+      </math>
+    `, root);
+
+    expect(root.querySelector('#array-mi')?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+    expect(root.querySelector('#keyed-mi')?.namespaceURI).toBe('http://www.w3.org/1998/Math/MathML');
+  });
+
+  it('rejects binding-only helpers and destructive or mismatched sink values', () => {
+    const listener = () => undefined;
+
+    expect(() => render(html`<div>${event(listener)}</div>`, document.createElement('div'))).toThrow(
+      /only be used in matching attribute bindings/i,
+    );
+    expect(() => render(
+      html`<div>${unsafeURL('data:text/plain,reviewed')}</div>`,
+      document.createElement('div'),
+    )).toThrow(/only be used in matching attribute bindings/i);
+    expect(() => render(
+      html`<div title=${unsafeHTML('<b>wrong sink</b>')}></div>`,
+      document.createElement('div'),
+    )).toThrow(/unsafeHTML.*child content/i);
+    expect(() => render(
+      html`<div title=${unsafeURL('data:text/plain,reviewed')}></div>`,
+      document.createElement('div'),
+    )).toThrow(/unsafeURL.*URL-valued attribute/i);
+    expect(() => render(
+      html`<div .textContent=${'destructive'}></div>`,
+      document.createElement('div'),
+    )).toThrow(/replaces renderer-owned DOM/i);
+    expect(() => render(
+      html`<select .value=${['a']}><option value="a">A</option></select>`,
+      document.createElement('div'),
+    )).toThrow(/requires a <select multiple>/i);
+    expect(() => render(
+      html`<img srcset=${'safe.png 1x, data:image/png;base64,AAAA 2x'}>`,
+      document.createElement('div'),
+    )).toThrow(/blocked unsafe URL protocol/i);
+    expect(() => render(
+      html`<a ping=${'/audit javascript:alert(1)'}>Ping</a>`,
+      document.createElement('div'),
+    )).toThrow(/blocked unsafe URL protocol/i);
+
+    suspendRender(null);
+    unmount(null);
+  });
+
+  it('recovers renderer-owned root and dynamic nodes after external DOM changes', () => {
+    const root = document.createElement('div');
+    const click = vi.fn();
+    const view = (label: string) => html`<button @click=${click}>${label}</button>`;
+
+    render(view('first'), root);
+    const detached = root.querySelector('button') as HTMLButtonElement;
+    root.replaceChildren(document.createElement('aside'));
+    render(view('second'), root);
+
+    const replacement = root.querySelector('button') as HTMLButtonElement;
+    expect(replacement).not.toBe(detached);
+    expect(replacement.textContent).toBe('second');
+    detached.click();
+    replacement.click();
+    expect(click).toHaveBeenCalledTimes(1);
+
+    const dynamicRoot = document.createElement('div');
+    const strong = document.createElement('strong');
+    strong.textContent = 'owned';
+    const dynamicView = () => html`<section>${strong}</section>`;
+    render(dynamicView(), dynamicRoot);
+    strong.remove();
+    render(dynamicView(), dynamicRoot);
+    expect(dynamicRoot.querySelector('strong')).toBe(strong);
+
+    const attributeRoot = document.createElement('div');
+    const attributeView = () => html`<button title=${'owned'} ?disabled=${true}>Owned</button>`;
+    render(attributeView(), attributeRoot);
+    const ownedButton = attributeRoot.querySelector('button') as HTMLButtonElement;
+    ownedButton.removeAttribute('title');
+    ownedButton.removeAttribute('disabled');
+    render(attributeView(), attributeRoot);
+    expect(ownedButton.title).toBe('owned');
+    expect(ownedButton.disabled).toBe(true);
+  });
+
+  it('preserves null and undefined as explicit property values', () => {
+    const root = document.createElement('div');
+    const view = (value: null | undefined) => html`<div .payload=${value}></div>`;
+
+    render(view(null), root);
+    const target = root.querySelector('div') as HTMLDivElement & { payload?: unknown };
+    expect(target.payload).toBeNull();
+    render(view(undefined), root);
+    expect(target.payload).toBeUndefined();
+  });
+
+  it('treats nothing as absent for direct and spread boolean attributes', () => {
+    const root = document.createElement('div');
+    render(html`
+      <button id="direct" ?disabled=${nothing}>Direct</button>
+      <button id="spread" ...=${{ '?disabled': nothing }}>Spread</button>
+    `, root);
+
+    expect((root.querySelector('#direct') as HTMLButtonElement).disabled).toBe(false);
+    expect((root.querySelector('#spread') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('releases listener and ref ownership across repeated permanent unmounts', () => {
+    const root = document.createElement('div');
+    const click = vi.fn();
+    const detached: HTMLButtonElement[] = [];
+
+    for (let index = 0; index < 100; index += 1) {
+      const ref: { value?: Element } = {};
+      render(html`<button ...=${{ ref, onClick: click }}>${index}</button>`, root);
+      detached.push(ref.value as HTMLButtonElement);
+      unmount(root);
+      expect(ref.value).toBeUndefined();
+    }
+
+    for (const button of detached) button.click();
+    expect(click).not.toHaveBeenCalled();
+    expect(root.childNodes).toHaveLength(0);
+  });
+
+  it('removes capture listeners with their original options on unmount', () => {
+    const root = document.createElement('div');
+    const click = vi.fn();
+    const options: AddEventListenerOptions = { capture: true };
+    render(html`<button @click=${event(click, options)}>Capture</button>`, root);
+    const button = root.querySelector('button') as HTMLButtonElement;
+    options.capture = false;
+
+    unmount(root);
+    button.click();
+
+    expect(click).not.toHaveBeenCalled();
+  });
+
+  it('suspends Custom Element listeners and refs while retaining DOM for reconnect', async () => {
+    const tagName = `gluon-lifecycle-${lifecycleElementSequence += 1}` as `${string}-${string}`;
+
+    class LifecycleElement extends GluonElement {
+      readonly click = vi.fn();
+      readonly ref = vi.fn<(element: Element | undefined) => void>();
+
+      protected override render() {
+        return html`<button ...=${{ ref: this.ref, onClick: this.click }}>Retained</button>`;
+      }
+    }
+
+    defineElement(tagName, LifecycleElement);
+    const element = document.createElement(tagName) as LifecycleElement;
+    document.body.append(element);
+    await element.updateComplete;
+    const button = element.shadowRoot?.querySelector('button') as HTMLButtonElement;
+    button.click();
+    expect(element.click).toHaveBeenCalledOnce();
+
+    element.remove();
+    expect(element.ref).toHaveBeenLastCalledWith(undefined);
+    button.click();
+    expect(element.click).toHaveBeenCalledOnce();
+
+    document.body.append(element);
+    await element.updateComplete;
+    const reconnected = element.shadowRoot?.querySelector('button') as HTMLButtonElement;
+    expect(reconnected).toBe(button);
+    expect(element.ref).toHaveBeenLastCalledWith(button);
+    reconnected.click();
+    expect(element.click).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not commit a queued element update after disconnection', async () => {
+    const tagName = `gluon-deferred-${lifecycleElementSequence += 1}` as `${string}-${string}`;
+
+    class DeferredElement extends GluonElement {
+      renders = 0;
+
+      protected override render() {
+        this.renders += 1;
+        return html`<p>Rendered</p>`;
+      }
+    }
+
+    defineElement(tagName, DeferredElement);
+    const element = document.createElement(tagName) as DeferredElement;
+    document.body.append(element);
+    element.remove();
+    await Promise.resolve();
+
+    expect(element.renders).toBe(0);
+    expect(element.shadowRoot?.childNodes).toHaveLength(0);
+
+    document.body.append(element);
+    await element.updateComplete;
+    expect(element.renders).toBe(1);
+    expect(element.shadowRoot?.textContent).toBe('Rendered');
+  });
+});

--- a/tests/element-advanced.spec.ts
+++ b/tests/element-advanced.spec.ts
@@ -155,6 +155,7 @@ describe('advanced GluonElement behavior', () => {
   it('captures properties assigned before upgrade and rejects conflicting definitions', async () => {
     const tagName = `gluon-preupgrade-${advancedElementSequence += 1}` as `${string}-${string}`;
     const element = document.createElement(tagName) as HTMLElement & { value?: string };
+    element.setAttribute('value', 'attribute');
     element.value = 'captured';
     document.body.append(element);
 
@@ -182,6 +183,10 @@ describe('advanced GluonElement behavior', () => {
     expect((element as unknown as PreUpgradeElement).value).toBe('captured');
     expect(element.getAttribute('value')).toBe('captured');
     expect(element.shadowRoot?.textContent).toBe('captured');
+    element.setAttribute('value', 'later-attribute');
+    await (element as unknown as PreUpgradeElement).updateComplete;
+    expect((element as unknown as PreUpgradeElement).value).toBe('later-attribute');
+    expect(element.shadowRoot?.textContent).toBe('later-attribute');
     expect(() => defineElement(tagName, ConflictingElement)).toThrow(/already defined/i);
   });
 });

--- a/tests/form-controls.spec.ts
+++ b/tests/form-controls.spec.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GluonElement,
+  defineElement,
+  html,
+  render,
+  type PropertyDeclarations,
+} from '../src/index.js';
+
+let formElementSequence = 0;
+
+describe('form control integration', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('restores controlled text values and preserves uncontrolled user edits', () => {
+    const root = document.createElement('div');
+    const view = (value: string) => html`
+      <input id="controlled" .value=${value}>
+      <input id="uncontrolled" value=${'initial'}>
+      <textarea id="controlled-area" .value=${value}></textarea>
+      <textarea id="uncontrolled-area" .defaultValue=${'initial'}></textarea>
+    `;
+
+    render(view('controlled'), root);
+    const controlled = root.querySelector('#controlled') as HTMLInputElement;
+    const uncontrolled = root.querySelector('#uncontrolled') as HTMLInputElement;
+    const controlledArea = root.querySelector('#controlled-area') as HTMLTextAreaElement;
+    const uncontrolledArea = root.querySelector('#uncontrolled-area') as HTMLTextAreaElement;
+
+    controlled.value = 'user';
+    uncontrolled.value = 'user';
+    controlledArea.value = 'user';
+    uncontrolledArea.value = 'user';
+    render(view('controlled'), root);
+
+    expect(controlled.value).toBe('controlled');
+    expect(controlledArea.value).toBe('controlled');
+    expect(uncontrolled.value).toBe('user');
+    expect(uncontrolledArea.value).toBe('user');
+  });
+
+  it('restores controlled checkbox and radio state while preserving uncontrolled state', () => {
+    const root = document.createElement('div');
+    const view = () => html`
+      <input id="controlled-check" type="checkbox" .checked=${true}>
+      <input id="uncontrolled-check" type="checkbox" ?checked=${true}>
+      <input id="controlled-a" type="radio" name="controlled" .checked=${true}>
+      <input id="controlled-b" type="radio" name="controlled" .checked=${false}>
+      <input id="uncontrolled-a" type="radio" name="uncontrolled" ?checked=${true}>
+      <input id="uncontrolled-b" type="radio" name="uncontrolled" ?checked=${false}>
+    `;
+
+    render(view(), root);
+    const controlledCheck = root.querySelector('#controlled-check') as HTMLInputElement;
+    const uncontrolledCheck = root.querySelector('#uncontrolled-check') as HTMLInputElement;
+    const controlledA = root.querySelector('#controlled-a') as HTMLInputElement;
+    const controlledB = root.querySelector('#controlled-b') as HTMLInputElement;
+    const uncontrolledA = root.querySelector('#uncontrolled-a') as HTMLInputElement;
+    const uncontrolledB = root.querySelector('#uncontrolled-b') as HTMLInputElement;
+
+    controlledCheck.checked = false;
+    uncontrolledCheck.checked = false;
+    controlledB.click();
+    uncontrolledB.click();
+    render(view(), root);
+
+    expect(controlledCheck.checked).toBe(true);
+    expect(uncontrolledCheck.checked).toBe(false);
+    expect(controlledA.checked).toBe(true);
+    expect(controlledB.checked).toBe(false);
+    expect(uncontrolledA.checked).toBe(false);
+    expect(uncontrolledB.checked).toBe(true);
+  });
+
+  it('controls single and multi-select values and preserves an uncontrolled selection', () => {
+    const root = document.createElement('div');
+    const view = (single: string, multiple: readonly string[]) => html`
+      <select id="single" .value=${single}>
+        <option value="a">A</option>
+        <option value="b">B</option>
+        <option value="c">C</option>
+      </select>
+      <select id="multiple" multiple .value=${multiple}>
+        <option value="a">A</option>
+        <option value="b">B</option>
+        <option value="c">C</option>
+      </select>
+      <select id="uncontrolled">
+        <option value="a" ?selected=${true}>A</option>
+        <option value="b" ?selected=${false}>B</option>
+      </select>
+    `;
+
+    render(view('b', ['a', 'c']), root);
+    const single = root.querySelector('#single') as HTMLSelectElement;
+    const multiple = root.querySelector('#multiple') as HTMLSelectElement;
+    const uncontrolled = root.querySelector('#uncontrolled') as HTMLSelectElement;
+
+    single.value = 'a';
+    for (const option of multiple.options) option.selected = option.value === 'b';
+    uncontrolled.value = 'b';
+    render(view('b', ['a', 'c']), root);
+
+    expect(single.value).toBe('b');
+    expect([...multiple.selectedOptions].map((option) => option.value)).toEqual(['a', 'c']);
+    expect(uncontrolled.value).toBe('b');
+
+    render(view('c', ['b']), root);
+    expect(single.value).toBe('c');
+    expect([...multiple.selectedOptions].map((option) => option.value)).toEqual(['b']);
+  });
+
+  it('commits controlled selection after dynamic options are rendered', () => {
+    const root = document.createElement('div');
+    const option = (value: string) => html`<option value=${value}>${value.toUpperCase()}</option>`;
+    const view = (single: string, multiple: readonly string[], options: readonly string[]) => html`
+      <select id="single" .value=${single}>${options.map(option)}</select>
+      <select id="multiple" multiple ...=${{ '.value': multiple }}>${options.map(option)}</select>
+    `;
+
+    render(view('b', ['a', 'c'], ['a', 'b', 'c']), root);
+
+    const single = root.querySelector('#single') as HTMLSelectElement;
+    const multiple = root.querySelector('#multiple') as HTMLSelectElement;
+    expect(single.value).toBe('b');
+    expect([...multiple.selectedOptions].map((selected) => selected.value)).toEqual(['a', 'c']);
+
+    render(view('d', ['b', 'd'], ['a', 'b', 'c', 'd']), root);
+    expect(single.value).toBe('d');
+    expect([...multiple.selectedOptions].map((selected) => selected.value)).toEqual(['b', 'd']);
+  });
+
+  it('preserves an uncontrolled file selection and only permits controlled clearing', () => {
+    const root = document.createElement('div');
+    const view = () => html`
+      <input id="controlled" type="file" .value=${''}>
+      <input id="uncontrolled" type="file">
+    `;
+
+    render(view(), root);
+    const controlled = root.querySelector('#controlled') as HTMLInputElement;
+    const uncontrolled = root.querySelector('#uncontrolled') as HTMLInputElement;
+    const controlledTransfer = new DataTransfer();
+    controlledTransfer.items.add(new File(['gluon'], 'controlled.txt', { type: 'text/plain' }));
+    const uncontrolledTransfer = new DataTransfer();
+    uncontrolledTransfer.items.add(new File(['gluon'], 'gluon.txt', { type: 'text/plain' }));
+    controlled.files = controlledTransfer.files;
+    uncontrolled.files = uncontrolledTransfer.files;
+
+    render(view(), root);
+
+    expect(controlled.files).toHaveLength(0);
+    expect(uncontrolled.files?.item(0)?.name).toBe('gluon.txt');
+
+    const invalidRoot = document.createElement('div');
+    expect(() => render(
+      html`<input type="file" .value=${'not-allowed'}>`,
+      invalidRoot,
+    )).toThrow();
+  });
+
+  it('supports the platform form-associated Custom Element contract', async () => {
+    const tagName = `gluon-form-control-${formElementSequence += 1}` as `${string}-${string}`;
+
+    class FormControlElement extends GluonElement {
+      static readonly formAssociated = true;
+      static override readonly properties: PropertyDeclarations = {
+        value: { default: 'initial' },
+        required: { type: Boolean, reflect: true, default: false },
+      };
+
+      declare value: string;
+      declare required: boolean;
+      readonly internals = this.attachInternals();
+      private disabledByForm = false;
+
+      get form(): HTMLFormElement | null {
+        return this.internals.form;
+      }
+
+      get labels(): NodeList {
+        return this.internals.labels;
+      }
+
+      checkValidity(): boolean {
+        return this.internals.checkValidity();
+      }
+
+      formDisabledCallback(disabled: boolean): void {
+        this.disabledByForm = disabled;
+        void this.requestUpdate();
+      }
+
+      formResetCallback(): void {
+        this.value = 'initial';
+      }
+
+      formStateRestoreCallback(state: string | File | FormData | null): void {
+        if (typeof state === 'string') this.value = state;
+      }
+
+      override focus(options?: FocusOptions): void {
+        this.shadowRoot?.querySelector('input')?.focus(options);
+      }
+
+      protected override update(): void {
+        super.update();
+        this.internals.setFormValue(this.value, this.value);
+        if (this.required && !this.value) {
+          this.internals.setValidity({ valueMissing: true }, 'A value is required.');
+        } else {
+          this.internals.setValidity({});
+        }
+      }
+
+      protected override render() {
+        return html`
+          <input
+            .value=${this.value}
+            ?disabled=${this.disabledByForm}
+            @input=${(inputEvent: Event) => {
+              this.value = (inputEvent.currentTarget as HTMLInputElement).value;
+            }}
+          >
+        `;
+      }
+    }
+
+    defineElement(tagName, FormControlElement);
+    const form = document.createElement('form');
+    const label = document.createElement('label');
+    label.htmlFor = 'control';
+    label.textContent = 'Value';
+    const control = document.createElement(tagName) as FormControlElement;
+    control.id = 'control';
+    control.setAttribute('name', 'entry');
+    form.append(label, control);
+    document.body.append(form);
+    await control.updateComplete;
+
+    control.value = 'submitted';
+    await control.updateComplete;
+    expect(new FormData(form).get('entry')).toBe('submitted');
+    expect(control.form).toBe(form);
+    expect([...control.labels]).toContain(label);
+
+    const inputEvent = vi.fn();
+    control.addEventListener('input', inputEvent);
+    const internalInput = control.shadowRoot?.querySelector('input') as HTMLInputElement;
+    internalInput.value = 'typed';
+    internalInput.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+    await control.updateComplete;
+    expect(control.value).toBe('typed');
+    expect(new FormData(form).get('entry')).toBe('typed');
+    expect(inputEvent).toHaveBeenCalledOnce();
+
+    control.required = true;
+    control.value = '';
+    await control.updateComplete;
+    expect(control.checkValidity()).toBe(false);
+
+    form.reset();
+    await control.updateComplete;
+    expect(control.value).toBe('initial');
+    control.formStateRestoreCallback('restored');
+    await control.updateComplete;
+    expect(control.value).toBe('restored');
+
+    control.focus();
+    expect(control.shadowRoot?.activeElement).toBe(control.shadowRoot?.querySelector('input'));
+
+    control.setAttribute('disabled', '');
+    await Promise.resolve();
+    expect(new FormData(form).has('entry')).toBe(false);
+    expect((control.shadowRoot?.querySelector('input') as HTMLInputElement).disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #21

## Summary
- define controlled and uncontrolled semantics for text, checkbox, radio, select, multi-select, textarea, file inputs, and form-associated Custom Elements
- add lifecycle directives with deterministic mount, update, cleanup, disconnect, suspension, and failed-update behavior
- complete SVG, MathML, qualified attributes, property/attribute/boolean bindings, and native event options
- add explicit `unsafeHTML()` and `unsafeURL()` escape hatches while keeping ordinary strings inert and blocking unsafe dynamic protocols
- release directives, listeners, and refs on suspension/unmount while retaining reconnectable Custom Element DOM
- recover renderer-owned nodes and attributes after external DOM interaction
- document the complete DOM/form/runtime contract and expose the public API/types

## Verification
- `npm run check`
  - Core browser: 57 tests passed
  - Core coverage: 96.81% statements, 94.28% branches, 100% functions, 97.66% lines
  - Reactivity: 64 tests passed
  - Reactivity coverage: 99.06% statements, 95.28% branches, 100% functions, 99.81% lines
  - Core and Reactivity builds passed
  - Core and Reactivity generated declaration contracts passed
  - package contract validation passed for all 16 package entries
- `npx vitest run tests/dom-runtime-contract.spec.ts tests/form-controls.spec.ts tests/element-advanced.spec.ts`: 26 tests passed
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- `git diff --check`
- independent `gpt-5.4-mini` review: no actionable findings