### PR TITLE
Integrate reactive render effects with GluonElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and released versions follow [Semantic Versioning](https://semver.org/).
   directives, native event options, qualified namespaces, explicit unsafe HTML
   and URL escapes, reversible render suspension, permanent unmount, external
   DOM recovery, and pre-upgrade property precedence.
+- Scope-owned reactive `GluonElement` rendering through the shared update
+  scheduler, including reconnect retention and render-cause/timing diagnostics.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,13 @@ class GreetingElement extends GluonElement {
 defineElement('gluon-greeting', GreetingElement);
 ```
 
-Declared properties receive accessors, schedule microtask-batched updates, may reflect to attributes, and expose an `updateComplete` promise.
+Declared properties receive accessors, may reflect to attributes, and join
+reactive values read during render on one scope-owned, update-phase scheduler
+runner. Synchronous invalidations are deduplicated, `updateComplete` resolves
+after commit, and disconnect stops owned effects while retaining state and
+matching DOM for reconnection. The complete behavior and development render
+diagnostics are defined in the
+[Reactive Custom Element contract](docs/reactive-elements.md).
 
 ## Adopted stylesheets only
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,9 @@ their rejections use the same error channel. A recursion limit routes
 self-queueing failures through the error channel without rejecting the flush
 promise.
 
-Effects remain synchronous unless they select `pre` or `post`. The outermost
+Effects remain synchronous unless they select `pre`, `update`, or `post`. Lazy
+effects can defer their first execution and expose an eager scheduling hook for
+render-owner integration. The outermost
 synchronous `batch` deduplicates all affected effects before dispatch. `untracked`
 temporarily suppresses subscription collection while preserving nested active
 effect behavior.
@@ -76,9 +78,15 @@ Low-level failures select the closest effect, watcher, job, or scope handler;
 the configured global reactivity handler is used when no local handler exists.
 The default uses platform `reportError` or `console.error`; handler failures are
 contained by that default channel. Application-
-specific error ownership remains issue #23. Issue #22 integrates these scheduler
-and scope primitives with `GluonElement`; the element still uses its current
-property-update microtask until that lifecycle integration is implemented.
+specific error ownership remains issue #23.
+
+`GluonElement` owns one lazy update-phase render effect per connection. Declared
+property requests and reactive invalidations queue the same runner, conditional
+render dependencies are rebuilt each run, and disconnect stops the complete
+scope before suspending DOM bindings. Reconnection retains state and matching
+DOM while creating fresh reactive ownership. The public diagnostic hook reports
+batched render causes, tracked dependencies, and timings. The full contract is
+documented in [Reactive Custom Elements](reactive-elements.md).
 
 ## Runtime contract
 
@@ -154,8 +162,9 @@ prototype gaps and the required Gluon 1.0 contract.
 - defaults and custom converters
 - change predicates
 - property-to-attribute reflection
-- microtask-batched rendering
+- scoped reactive rendering through the shared phased scheduler
 - `updateComplete`
+- disconnect/reconnect effect ownership and development render diagnostics
 - inherited constructable stylesheets
 
 Every instance renders into an open ShadowRoot. Component styles are always adopted `CSSStyleSheet` instances.

--- a/docs/reactive-elements.md
+++ b/docs/reactive-elements.md
@@ -1,0 +1,95 @@
+# Reactive Custom Element contract
+
+`GluonElement` integrates `@gluonjs/core` rendering with the shared
+`@gluonjs/reactivity` dependency graph, scheduler, and effect scopes. The Core
+package declares Reactivity as a runtime dependency and leaves that import
+external in its production ESM build so an application uses one reactivity
+identity.
+
+## Render dependencies and scheduling
+
+Each connected element owns one lazy render effect in a detached effect scope.
+The first connection queues that runner in the scheduler's `update` phase.
+Declared property writes, explicit `requestUpdate()` calls, and reactive
+invalidations all queue the same runner identity with the element's stable
+numeric update ID. Multiple synchronous writes are therefore deduplicated into
+one render.
+
+```ts
+import { GluonElement, defineElement, html } from '@gluonjs/core';
+import { reactive } from '@gluonjs/reactivity';
+
+class CounterElement extends GluonElement {
+  readonly state = reactive({ count: 0, ignored: false });
+
+  protected override render() {
+    return html`<output>${this.state.count}</output>`;
+  }
+}
+
+defineElement('gluon-counter', CounterElement);
+```
+
+Only reactive properties and collection operations read during the current
+`update()`/`render()` execution become dependencies. Dependencies are rebuilt
+on every run, so a value that is no longer read after a conditional branch
+changes no longer invalidates the element. `updateComplete` refers to the
+pending scheduled update and resolves after that render has committed.
+
+The scheduler drains `pre`, `update`, and `post` phases in order. Element IDs
+preserve deterministic ordering within the update phase, while matching runner
+identity deduplicates declared-property and reactive invalidations that happen
+in the same synchronous turn.
+
+## Connection ownership
+
+Connection creates a new detached effect scope and queues the lazy render
+effect. The scope is active while the element's update executes, so effects,
+watchers, and `onScopeDispose()` callbacks created during that execution are
+owned by the current connection. Resource creation must still be guarded so a
+component does not create a duplicate watcher on every render.
+
+Disconnection performs reversible cleanup:
+
+1. mark the element disconnected and stop its scope;
+2. invalidate queued render effects and owned watcher jobs;
+3. run owned watcher and scope cleanup;
+4. resolve a cancelled pending `updateComplete`;
+5. suspend renderer directives, listeners, and refs while retaining matching
+   Shadow DOM and element state.
+
+Reactive or declared-property writes while disconnected update their source
+state but perform no DOM work. If the element reconnects, Gluon creates a new
+scope and render effect, reads the current state, and resumes the retained DOM
+when its template still matches. If it never reconnects, no stopped render
+effect, watcher, directive, listener, ref, or scheduler job can execute on its
+behalf.
+
+## Development render diagnostics
+
+`setGluonRenderDebugHook()` installs the current development observer and
+returns a function that restores the previous observer:
+
+```ts
+import { setGluonRenderDebugHook } from '@gluonjs/core';
+
+const restore = setGluonRenderDebugHook((event) => {
+  console.log(event.element, event.causes, event.dependencies, event.duration);
+});
+```
+
+One diagnostic is emitted after each completed or failed render. It contains:
+
+- the `GluonElement` instance;
+- every batched connection, explicit request, declared-property, and reactive
+  cause recorded for that render;
+- the reactive target, operation, and key for reactive causes;
+- the dependencies tracked by the resulting render;
+- `performance.now()` start/end timestamps and duration;
+- a failure flag and the thrown value when rendering failed.
+
+Reactive `onTrack`/`onTrigger` collection and the Gluon observer are disabled
+when `globalThis.process?.env?.NODE_ENV` is `"production"`. Observer failures
+are reported through `reportError` when available, otherwise `console.error`,
+and do not change the render result. Application-specific error ownership is
+part of issue #23 rather than this low-level diagnostic contract.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,7 +56,8 @@ Gluon currently provides:
 - nested templates, index-based array rendering, and keyed `repeat()` reconciliation
 - standalone DOM-free refs, reactive and readonly proxies, effects, and computed values
 - deterministic batching, phased scheduling, `nextTick`, effect scopes, and watchers
-- reactive declared properties through `GluonElement`
+- scope-owned reactive render effects, batched declared properties, reconnect
+  retention, and render diagnostics through `GluonElement`
 - constructable stylesheet creation and adopted stylesheet management
 - typed Quark factories for native HTML elements
 - representative Atom, Molecule, and Organism packages

--- a/package-contract.json
+++ b/package-contract.json
@@ -35,7 +35,9 @@
       "environment": "browser",
       "exports": [".", "./styles", "./quarks", "./atoms", "./molecules", "./organisms"],
       "finalExports": [".", "./styles"],
-      "currentDependencies": [],
+      "currentDependencies": [
+        "@gluonjs/reactivity"
+      ],
       "dependencies": ["@gluonjs/reactivity"]
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "workspaces": [
         "packages/*"
       ],
+      "dependencies": {
+        "@gluonjs/reactivity": "0.0.0"
+      },
       "devDependencies": {
         "@types/node": "^22.10.0",
         "@vitest/browser-playwright": "^4.0.18",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,12 @@
     "access": "public",
     "provenance": true
   },
+  "dependencies": {
+    "@gluonjs/reactivity": "0.0.0"
+  },
   "scripts": {
-    "build": "npm run build:core && npm run build:reactivity",
-    "build:core": "vite build && tsc -p tsconfig.build.json",
+    "build": "npm run build:core",
+    "build:core": "npm run build:reactivity && vite build && tsc -p tsconfig.build.json",
     "build:reactivity": "npm run build --workspace @gluonjs/reactivity",
     "typecheck": "npm run typecheck:core && npm run typecheck:reactivity",
     "typecheck:core": "tsc -p tsconfig.json --noEmit",

--- a/packages/reactivity/CHANGELOG.md
+++ b/packages/reactivity/CHANGELOG.md
@@ -9,3 +9,5 @@
 - A deduplicating pre/update/post scheduler, synchronous batching, `nextTick`,
   untracked reads, hierarchical effect scopes, watchers, cleanup, and error
   routing.
+- Lazy effects, update-phase effect scheduling, and an eager invalidation hook
+  for render-owner integration.

--- a/packages/reactivity/README.md
+++ b/packages/reactivity/README.md
@@ -23,7 +23,8 @@ await nextTick();
 - `ref`, `shallowRef`, `isRef`, and `unref`
 - `reactive`, `shallowReactive`, `readonly`, and `shallowReadonly`
 - `isReactive`, `isReadonly`, `isProxy`, and `toRaw`
-- `effect`, `stop`, and development-only `onTrack`/`onTrigger` callbacks
+- `effect`, `stop`, lazy activation, scheduling hooks, and development-only
+  `onTrack`/`onTrigger` callbacks
 - lazy, cached readonly and writable `computed` values
 - `batch`, `untracked`, phased queue helpers, and `nextTick`
 - attached or detached `effectScope` ownership and `onScopeDispose`
@@ -45,10 +46,12 @@ cycle, including post-flush work, is complete. A queued job may return a promise
 the current phase waits for it and routes rejection through the same error
 channel.
 
-Effects are synchronous by default. `flush: 'pre'` and `flush: 'post'` opt into
-the shared microtask queue. `batch()` deduplicates synchronous invalidations
-until the outermost synchronous batch returns; it does not extend across an
-`await` boundary.
+Effects are synchronous by default. `flush: 'pre'`, `flush: 'update'`, and
+`flush: 'post'` opt into the matching shared microtask phase. `lazy: true`
+returns a runner without executing it; `onSchedule` runs synchronously before
+an invalidated effect enters its selected phase. `batch()` deduplicates
+synchronous invalidations until the outermost synchronous batch returns; it
+does not extend across an `await` boundary.
 
 An attached scope stops its owned effects in reverse creation order, then child
 scopes in reverse creation order, then cleanup callbacks in reverse registration

--- a/packages/reactivity/src/effect.ts
+++ b/packages/reactivity/src/effect.ts
@@ -31,6 +31,8 @@ export interface EffectDebuggerEvent {
 export interface EffectOptions {
   readonly flush?: EffectFlush;
   readonly id?: number;
+  readonly lazy?: boolean;
+  readonly onSchedule?: () => void;
   readonly onTrack?: (event: EffectDebuggerEvent) => void;
   readonly onTrigger?: (event: EffectDebuggerEvent) => void;
   readonly onStop?: () => void;
@@ -159,6 +161,7 @@ export function effect<T>(
   let runner!: ReactiveEffectRunner<T>;
   const onError = options.onError ?? getCurrentScope()?.onError;
   const scheduler = () => {
+    options.onSchedule?.();
     scheduleEffect(
       runner,
       options.flush ?? 'sync',
@@ -167,7 +170,7 @@ export function effect<T>(
     );
   };
   runner = createReactiveEffect(callback, scheduler, { ...options, onError });
-  runner();
+  if (!options.lazy) runner();
   return runner;
 }
 

--- a/packages/reactivity/src/scheduler.ts
+++ b/packages/reactivity/src/scheduler.ts
@@ -5,7 +5,7 @@ import {
 import { getCurrentScope } from './scope.js';
 
 export type FlushPhase = 'pre' | 'update' | 'post';
-export type EffectFlush = 'sync' | 'pre' | 'post';
+export type EffectFlush = 'sync' | FlushPhase;
 export type SchedulerJob = () => unknown;
 
 export interface SchedulerJobOptions {

--- a/src/element.ts
+++ b/src/element.ts
@@ -1,5 +1,50 @@
 import { render, suspendRender, type TemplateResult } from './runtime.js';
 import { adoptStyles } from './styles/index.js';
+import {
+  effect,
+  effectScope,
+  queueJob,
+  type EffectDebuggerEvent,
+  type EffectScope,
+  type ReactiveEffectRunner,
+} from '@gluonjs/reactivity';
+
+export type GluonRenderCause =
+  | { readonly type: 'connection' }
+  | { readonly type: 'request' }
+  | {
+    readonly type: 'property';
+    readonly name: string;
+    readonly value: unknown;
+    readonly oldValue: unknown;
+  }
+  | { readonly type: 'reactive'; readonly dependency: EffectDebuggerEvent };
+
+export interface GluonRenderDebugEvent {
+  readonly element: GluonElement;
+  readonly causes: readonly GluonRenderCause[];
+  readonly dependencies: readonly EffectDebuggerEvent[];
+  readonly startedAt: number;
+  readonly endedAt: number;
+  readonly duration: number;
+  readonly failed: boolean;
+  readonly error?: unknown;
+}
+
+export type GluonRenderDebugHook = (event: GluonRenderDebugEvent) => void;
+
+let renderDebugHook: GluonRenderDebugHook | undefined;
+
+/** Installs the development render diagnostic hook and returns a restore handle. */
+export function setGluonRenderDebugHook(
+  hook: GluonRenderDebugHook | undefined,
+): () => void {
+  const previous = renderDebugHook;
+  renderDebugHook = hook;
+  return () => {
+    renderDebugHook = previous;
+  };
+}
 
 export type PropertyType =
   | StringConstructor
@@ -35,6 +80,13 @@ const declarationCache = new WeakMap<Function, PropertyDeclarations>();
 const styleCache = new WeakMap<Function, readonly CSSStyleSheet[]>();
 const propertyValues = Symbol('gluon.property-values');
 const setProperty = Symbol('gluon.set-property');
+let elementUpdateSequence = 0;
+
+interface UpdateDeferred {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+  readonly reject: (reason?: unknown) => void;
+}
 
 export abstract class GluonElement extends HTMLElement {
   static readonly properties: PropertyDeclarations = {};
@@ -42,14 +94,20 @@ export abstract class GluonElement extends HTMLElement {
 
   protected readonly renderRoot: ShadowRoot;
   private readonly [propertyValues] = new Map<string, unknown>();
-  private updatePending = false;
+  private readonly updateId = elementUpdateSequence;
   private connected = false;
   private reflectingAttribute?: string;
   private readonly initialAttributePrecedence = new Map<string, string>();
+  private renderScope?: EffectScope;
+  private renderEffect?: ReactiveEffectRunner<void | undefined>;
+  private pendingUpdate?: UpdateDeferred;
+  private readonly pendingRenderCauses: GluonRenderCause[] = [];
+  private activeRenderDependencies?: EffectDebuggerEvent[];
   private updatePromise: Promise<void> = Promise.resolve();
 
   constructor() {
     super();
+    elementUpdateSequence += 1;
     this.renderRoot = this.createRenderRoot();
     const constructor = this.constructor as GluonElementConstructor;
     finalizeProperties(constructor);
@@ -67,15 +125,28 @@ export abstract class GluonElement extends HTMLElement {
   }
 
   connectedCallback(): void {
+    if (this.connected) return;
     this.connected = true;
     adoptStyles(this.renderRoot, ...getStyles(this.constructor as GluonElementConstructor));
     this.reflectCurrentProperties();
-    void this.requestUpdate();
+    this.createRenderEffect();
+    void this.queueUpdate({ type: 'connection' });
   }
 
   disconnectedCallback(): void {
+    if (!this.connected) return;
     this.connected = false;
-    suspendRender(this.renderRoot);
+    const scope = this.renderScope;
+    this.renderScope = undefined;
+    this.renderEffect = undefined;
+    try {
+      scope?.stop();
+    } finally {
+      this.resolvePendingUpdate();
+      this.pendingRenderCauses.length = 0;
+      this.activeRenderDependencies = undefined;
+      suspendRender(this.renderRoot);
+    }
   }
 
   attributeChangedCallback(
@@ -111,24 +182,7 @@ export abstract class GluonElement extends HTMLElement {
   }
 
   protected requestUpdate(): Promise<void> {
-    if (!this.connected || this.updatePending) return this.updatePromise;
-    this.updatePending = true;
-    this.updatePromise = new Promise((resolve, reject) => {
-      queueMicrotask(() => {
-        this.updatePending = false;
-        if (!this.connected) {
-          resolve();
-          return;
-        }
-        try {
-          this.update();
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      });
-    });
-    return this.updatePromise;
+    return this.queueUpdate({ type: 'request' });
   }
 
   protected update(): void {
@@ -164,7 +218,100 @@ export abstract class GluonElement extends HTMLElement {
     if (reflect && declaration.reflect && this.connected) {
       this.reflectProperty(name, value, declaration);
     }
-    void this.requestUpdate();
+    void this.queueUpdate({
+      type: 'property',
+      name,
+      value,
+      oldValue,
+    });
+  }
+
+  private createRenderEffect(): void {
+    if (this.renderEffect) return;
+    const scope = effectScope(true);
+    const runner = scope.run(() => effect(
+      () => scope.run(() => this.performUpdate()),
+      {
+        flush: 'update',
+        id: this.updateId,
+        lazy: true,
+        onSchedule: () => {
+          if (this.connected) this.ensurePendingUpdate();
+        },
+        onTrack: (dependency) => {
+          this.activeRenderDependencies?.push(dependency);
+        },
+        onTrigger: (dependency) => {
+          this.recordRenderCause({ type: 'reactive', dependency });
+        },
+      },
+    ))!;
+    this.renderScope = scope;
+    this.renderEffect = runner;
+  }
+
+  private queueUpdate(cause: GluonRenderCause): Promise<void> {
+    const runner = this.renderEffect;
+    if (!this.connected || !runner) return this.updatePromise;
+    this.recordRenderCause(cause);
+    const promise = this.ensurePendingUpdate();
+    queueJob(runner, { phase: 'update', id: this.updateId });
+    return promise;
+  }
+
+  private performUpdate(): void {
+    const deferred = this.pendingUpdate ?? createUpdateDeferred();
+    if (!this.pendingUpdate) this.updatePromise = deferred.promise;
+    this.pendingUpdate = undefined;
+
+    const causes = Object.freeze([...this.pendingRenderCauses]);
+    this.pendingRenderCauses.length = 0;
+    const dependencies: EffectDebuggerEvent[] = [];
+    this.activeRenderDependencies = dependencies;
+    const startedAt = performance.now();
+    let failed = false;
+    let renderError: unknown;
+
+    try {
+      this.update();
+      deferred.resolve();
+    } catch (error) {
+      failed = true;
+      renderError = error;
+      deferred.reject(error);
+      throw error;
+    } finally {
+      const endedAt = performance.now();
+      this.activeRenderDependencies = undefined;
+      emitRenderDebugEvent({
+        element: this,
+        causes,
+        dependencies: Object.freeze([...dependencies]),
+        startedAt,
+        endedAt,
+        duration: endedAt - startedAt,
+        failed,
+        ...(failed ? { error: renderError } : {}),
+      });
+    }
+  }
+
+  private ensurePendingUpdate(): Promise<void> {
+    if (!this.pendingUpdate) {
+      this.pendingUpdate = createUpdateDeferred();
+      this.updatePromise = this.pendingUpdate.promise;
+    }
+    return this.pendingUpdate.promise;
+  }
+
+  private resolvePendingUpdate(): void {
+    this.pendingUpdate?.resolve();
+    this.pendingUpdate = undefined;
+    this.updatePromise = Promise.resolve();
+  }
+
+  private recordRenderCause(cause: GluonRenderCause): void {
+    if (isDevelopment() && renderDebugHook) this.pendingRenderCauses.push(cause);
   }
 
   private capturePreUpgradeProperties(constructor: GluonElementConstructor): void {
@@ -223,6 +370,45 @@ export abstract class GluonElement extends HTMLElement {
       this.reflectingAttribute = undefined;
     }
   }
+}
+
+function createUpdateDeferred(): UpdateDeferred {
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function emitRenderDebugEvent(event: GluonRenderDebugEvent): void {
+  const hook = renderDebugHook;
+  if (!hook || !isDevelopment()) return;
+  try {
+    hook(Object.freeze(event));
+  } catch (error) {
+    reportDebugHookError(error);
+  }
+}
+
+function reportDebugHookError(error: unknown): void {
+  const environment = globalThis as {
+    reportError?: (reason: unknown) => void;
+    console?: { error?: (...values: unknown[]) => void };
+  };
+  try {
+    if (typeof environment.reportError === 'function') environment.reportError(error);
+    else environment.console?.error?.(error);
+  } catch {
+    // A development observer cannot turn a completed render into an application failure.
+  }
+}
+
+function isDevelopment(): boolean {
+  return (
+    globalThis as { process?: { env?: { NODE_ENV?: string } } }
+  ).process?.env?.NODE_ENV !== 'production';
 }
 
 export type GluonElementClass<ElementType extends GluonElement = GluonElement> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,11 @@ export {
 export {
   GluonElement,
   defineElement,
+  setGluonRenderDebugHook,
   type GluonElementClass,
+  type GluonRenderCause,
+  type GluonRenderDebugEvent,
+  type GluonRenderDebugHook,
   type PropertyConverter,
   type PropertyDeclaration,
   type PropertyDeclarations,

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -3,12 +3,14 @@ import {
   event,
   html,
   repeat,
+  setGluonRenderDebugHook,
   suspendRender,
   unmount,
   unsafeHTML,
   unsafeURL,
   type DirectiveLifecycle,
   type EventBinding,
+  type GluonRenderDebugEvent,
   type Key,
   type RepeatResult,
   type TemplateValue,
@@ -43,6 +45,14 @@ html`<div>${unsafeHTML('<strong>trusted</strong>')}</div>`;
 html`<a href=${unsafeURL('data:text/plain,reviewed')}>Reviewed</a>`;
 suspendRender(null);
 unmount(null);
+const restoreRenderDebugHook = setGluonRenderDebugHook((diagnostic: GluonRenderDebugEvent) => {
+  diagnostic.element;
+  diagnostic.duration.toFixed();
+  for (const cause of diagnostic.causes) {
+    if (cause.type === 'reactive') cause.dependency.key;
+  }
+});
+restoreRenderDebugHook();
 
 // @ts-expect-error keys cannot be null
 repeat(rows, () => null, (row) => row.label);

--- a/tests-node/reactivity.types.ts
+++ b/tests-node/reactivity.types.ts
@@ -37,8 +37,10 @@ const writable: WritableComputedRef<number> = computed({
   set: (value) => { count.value = value; },
 });
 const runner: ReactiveEffectRunner<number> = effect(() => state.count, {
-  flush: 'pre',
+  flush: 'update',
   id: 1,
+  lazy: true,
+  onSchedule() {},
   onTrack(event: EffectDebuggerEvent) {
     event.effect;
     event.key;
@@ -83,3 +85,5 @@ doubled.value = 4;
 listView.push({ count: 2 });
 // @ts-expect-error refs preserve their value type
 count.value = 'invalid';
+// @ts-expect-error effect phases use the shared scheduler phase names
+effect(() => state.count, { flush: 'render' });

--- a/tests-node/scheduler.spec.ts
+++ b/tests-node/scheduler.spec.ts
@@ -36,6 +36,29 @@ describe('reactivity scheduler', () => {
     expect(values).toEqual([0, 3]);
   });
 
+  it('supports lazy update-phase effects with an eager scheduling hook', async () => {
+    const state = reactive({ count: 0 });
+    const values: number[] = [];
+    const scheduled = vi.fn();
+    const runner = effect(() => values.push(state.count), {
+      flush: 'update',
+      lazy: true,
+      onSchedule: scheduled,
+    });
+
+    expect(values).toEqual([]);
+    runner();
+    expect(values).toEqual([0]);
+
+    state.count = 1;
+    state.count = 2;
+    expect(scheduled).toHaveBeenCalledTimes(2);
+    expect(values).toEqual([0]);
+
+    await nextTick();
+    expect(values).toEqual([0, 2]);
+  });
+
   it('orders phases and parent ids deterministically while deduplicating jobs', async () => {
     const order: string[] = [];
     const preParent = () => order.push('pre-parent');

--- a/tests/form-controls.spec.ts
+++ b/tests/form-controls.spec.ts
@@ -273,6 +273,7 @@ describe('form control integration', () => {
 
     control.setAttribute('disabled', '');
     await Promise.resolve();
+    await control.updateComplete;
     expect(new FormData(form).has('entry')).toBe(false);
     expect((control.shadowRoot?.querySelector('input') as HTMLInputElement).disabled).toBe(true);
   });

--- a/tests/reactive-element.spec.ts
+++ b/tests/reactive-element.spec.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GluonElement,
+  defineElement,
+  html,
+  setGluonRenderDebugHook,
+  type GluonRenderDebugEvent,
+  type PropertyDeclarations,
+} from '../src/index.js';
+import {
+  nextTick,
+  onScopeDispose,
+  reactive,
+  setReactivityErrorHandler,
+  watchEffect,
+} from '@gluonjs/reactivity';
+
+let reactiveElementSequence = 0;
+
+describe('reactive GluonElement rendering', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('tracks only render dependencies and batches synchronous writes', async () => {
+    const tagName = `gluon-reactive-${reactiveElementSequence += 1}` as `${string}-${string}`;
+
+    class ReactiveElement extends GluonElement {
+      readonly state = reactive({ count: 0, visible: true, ignored: 0 });
+      renders = 0;
+
+      protected override render() {
+        this.renders += 1;
+        return html`<output>${this.state.visible ? this.state.count : 'hidden'}</output>`;
+      }
+    }
+
+    defineElement(tagName, ReactiveElement);
+    const element = document.createElement(tagName) as ReactiveElement;
+    document.body.append(element);
+    await element.updateComplete;
+    expect(element.renders).toBe(1);
+    expect(element.shadowRoot?.textContent).toBe('0');
+
+    element.state.ignored = 1;
+    await nextTick();
+    expect(element.renders).toBe(1);
+
+    element.state.count = 1;
+    element.state.count = 2;
+    element.state.count = 3;
+    await element.updateComplete;
+    expect(element.renders).toBe(2);
+    expect(element.shadowRoot?.textContent).toBe('3');
+
+    element.state.visible = false;
+    await element.updateComplete;
+    expect(element.renders).toBe(3);
+    expect(element.shadowRoot?.textContent).toBe('hidden');
+
+    element.state.count = 4;
+    await nextTick();
+    expect(element.renders).toBe(3);
+  });
+
+  it('stops scoped work on disconnect and recreates it while retaining state and DOM', async () => {
+    const tagName = `gluon-scope-${reactiveElementSequence += 1}` as `${string}-${string}`;
+
+    class ScopedElement extends GluonElement {
+      readonly state = reactive({ count: 0, watched: 0 });
+      readonly click = vi.fn();
+      readonly buttonRef: { value?: Element } = {};
+      renders = 0;
+      watcherRuns = 0;
+      scopeDisposals = 0;
+      private watcherInstalled = false;
+
+      override disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.watcherInstalled = false;
+      }
+
+      protected override update(): void {
+        if (!this.watcherInstalled) {
+          this.watcherInstalled = true;
+          watchEffect(() => {
+            this.state.watched;
+            this.watcherRuns += 1;
+          });
+          onScopeDispose(() => {
+            this.scopeDisposals += 1;
+          });
+        }
+        super.update();
+      }
+
+      protected override render() {
+        this.renders += 1;
+        return html`
+          <button ...=${{ ref: this.buttonRef, onClick: this.click }}>${this.state.count}</button>
+        `;
+      }
+    }
+
+    defineElement(tagName, ScopedElement);
+    const element = document.createElement(tagName) as ScopedElement;
+    document.body.append(element);
+    await element.updateComplete;
+    const retainedButton = element.buttonRef.value as HTMLButtonElement;
+    retainedButton.click();
+    expect(element.click).toHaveBeenCalledOnce();
+    expect(element.watcherRuns).toBe(1);
+
+    element.state.count = 1;
+    const cancelledUpdate = element.updateComplete;
+    element.remove();
+    await expect(cancelledUpdate).resolves.toBeUndefined();
+    await nextTick();
+    expect(element.renders).toBe(1);
+    expect(element.scopeDisposals).toBe(1);
+    expect(element.buttonRef.value).toBeUndefined();
+
+    element.state.count = 2;
+    element.state.watched = 1;
+    await nextTick();
+    retainedButton.click();
+    expect(element.renders).toBe(1);
+    expect(element.watcherRuns).toBe(1);
+    expect(element.click).toHaveBeenCalledOnce();
+
+    document.body.append(element);
+    await element.updateComplete;
+    expect(element.renders).toBe(2);
+    expect(element.watcherRuns).toBe(2);
+    expect(element.buttonRef.value).toBe(retainedButton);
+    expect(retainedButton.textContent).toBe('2');
+    retainedButton.click();
+    expect(element.click).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports batched render causes, tracked dependencies, and timings', async () => {
+    const tagName = `gluon-debug-${reactiveElementSequence += 1}` as `${string}-${string}`;
+    const events: GluonRenderDebugEvent[] = [];
+    const restore = setGluonRenderDebugHook((event) => events.push(event));
+
+    class DebugElement extends GluonElement {
+      static override readonly properties: PropertyDeclarations = {
+        label: { default: 'initial' },
+      };
+
+      declare label: string;
+      readonly state = reactive({ count: 0, ignored: 0 });
+
+      protected override render() {
+        return html`<output>${this.label}:${this.state.count}</output>`;
+      }
+    }
+
+    try {
+      defineElement(tagName, DebugElement);
+      const element = document.createElement(tagName) as DebugElement;
+      document.body.append(element);
+      await element.updateComplete;
+
+      expect(events).toHaveLength(1);
+      expect(events[0]?.causes).toEqual([{ type: 'connection' }]);
+      expect(events[0]?.dependencies.some((dependency) => dependency.key === 'count')).toBe(true);
+      events.length = 0;
+
+      element.state.count = 1;
+      element.state.count = 2;
+      element.label = 'updated';
+      await element.updateComplete;
+
+      expect(events).toHaveLength(1);
+      const event = events[0] as GluonRenderDebugEvent;
+      expect(event.element).toBe(element);
+      expect(event.causes.filter((cause) => cause.type === 'reactive')).toHaveLength(2);
+      expect(event.causes).toContainEqual(expect.objectContaining({
+        type: 'property',
+        name: 'label',
+        value: 'updated',
+        oldValue: 'initial',
+      }));
+      const reactiveCauses = event.causes.filter((cause) => cause.type === 'reactive');
+      expect(reactiveCauses.every((cause) => cause.dependency.key === 'count')).toBe(true);
+      expect(event.dependencies.some((dependency) => dependency.key === 'count')).toBe(true);
+      expect(event.endedAt).toBeGreaterThanOrEqual(event.startedAt);
+      expect(event.duration).toBe(event.endedAt - event.startedAt);
+      expect(event.failed).toBe(false);
+      expect(element.shadowRoot?.textContent).toBe('updated:2');
+
+      events.length = 0;
+      element.state.ignored = 1;
+      await nextTick();
+      expect(events).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('reports failed renders without losing reactive recovery', async () => {
+    const tagName = `gluon-failure-${reactiveElementSequence += 1}` as `${string}-${string}`;
+    const diagnostics: GluonRenderDebugEvent[] = [];
+    const reactiveErrors: unknown[] = [];
+    const restoreDebug = setGluonRenderDebugHook((event) => diagnostics.push(event));
+    const restoreErrors = setReactivityErrorHandler(({ error }) => {
+      reactiveErrors.push(error);
+    });
+
+    class FailureElement extends GluonElement {
+      readonly state = reactive({ fail: false });
+
+      protected override render() {
+        if (this.state.fail) throw new Error('render failed');
+        return html`<p>recovered</p>`;
+      }
+    }
+
+    try {
+      defineElement(tagName, FailureElement);
+      const element = document.createElement(tagName) as FailureElement;
+      document.body.append(element);
+      await element.updateComplete;
+      diagnostics.length = 0;
+
+      element.state.fail = true;
+      await expect(element.updateComplete).rejects.toThrow('render failed');
+      expect(reactiveErrors).toHaveLength(1);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toMatchObject({
+        element,
+        failed: true,
+        error: expect.objectContaining({ message: 'render failed' }),
+      });
+
+      element.state.fail = false;
+      await element.updateComplete;
+      expect(element.shadowRoot?.textContent).toBe('recovered');
+      expect(diagnostics.at(-1)?.failed).toBe(false);
+    } finally {
+      restoreErrors();
+      restoreDebug();
+    }
+  });
+
+  it('contains development observer failures without failing the render', async () => {
+    const tagName = `gluon-debug-error-${reactiveElementSequence += 1}` as `${string}-${string}`;
+    const reported = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.stubGlobal('reportError', reported);
+    const restore = setGluonRenderDebugHook(() => {
+      throw new Error('observer failed');
+    });
+
+    class DebugErrorElement extends GluonElement {
+      protected override render() {
+        return html`<p>rendered</p>`;
+      }
+    }
+
+    try {
+      defineElement(tagName, DebugErrorElement);
+      const element = document.createElement(tagName) as DebugErrorElement;
+      document.body.append(element);
+      await expect(element.updateComplete).resolves.toBeUndefined();
+      expect(element.shadowRoot?.textContent).toBe('rendered');
+      expect(reported).toHaveBeenCalledOnce();
+      expect(reported.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+        message: 'observer failed',
+      }));
+
+      element.remove();
+      vi.stubGlobal('reportError', undefined);
+      document.body.append(element);
+      await element.updateComplete;
+      expect(consoleError).toHaveBeenCalledOnce();
+      expect(consoleError.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+        message: 'observer failed',
+      }));
+    } finally {
+      restore();
+      consoleError.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('disables render diagnostics in production mode', async () => {
+    const tagName = `gluon-production-${reactiveElementSequence += 1}` as `${string}-${string}`;
+    const diagnostic = vi.fn();
+    vi.stubGlobal('process', { env: { NODE_ENV: 'production' } });
+    const restore = setGluonRenderDebugHook(diagnostic);
+
+    class ProductionElement extends GluonElement {
+      readonly state = reactive({ count: 0 });
+
+      protected override render() {
+        return html`<p>${this.state.count}</p>`;
+      }
+    }
+
+    try {
+      defineElement(tagName, ProductionElement);
+      const element = document.createElement(tagName) as ProductionElement;
+      document.body.append(element);
+      await element.updateComplete;
+      element.state.count = 1;
+      await element.updateComplete;
+      expect(element.shadowRoot?.textContent).toBe('1');
+      expect(diagnostic).not.toHaveBeenCalled();
+    } finally {
+      restore();
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,6 +6,9 @@
     "emitDeclarationOnly": true,
     "outDir": "dist/types",
     "rootDir": "src",
+    "paths": {
+      "@gluonjs/reactivity": ["packages/reactivity/dist/index.d.ts"]
+    },
     "stripInternal": true
   },
   "include": ["src/**/*.ts"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,10 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@gluonjs/reactivity": ["packages/reactivity/src/index.ts"]
+    },
     "types": ["node"],
     "strict": true,
     "noUncheckedIndexedAccess": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,11 @@ const entry = {
 };
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@gluonjs/reactivity': resolve(import.meta.dirname, 'packages/reactivity/src/index.ts'),
+    },
+  },
   build: {
     emptyOutDir: true,
     minify: 'oxc',
@@ -20,6 +25,7 @@ export default defineConfig({
       formats: ['es'],
     },
     rollupOptions: {
+      external: ['@gluonjs/reactivity'],
       output: {
         entryFileNames: '[name].js',
       },
@@ -36,6 +42,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**/*.ts'],
+      exclude: ['packages/**'],
       reporter: ['text', 'html'],
       thresholds: {
         statements: 95,


### PR DESCRIPTION
Closes #22

## Summary
- run each connected `GluonElement` update inside a lazy, detached reactive effect scope
- queue declared-property, manual, and reactive invalidations through one deduplicated update-phase runner
- rebuild conditional render dependencies on every execution and preserve `updateComplete` for scheduled/cancelled work
- stop render effects, owned watchers, scheduler jobs, directives, listeners, and refs on disconnect
- recreate reactive ownership on reconnect while retaining current state and matching Shadow DOM
- expose development render diagnostics with batched causes, tracked dependencies, timings, and failure details
- declare and externally preserve the official `@gluonjs/core` → `@gluonjs/reactivity` package dependency
- add lazy/update-phase effect support and an eager scheduling hook to Reactivity
- document the reactive Custom Element contract, architecture, roadmap state, and changelogs

## Verification
- `npm run check`
  - Core browser: 63 tests passed
  - Core coverage: 96.75% statements, 93.62% branches, 100% functions, 97.92% lines
  - Reactivity: 65 tests passed
  - Reactivity coverage: 99.06% statements, 95.30% branches, 100% functions, 99.81% lines
  - Core and Reactivity builds passed
  - Core and Reactivity generated declaration contracts passed
  - package contract validation passed for all 16 package entries
- clean-build simulation with both `dist` directories absent: `npm run build:core` passed
- `npm audit --audit-level=moderate`: 0 vulnerabilities
- `git diff --check`
- independent `gpt-5.4-mini` review found and verified the clean-build fix; focused re-review: no actionable findings