### PR TITLE
Add isolated application runtime, lifecycle, and error ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and released versions follow [Semantic Versioning](https://semver.org/).
   DOM recovery, and pre-upgrade property precedence.
 - Scope-owned reactive `GluonElement` rendering through the shared update
   scheduler, including reconnect retention and render-cause/timing diagnostics.
+- Isolated application instances with plugins, typed providers, dynamic
+  functional components, lifecycle hooks, warnings, error boundaries,
+  event/async ownership, deterministic unmount, and controlled exposure.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 - nested templates, index-based arrays, and keyed `repeat()` reconciliation
 - standalone DOM-free reactivity with refs, proxies, effects, and computed values
 - reactive Custom Elements through `GluonElement`
+- isolated application instances with plugins, providers, lifecycle, dynamic
+  functional components, error boundaries, and controlled public exposure
 - constructable `CSSStyleSheet` creation and `adoptedStyleSheets` adoption only
 - typed `q.<tag>()` Quark factories for `HTMLElementTagNameMap`
 - working Atom, Molecule, and Organism entry points
@@ -219,6 +221,28 @@ after commit, and disconnect stops owned effects while retaining state and
 matching DOM for reconnection. The complete behavior and development render
 diagnostics are defined in the
 [Reactive Custom Element contract](docs/reactive-elements.md).
+
+## Application runtime
+
+`createApp()` owns one renderer root and reactive scope while keeping plugins,
+providers, component registrations, configuration, warnings, and errors
+isolated from every other application on the page:
+
+```ts
+import { createApp, createInjectionKey, html, inject } from '@gluonjs/core';
+
+const greetingKey = createInjectionKey<string>('greeting');
+const app = createApp(() => html`<h1>${inject(greetingKey)}</h1>`);
+
+app.provide(greetingKey, 'Hello Gluon');
+const mount = app.mount(document.querySelector('#app')!);
+mount.unmount();
+```
+
+Application and component lifecycle, plugin cleanup, dynamic component
+registries, error/warning ownership, event/async protection, and explicit
+public exposure are defined in the
+[Application runtime contract](docs/application-runtime.md).
 
 ## Adopted stylesheets only
 

--- a/docs/application-runtime.md
+++ b/docs/application-runtime.md
@@ -1,0 +1,157 @@
+# Application runtime contract
+
+`createApp()` adds application-scoped ownership around Gluon's renderer and
+Custom Elements without creating a second managed component-instance model.
+Stateful components remain `GluonElement` instances; functional components
+remain render functions.
+
+## Create, configure, and mount
+
+```ts
+import {
+  createApp,
+  createInjectionKey,
+  dynamicComponent,
+  html,
+  inject,
+} from '@gluonjs/core';
+import { reactive } from '@gluonjs/reactivity';
+
+const storeKey = createInjectionKey<{ count: number }>('counter');
+
+const app = createApp<{ increment(): void }>((context) => {
+  const store = inject(storeKey);
+  context.expose({ increment: () => { store.count += 1; } });
+  return html`<main>${dynamicComponent('counter', store)}</main>`;
+});
+
+app.provide(storeKey, reactive({ count: 0 }));
+app.component<{ count: number }>('counter', ({ count }) => html`
+  <output>${count}</output>
+`);
+app.config.globalProperties.locale = 'en';
+
+const mount = app.mount(document.querySelector('#app')!);
+mount.exposed?.increment();
+mount.unmount();
+```
+
+An application has three states: created, mounted, and unmounted. Plugins,
+providers, functional component registrations, and application hooks are
+registered while created. One application mounts once. A container can own one
+application at a time and becomes available to another application after
+unmount.
+
+The root is a `TemplateResult` or a function returning one. Root functions run
+inside an application-owned effect scope and update-phase reactive effect.
+Reactive values read by the root therefore invalidate only that application.
+
+## Per-application isolation
+
+Every application owns independent instances of:
+
+- its plugin installation set and reverse-order cleanup stack;
+- its typed provider map;
+- its named functional component registry;
+- `config.errorHandler`, `config.warnHandler`, and `config.globalProperties`;
+- its root effect scope, renderer root, lifecycle hooks, and public exposure.
+
+`createInjectionKey<Value>()` preserves the provided value type. `inject()` is
+valid while an application root, functional component, element update, event,
+or lifecycle callback owns the active context. A fallback is returned only when
+one is supplied; otherwise a missing injection throws a deterministic error.
+Reactive stores are ordinary provided values until the official store package
+in issue #26 adds its higher-level contract.
+
+`app.use(plugin, options)` installs each plugin identity once. A synchronous
+cleanup function returned by `install` runs during unmount in reverse install
+order. Repeated installation warns with `GLUON_PLUGIN_DUPLICATE`. Plugin errors
+use the owning application's error handler.
+
+`dynamicComponent(component, props)` accepts a functional component directly
+or resolves a name from the current application's registry. Missing named
+components render no child and warn with `GLUON_COMPONENT_MISSING`. Custom
+Elements remain explicitly registered through `defineElement`; the application
+registry does not replace the platform's document-wide `CustomElementRegistry`.
+
+## Mount and unmount ordering
+
+Mount performs these steps:
+
+1. claim and register the container's application context;
+2. create the detached application effect scope and lazy root effect;
+3. synchronously perform the initial root render;
+4. run `app.onMounted` callbacks after the first successful commit.
+
+Unmount is idempotent after a successful mount and performs:
+
+1. mark the application unmounted and stop/invalidate its effect scope;
+2. permanently unmount renderer bindings and clear the container;
+3. run `app.onUnmounted` callbacks in registration order;
+4. run plugin cleanups in reverse installation order;
+5. release the container registration, public exposure, providers, and
+   functional component registry.
+
+Queued root effects cannot execute after unmount. Renderer unmount releases
+directives, native event listeners, and refs. Scope stopping continues through
+all owned effects even if one `onStop` hook fails; the failure enters the
+scope/application cleanup error channel. A failing renderer cleanup likewise
+enters that channel without skipping application hooks or plugin cleanups.
+
+## Component lifecycle
+
+`GluonElement` subclasses register connection lifecycle callbacks with the
+protected methods below, normally in their constructor:
+
+- `onConnected`: after the first successful render of each connection;
+- `onBeforeUpdate`: before every later render in that connection;
+- `onUpdated`: after every successful initial or later render;
+- `onDisconnected`: after scope cleanup and renderer suspension;
+- `onErrorCaptured`: capture descendant component errors.
+
+Connection order is `render → onConnected → onUpdated`. Later updates use
+`onBeforeUpdate → render → onUpdated`. Disconnect stops the connection scope,
+suspends DOM resources, then runs `onDisconnected`. Reconnection creates a new
+scope, retains state and matching DOM, and begins again with the connection
+order. Promise rejections returned by lifecycle callbacks are routed as
+`lifecycle` errors.
+
+Effects, watchers, and `onScopeDispose()` registrations created while an
+element update executes belong to that connection scope. Resource creation must
+still be guarded against accidental duplication on every render.
+
+## Errors, warnings, and boundaries
+
+Application error information includes the app, thrown value, source, and
+optional originating element. Sources are `application`, `render`, `effect`,
+`event`, `async`, `lifecycle`, and `plugin`.
+
+Element render effects and scope-owned effects/watchers route through the
+closest ancestor `onErrorCaptured` handler. Returning `true` marks the error
+handled. Otherwise it reaches the owning `app.config.errorHandler`; standalone
+components use the Reactivity/platform fallback. A boundary failure itself
+reaches the application handler as an `application` error.
+
+Event listeners created during app or element rendering are automatically
+wrapped while preserving listener identity, native `this`, objects with
+`handleEvent`, and removal options. Synchronous throws use source `event` and a
+returned promise rejection uses `async`.
+
+`app.run(callback)` binds manually started synchronous or asynchronous work to
+one application. `runWithErrorHandling(callback)` binds work to the currently
+active application/element owner. Arbitrary work started later without either
+owner cannot be attributed automatically and uses the platform fallback.
+
+Warnings use the current application's `warnHandler`; `warn(message, code)` is
+the public manual entry point. Warning-handler failures enter the application
+error channel rather than changing the caller's control flow.
+
+## Controlled public exposure
+
+An application root exposes only the value passed to `context.expose`; the
+mount handle never returns internal application state. An element subclass can
+likewise call protected `expose(value)`, and consumers retrieve only that value
+with the explicitly typed `getPublicInstance<Public>(element)` helper. Exposure
+objects are frozen at the boundary. The application mount exposure is cleared
+when that application unmounts; element exposure remains attached to the element
+across its documented reconnect lifecycle.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,8 @@ tree-shakable.
 
 ```text
 src/
+├── application.ts      App instances, plugins, providers, registries, mount
+├── application-context.ts  Context propagation, event guards, errors, warnings
 ├── runtime.ts          Template results, compiler plans, Parts, spreading, render
 ├── element.ts          Reactive Custom Element base and definition helper
 ├── component.ts        Atom, Molecule, and Organism metadata helpers
@@ -107,6 +109,25 @@ The production binding semantics for forms, lifecycle directives, event
 options, qualified namespaces, unsafe-content boundaries, root suspension,
 permanent unmount, and external DOM recovery are specified by the
 [DOM runtime contract](dom-runtime.md).
+
+## Application runtime
+
+`createApp` owns a renderer container, detached reactive scope, plugin cleanup
+stack, provider map, functional component registry, configuration, and explicit
+public exposure. Container-to-context ownership uses weak roots. A connected
+`GluonElement` walks its composed ancestry to resolve the nearest root, so
+nested applications override outer context without a process-global registry.
+
+Application root functions and element update/lifecycle callbacks run inside a
+synchronous context frame. That frame supplies typed injection, error ownership,
+warning ownership, and stable event-listener guards. Runtime event Parts capture
+the frame while they install a listener, preserving native listener behavior
+while routing synchronous throws and returned promise rejections.
+
+Custom Elements remain the only stateful component instances. Per-app named
+components are functional render functions; they do not own state, lifecycle,
+or a second DOM identity. The complete isolation, ordering, failure, and cleanup
+contract is documented in [Application runtime](application-runtime.md).
 
 ### List identity
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -58,13 +58,15 @@ Gluon currently provides:
 - deterministic batching, phased scheduling, `nextTick`, effect scopes, and watchers
 - scope-owned reactive render effects, batched declared properties, reconnect
   retention, and render diagnostics through `GluonElement`
+- isolated application instances with plugins, providers, dynamic functional
+  component registries, lifecycle, warnings, error boundaries, and exposure
 - constructable stylesheet creation and adopted stylesheet management
 - typed Quark factories for native HTML elements
 - representative Atom, Molecule, and Organism packages
 - ESM builds, TypeScript declarations, Chromium tests, and coverage thresholds
 
-The current repository does not provide an application runtime, routing, shared
-state management, SSR, hydration, SSG, Gluon-specific
+The current repository does not provide routing, an official shared-state
+package, SSR, hydration, SSG, Gluon-specific
 HMR, language tooling, Devtools, consumer test utilities, or a public release.
 
 ## Product principles

--- a/packages/reactivity/CHANGELOG.md
+++ b/packages/reactivity/CHANGELOG.md
@@ -11,3 +11,5 @@
   routing.
 - Lazy effects, update-phase effect scheduling, and an eager invalidation hook
   for render-owner integration.
+- Scope stopping continues through remaining owned effects and cleanup when an
+  effect stop hook fails.

--- a/packages/reactivity/README.md
+++ b/packages/reactivity/README.md
@@ -57,6 +57,8 @@ An attached scope stops its owned effects in reverse creation order, then child
 scopes in reverse creation order, then cleanup callbacks in reverse registration
 order. A detached scope has independent ownership. Stopping a scope cancels its
 queued effects and watchers and prevents their runners from executing again.
+If an effect stop hook throws, the scope reports a cleanup error and continues
+stopping the remaining effects and resources.
 
 Errors are delivered to the closest explicit effect, watcher, job, or scope
 handler. When no local handler exists, the handler installed by

--- a/packages/reactivity/src/scope.ts
+++ b/packages/reactivity/src/scope.ts
@@ -56,7 +56,12 @@ export class EffectScope {
     this.stopped = true;
 
     for (let index = this.effects.length - 1; index >= 0; index -= 1) {
-      this.effects[index]?.stop(true);
+      const effect = this.effects[index];
+      try {
+        effect?.stop(true);
+      } catch (error) {
+        reportReactivityError(error, 'cleanup', effect, this.onError);
+      }
     }
     for (let index = this.childScopes.length - 1; index >= 0; index -= 1) {
       this.childScopes[index]?.stop();

--- a/src/application-context.ts
+++ b/src/application-context.ts
@@ -1,0 +1,289 @@
+import type { TemplateResult, TemplateValue } from './runtime.js';
+
+declare const injectionValue: unique symbol;
+
+export type InjectionKey<Value> = symbol & {
+  readonly [injectionValue]?: Value;
+};
+
+export type AppErrorSource =
+  | 'application'
+  | 'render'
+  | 'effect'
+  | 'event'
+  | 'async'
+  | 'lifecycle'
+  | 'plugin';
+
+export interface AppErrorInfo {
+  readonly app: GluonApp;
+  readonly error: unknown;
+  readonly source: AppErrorSource;
+  readonly element?: Element;
+}
+
+export interface AppWarningInfo {
+  readonly app: GluonApp;
+  readonly message: string;
+  readonly code?: string;
+  readonly element?: Element;
+}
+
+export type AppErrorHandler = (info: AppErrorInfo) => void | PromiseLike<void>;
+export type AppWarningHandler = (info: AppWarningInfo) => void;
+
+export interface AppConfig {
+  errorHandler?: AppErrorHandler;
+  warnHandler?: AppWarningHandler;
+  readonly globalProperties: Record<string, unknown>;
+}
+
+export type FunctionalComponent<Props = Readonly<Record<string, unknown>>> = (
+  props: Readonly<Props>,
+) => TemplateValue;
+
+export type AppPluginCleanup = () => void | PromiseLike<void>;
+
+export interface GluonPlugin<Options = void> {
+  install(
+    app: GluonApp,
+    options: Options,
+  ): void | AppPluginCleanup;
+}
+
+export type GluonPluginFunction<Options = void> = (
+  app: GluonApp,
+  options: Options,
+) => void | AppPluginCleanup;
+
+export type GluonAppPlugin<Options = void> =
+  | GluonPlugin<Options>
+  | GluonPluginFunction<Options>;
+
+export interface AppRootRenderContext<Public> {
+  readonly app: GluonApp<Public>;
+  expose(value: Public): void;
+  inject<Value>(key: InjectionKey<Value>): Value;
+  inject<Value>(key: InjectionKey<Value>, fallback: Value): Value;
+  component<Props>(name: string, props: Readonly<Props>): TemplateValue;
+}
+
+export type AppRoot<Public = unknown> =
+  | TemplateResult
+  | ((context: AppRootRenderContext<Public>) => TemplateResult);
+
+export interface AppMount<Public = unknown> {
+  readonly app: GluonApp<Public>;
+  readonly container: Element | DocumentFragment;
+  readonly exposed: Readonly<Public> | undefined;
+  unmount(): void;
+}
+
+export interface GluonApp<Public = unknown> {
+  readonly config: AppConfig;
+  readonly mounted: boolean;
+  use<Options>(plugin: GluonAppPlugin<Options>, options: Options): this;
+  use(plugin: GluonAppPlugin<void>): this;
+  provide<Value>(key: InjectionKey<Value>, value: Value): this;
+  component<Props>(name: string, component: FunctionalComponent<Props>): this;
+  onMounted(callback: () => void | PromiseLike<void>): this;
+  onUnmounted(callback: () => void | PromiseLike<void>): this;
+  mount(container: Element | DocumentFragment): AppMount<Public>;
+  unmount(): void;
+  run<Result>(callback: () => Result | PromiseLike<Result>): Result | Promise<Result | undefined> | undefined;
+}
+
+export interface ApplicationContext {
+  readonly app: GluonApp;
+  readonly config: AppConfig;
+  readonly provides: Map<InjectionKey<unknown>, unknown>;
+  readonly components: Map<string, FunctionalComponent<unknown>>;
+}
+
+interface RuntimeFrame {
+  readonly context?: ApplicationContext;
+  readonly element?: Element;
+  readonly handleError: (error: unknown, source: AppErrorSource) => void;
+}
+
+const applicationRoots = new WeakMap<Node, ApplicationContext>();
+const eventWrappers = new WeakMap<object, WeakMap<object, EventListener>>();
+let activeFrame: RuntimeFrame | undefined;
+
+export function createInjectionKey<Value>(description?: string): InjectionKey<Value> {
+  return Symbol(description) as InjectionKey<Value>;
+}
+
+export function registerApplicationRoot(root: Node, context: ApplicationContext): void {
+  applicationRoots.set(root, context);
+}
+
+export function unregisterApplicationRoot(root: Node, context: ApplicationContext): void {
+  if (applicationRoots.get(root) === context) applicationRoots.delete(root);
+}
+
+export function resolveApplicationContext(node: Node): ApplicationContext | undefined {
+  let current: Node | null = node;
+  while (current) {
+    const context = applicationRoots.get(current);
+    if (context) return context;
+    if (current.parentNode) {
+      current = current.parentNode;
+    } else if (current instanceof ShadowRoot) {
+      current = current.host;
+    } else {
+      current = null;
+    }
+  }
+  return undefined;
+}
+
+export function runWithApplicationContext<Result>(
+  context: ApplicationContext | undefined,
+  element: Element | undefined,
+  handleError: RuntimeFrame['handleError'],
+  callback: () => Result,
+): Result {
+  const previous = activeFrame;
+  activeFrame = { context, element, handleError };
+  try {
+    return callback();
+  } finally {
+    activeFrame = previous;
+  }
+}
+
+export function getActiveApplicationContext(): ApplicationContext | undefined {
+  return activeFrame?.context;
+}
+
+export function getActiveElement(): Element | undefined {
+  return activeFrame?.element;
+}
+
+export function reportApplicationError(
+  context: ApplicationContext | undefined,
+  error: unknown,
+  source: AppErrorSource,
+  element?: Element,
+): void {
+  const handler = context?.config.errorHandler;
+  if (!context || !handler) {
+    reportUnhandledError(error);
+    return;
+  }
+
+  const info = { app: context.app, error, source, ...(element ? { element } : {}) };
+  try {
+    const result = handler(info);
+    if (isPromiseLike(result)) {
+      void Promise.resolve(result).catch(reportUnhandledError);
+    }
+  } catch (handlerError) {
+    reportUnhandledError(handlerError);
+  }
+}
+
+export function reportApplicationWarning(
+  context: ApplicationContext | undefined,
+  message: string,
+  code?: string,
+  element?: Element,
+): void {
+  const handler = context?.config.warnHandler;
+  if (context && handler) {
+    try {
+      handler({ app: context.app, message, ...(code ? { code } : {}), ...(element ? { element } : {}) });
+      return;
+    } catch (error) {
+      reportApplicationError(context, error, 'application', element);
+      return;
+    }
+  }
+
+  try {
+    globalThis.console?.warn?.(code ? `[${code}] ${message}` : message);
+  } catch {
+    // Warning reporting cannot change application execution.
+  }
+}
+
+export function warn(message: string, code?: string): void {
+  reportApplicationWarning(activeFrame?.context, message, code, activeFrame?.element);
+}
+
+export function guardEventListener(
+  listener: EventListenerOrEventListenerObject,
+): EventListenerOrEventListenerObject {
+  const frame = activeFrame;
+  if (!frame) return listener;
+  const listenerKey = listener as object;
+  const ownerKey = (frame.element ?? frame.context?.app) as object | undefined;
+  if (!ownerKey) return listener;
+  let owners = eventWrappers.get(listenerKey);
+  if (!owners) {
+    owners = new WeakMap();
+    eventWrappers.set(listenerKey, owners);
+  }
+  const cached = owners.get(ownerKey);
+  if (cached) return cached;
+
+  const guarded = function guardedEventListener(this: EventTarget, event: Event): void {
+    try {
+      const result = runWithApplicationContext(
+        frame.context,
+        frame.element,
+        frame.handleError,
+        () => typeof listener === 'function'
+          ? (listener as unknown as (this: EventTarget, event: Event) => unknown).call(this, event)
+          : (listener as EventListenerObject).handleEvent(event),
+      );
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).catch((error: unknown) => frame.handleError(error, 'async'));
+      }
+    } catch (error) {
+      frame.handleError(error, 'event');
+    }
+  };
+  owners.set(ownerKey, guarded);
+  return guarded;
+}
+
+export function runActiveGuarded<Result>(
+  callback: () => Result | PromiseLike<Result>,
+  source: AppErrorSource = 'async',
+): Result | Promise<Result | undefined> | undefined {
+  const frame = activeFrame;
+  try {
+    const result = callback();
+    if (!isPromiseLike(result)) return result;
+    return Promise.resolve(result).catch((error: unknown) => {
+      if (frame) frame.handleError(error, source);
+      else reportUnhandledError(error);
+      return undefined;
+    });
+  } catch (error) {
+    if (frame) frame.handleError(error, source);
+    else reportUnhandledError(error);
+    return undefined;
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  ) && typeof Reflect.get(value, 'then') === 'function';
+}
+
+function reportUnhandledError(error: unknown): void {
+  try {
+    const environment = globalThis as {
+      reportError?: (reason: unknown) => void;
+      console?: { error?: (...values: unknown[]) => void };
+    };
+    if (typeof environment.reportError === 'function') environment.reportError(error);
+    else environment.console?.error?.(error);
+  } catch {
+    // The default error channel must remain contained.
+  }
+}

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,0 +1,354 @@
+import {
+  effect,
+  effectScope,
+  type EffectScope,
+  type ReactiveEffectRunner,
+  type ReactivityErrorContext,
+} from '@gluonjs/reactivity';
+import {
+  createInjectionKey,
+  getActiveApplicationContext,
+  getActiveElement,
+  registerApplicationRoot,
+  reportApplicationError,
+  reportApplicationWarning,
+  runActiveGuarded,
+  runWithApplicationContext,
+  unregisterApplicationRoot,
+  warn,
+  type AppConfig,
+  type AppErrorSource,
+  type AppMount,
+  type AppPluginCleanup,
+  type AppRoot,
+  type AppRootRenderContext,
+  type ApplicationContext,
+  type FunctionalComponent,
+  type GluonApp,
+  type GluonAppPlugin,
+  type InjectionKey,
+} from './application-context.js';
+import {
+  isTemplateResult,
+  nothing,
+  render,
+  unmount as unmountRender,
+  type TemplateResult,
+  type TemplateValue,
+} from './runtime.js';
+
+const mountedContainers = new WeakMap<Node, GluonAppImpl<unknown>>();
+let applicationSequence = 1_000_000;
+
+export {
+  createInjectionKey,
+  runActiveGuarded as runWithErrorHandling,
+  warn,
+  type AppConfig,
+  type AppErrorHandler,
+  type AppErrorInfo,
+  type AppErrorSource,
+  type AppMount,
+  type AppPluginCleanup,
+  type AppRoot,
+  type AppRootRenderContext,
+  type AppWarningHandler,
+  type AppWarningInfo,
+  type FunctionalComponent,
+  type GluonApp,
+  type GluonAppPlugin,
+  type GluonPlugin,
+  type GluonPluginFunction,
+  type InjectionKey,
+} from './application-context.js';
+
+export function inject<Value>(key: InjectionKey<Value>): Value;
+export function inject<Value>(key: InjectionKey<Value>, fallback: Value): Value;
+export function inject<Value>(key: InjectionKey<Value>, fallback?: Value): Value {
+  const context = getActiveApplicationContext();
+  if (context?.provides.has(key as InjectionKey<unknown>)) {
+    return context.provides.get(key as InjectionKey<unknown>) as Value;
+  }
+  if (arguments.length >= 2) return fallback as Value;
+  throw new Error(`Missing Gluon application injection for ${String(key.description ?? key)}.`);
+}
+
+export function dynamicComponent<Props>(
+  component: string | FunctionalComponent<Props>,
+  props: Readonly<Props>,
+): TemplateValue {
+  const context = getActiveApplicationContext();
+  const resolved = typeof component === 'string'
+    ? context?.components.get(component) as FunctionalComponent<Props> | undefined
+    : component;
+  if (!resolved) {
+    reportApplicationWarning(
+      context,
+      `Application component "${String(component)}" is not registered.`,
+      'GLUON_COMPONENT_MISSING',
+      getActiveElement(),
+    );
+    return nothing;
+  }
+  return resolved(props);
+}
+
+export function createApp<Public = unknown>(root: AppRoot<Public>): GluonApp<Public> {
+  return new GluonAppImpl(root);
+}
+
+class GluonAppImpl<Public> implements GluonApp<Public> {
+  readonly config: AppConfig = { globalProperties: {} };
+  readonly context: ApplicationContext;
+  private readonly root: AppRoot<Public>;
+  private readonly plugins = new Set<GluonAppPlugin<unknown>>();
+  private readonly pluginCleanups: AppPluginCleanup[] = [];
+  private readonly mountedHooks: Array<() => void | PromiseLike<void>> = [];
+  private readonly unmountedHooks: Array<() => void | PromiseLike<void>> = [];
+  private readonly updateId = applicationSequence;
+  private state: 'created' | 'mounted' | 'unmounted' = 'created';
+  private container?: Element | DocumentFragment;
+  private scope?: EffectScope;
+  private runner?: ReactiveEffectRunner<void | undefined>;
+  private publicExposure?: Readonly<Public>;
+  private rootCommitted = false;
+
+  constructor(root: AppRoot<Public>) {
+    applicationSequence += 1;
+    this.root = root;
+    this.context = {
+      app: this as GluonApp,
+      config: this.config,
+      provides: new Map(),
+      components: new Map(),
+    };
+  }
+
+  get mounted(): boolean {
+    return this.state === 'mounted';
+  }
+
+  use<Options>(plugin: GluonAppPlugin<Options>, options: Options): this;
+  use(plugin: GluonAppPlugin<void>): this;
+  use<Options>(plugin: GluonAppPlugin<Options>, options?: Options): this {
+    this.assertConfigurable('install plugins');
+    const untypedPlugin = plugin as GluonAppPlugin<unknown>;
+    if (this.plugins.has(untypedPlugin)) {
+      reportApplicationWarning(this.context, 'The application plugin is already installed.', 'GLUON_PLUGIN_DUPLICATE');
+      return this;
+    }
+    this.plugins.add(untypedPlugin);
+    try {
+      const cleanup = typeof plugin === 'function'
+        ? plugin(this, options as Options)
+        : plugin.install(this, options as Options);
+      if (typeof cleanup === 'function') this.pluginCleanups.push(cleanup);
+    } catch (error) {
+      reportApplicationError(this.context, error, 'plugin');
+    }
+    return this;
+  }
+
+  provide<Value>(key: InjectionKey<Value>, value: Value): this {
+    this.assertConfigurable('provide application values');
+    this.context.provides.set(key as InjectionKey<unknown>, value);
+    return this;
+  }
+
+  component<Props>(name: string, component: FunctionalComponent<Props>): this {
+    this.assertConfigurable('register application components');
+    if (!name.trim()) throw new TypeError('Application component names cannot be empty.');
+    this.context.components.set(name, component as FunctionalComponent<unknown>);
+    return this;
+  }
+
+  onMounted(callback: () => void | PromiseLike<void>): this {
+    this.assertConfigurable('register mount hooks');
+    this.mountedHooks.push(callback);
+    return this;
+  }
+
+  onUnmounted(callback: () => void | PromiseLike<void>): this {
+    this.assertConfigurable('register unmount hooks');
+    this.unmountedHooks.push(callback);
+    return this;
+  }
+
+  mount(container: Element | DocumentFragment): AppMount<Public> {
+    if (this.state !== 'created') throw new Error('A Gluon application can only be mounted once.');
+    if (mountedContainers.has(container)) throw new Error('The mount container already owns a Gluon application.');
+    this.state = 'mounted';
+    this.container = container;
+    mountedContainers.set(container, this as GluonAppImpl<unknown>);
+    registerApplicationRoot(container, this.context);
+
+    const scope = effectScope({
+      detached: true,
+      onError: (errorContext) => this.reportReactiveError(errorContext),
+    });
+    const runner = scope.run(() => effect(
+      () => scope.run(() => this.renderRoot()),
+      {
+        flush: 'update',
+        id: this.updateId,
+        lazy: true,
+        onError: (errorContext) => this.reportReactiveError(errorContext),
+      },
+    ))!;
+    this.scope = scope;
+    this.runner = runner;
+    runner();
+
+    const app = this;
+    return {
+      app,
+      container,
+      get exposed() {
+        return app.publicExposure;
+      },
+      unmount() {
+        app.unmount();
+      },
+    };
+  }
+
+  unmount(): void {
+    if (this.state === 'unmounted') return;
+    if (this.state !== 'mounted' || !this.container) {
+      throw new Error('Cannot unmount a Gluon application before it is mounted.');
+    }
+    const container = this.container;
+    this.state = 'unmounted';
+    try {
+      this.scope?.stop();
+    } catch (error) {
+      reportApplicationError(this.context, error, 'lifecycle');
+    }
+    this.scope = undefined;
+    this.runner = undefined;
+    try {
+      try {
+        unmountRender(container);
+      } catch (error) {
+        reportApplicationError(this.context, error, 'lifecycle');
+      }
+      this.invokeHooks(this.unmountedHooks, 'lifecycle');
+      for (let index = this.pluginCleanups.length - 1; index >= 0; index -= 1) {
+        this.invokeCallback(this.pluginCleanups[index]!, 'plugin');
+      }
+    } finally {
+      unregisterApplicationRoot(container, this.context);
+      mountedContainers.delete(container);
+      this.container = undefined;
+      this.publicExposure = undefined;
+      this.context.provides.clear();
+      this.context.components.clear();
+      this.pluginCleanups.length = 0;
+    }
+  }
+
+  run<Result>(
+    callback: () => Result | PromiseLike<Result>,
+  ): Result | Promise<Result | undefined> | undefined {
+    return runWithApplicationContext(
+      this.context,
+      undefined,
+      (error, source) => reportApplicationError(this.context, error, source),
+      () => runActiveGuarded(callback, 'async'),
+    );
+  }
+
+  private renderRoot(): void {
+    const container = this.container;
+    if (!container || this.state !== 'mounted') return;
+    runWithApplicationContext(
+      this.context,
+      undefined,
+      (error, source) => reportApplicationError(this.context, error, source),
+      () => {
+        const result = typeof this.root === 'function'
+          ? this.root(this.createRootRenderContext())
+          : this.root;
+        if (!isTemplateResult(result)) {
+          throw new TypeError('A Gluon application root must return a TemplateResult.');
+        }
+        render(result, container);
+        if (!this.rootCommitted) {
+          this.rootCommitted = true;
+          this.invokeHooks(this.mountedHooks, 'lifecycle');
+        }
+      },
+    );
+  }
+
+  private createRootRenderContext(): AppRootRenderContext<Public> {
+    return {
+      app: this,
+      expose: (value) => {
+        this.publicExposure = freezeExposure(value);
+      },
+      inject,
+      component: (name, props) => dynamicComponent(name, props),
+    };
+  }
+
+  private invokeHooks(
+    hooks: ReadonlyArray<() => void | PromiseLike<void>>,
+    source: AppErrorSource,
+  ): void {
+    for (const hook of hooks) this.invokeCallback(hook, source);
+  }
+
+  private invokeCallback(
+    callback: () => void | PromiseLike<void>,
+    source: AppErrorSource,
+  ): void {
+    try {
+      const result = runWithApplicationContext(
+        this.context,
+        undefined,
+        (error, callbackSource) => reportApplicationError(
+          this.context,
+          error,
+          callbackSource,
+        ),
+        callback,
+      );
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).catch((error: unknown) => {
+          reportApplicationError(this.context, error, source);
+        });
+      }
+    } catch (error) {
+      reportApplicationError(this.context, error, source);
+    }
+  }
+
+  private reportReactiveError(errorContext: ReactivityErrorContext): void {
+    const source: AppErrorSource = errorContext.source === this.runner
+      ? 'render'
+      : errorContext.phase === 'cleanup'
+        ? 'lifecycle'
+        : 'effect';
+    reportApplicationError(this.context, errorContext.error, source);
+  }
+
+  private assertConfigurable(action: string): void {
+    if (this.state !== 'created') {
+      throw new Error(`Cannot ${action} after the application has mounted.`);
+    }
+  }
+}
+
+function freezeExposure<Public>(value: Public): Readonly<Public> {
+  if ((typeof value === 'object' && value !== null) || typeof value === 'function') {
+    return Object.freeze(value);
+  }
+  return value;
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  ) && typeof Reflect.get(value, 'then') === 'function';
+}

--- a/src/element.ts
+++ b/src/element.ts
@@ -6,8 +6,16 @@ import {
   queueJob,
   type EffectDebuggerEvent,
   type EffectScope,
+  type ReactivityErrorContext,
   type ReactiveEffectRunner,
 } from '@gluonjs/reactivity';
+import {
+  reportApplicationError,
+  resolveApplicationContext,
+  runWithApplicationContext,
+  type AppErrorSource,
+  type ApplicationContext,
+} from './application-context.js';
 
 export type GluonRenderCause =
   | { readonly type: 'connection' }
@@ -32,6 +40,16 @@ export interface GluonRenderDebugEvent {
 }
 
 export type GluonRenderDebugHook = (event: GluonRenderDebugEvent) => void;
+
+export type ComponentLifecycleCallback = () => void | PromiseLike<void>;
+
+export interface ComponentErrorInfo {
+  readonly error: unknown;
+  readonly source: AppErrorSource;
+  readonly element: GluonElement;
+}
+
+export type ComponentErrorBoundary = (info: ComponentErrorInfo) => boolean | void;
 
 let renderDebugHook: GluonRenderDebugHook | undefined;
 
@@ -80,12 +98,19 @@ const declarationCache = new WeakMap<Function, PropertyDeclarations>();
 const styleCache = new WeakMap<Function, readonly CSSStyleSheet[]>();
 const propertyValues = Symbol('gluon.property-values');
 const setProperty = Symbol('gluon.set-property');
+const publicInstance = Symbol('gluon.public-instance');
 let elementUpdateSequence = 0;
 
 interface UpdateDeferred {
   readonly promise: Promise<void>;
   readonly resolve: () => void;
   readonly reject: (reason?: unknown) => void;
+}
+
+interface CapturedComponentBoundary {
+  readonly element: GluonElement;
+  readonly context?: ApplicationContext;
+  readonly callbacks: readonly ComponentErrorBoundary[];
 }
 
 export abstract class GluonElement extends HTMLElement {
@@ -98,11 +123,19 @@ export abstract class GluonElement extends HTMLElement {
   private connected = false;
   private reflectingAttribute?: string;
   private readonly initialAttributePrecedence = new Map<string, string>();
+  private applicationContext?: ApplicationContext;
   private renderScope?: EffectScope;
   private renderEffect?: ReactiveEffectRunner<void | undefined>;
   private pendingUpdate?: UpdateDeferred;
   private readonly pendingRenderCauses: GluonRenderCause[] = [];
   private activeRenderDependencies?: EffectDebuggerEvent[];
+  private connectionRendered = false;
+  private readonly connectedHooks: ComponentLifecycleCallback[] = [];
+  private readonly beforeUpdateHooks: ComponentLifecycleCallback[] = [];
+  private readonly updatedHooks: ComponentLifecycleCallback[] = [];
+  private readonly disconnectedHooks: ComponentLifecycleCallback[] = [];
+  private readonly errorBoundaries: ComponentErrorBoundary[] = [];
+  [publicInstance]?: Readonly<object>;
   private updatePromise: Promise<void> = Promise.resolve();
 
   constructor() {
@@ -127,6 +160,7 @@ export abstract class GluonElement extends HTMLElement {
   connectedCallback(): void {
     if (this.connected) return;
     this.connected = true;
+    this.applicationContext = resolveApplicationContext(this);
     adoptStyles(this.renderRoot, ...getStyles(this.constructor as GluonElementConstructor));
     this.reflectCurrentProperties();
     this.createRenderEffect();
@@ -145,7 +179,13 @@ export abstract class GluonElement extends HTMLElement {
       this.resolvePendingUpdate();
       this.pendingRenderCauses.length = 0;
       this.activeRenderDependencies = undefined;
-      suspendRender(this.renderRoot);
+      try {
+        suspendRender(this.renderRoot);
+      } finally {
+        this.invokeLifecycle(this.disconnectedHooks);
+        this.connectionRendered = false;
+        this.applicationContext = undefined;
+      }
     }
   }
 
@@ -183,6 +223,32 @@ export abstract class GluonElement extends HTMLElement {
 
   protected requestUpdate(): Promise<void> {
     return this.queueUpdate({ type: 'request' });
+  }
+
+  protected onConnected(callback: ComponentLifecycleCallback): void {
+    this.connectedHooks.push(callback);
+  }
+
+  protected onBeforeUpdate(callback: ComponentLifecycleCallback): void {
+    this.beforeUpdateHooks.push(callback);
+  }
+
+  protected onUpdated(callback: ComponentLifecycleCallback): void {
+    this.updatedHooks.push(callback);
+  }
+
+  protected onDisconnected(callback: ComponentLifecycleCallback): void {
+    this.disconnectedHooks.push(callback);
+  }
+
+  protected onErrorCaptured(callback: ComponentErrorBoundary): void {
+    this.errorBoundaries.push(callback);
+  }
+
+  protected expose<Public extends object>(value: Public): Readonly<Public> {
+    const exposed = Object.freeze(value);
+    this[publicInstance] = exposed;
+    return exposed;
   }
 
   protected update(): void {
@@ -228,7 +294,13 @@ export abstract class GluonElement extends HTMLElement {
 
   private createRenderEffect(): void {
     if (this.renderEffect) return;
-    const scope = effectScope(true);
+    const ownsErrorRouting = Boolean(this.applicationContext) || this.hasAncestorErrorBoundary();
+    const scope = effectScope({
+      detached: true,
+      ...(ownsErrorRouting
+        ? { onError: (errorContext: ReactivityErrorContext) => this.reportReactiveError(errorContext) }
+        : {}),
+    });
     const runner = scope.run(() => effect(
       () => scope.run(() => this.performUpdate()),
       {
@@ -273,7 +345,13 @@ export abstract class GluonElement extends HTMLElement {
     let renderError: unknown;
 
     try {
-      this.update();
+      if (this.connectionRendered) this.invokeLifecycle(this.beforeUpdateHooks);
+      this.runOwned(() => this.update());
+      if (!this.connectionRendered) {
+        this.connectionRendered = true;
+        this.invokeLifecycle(this.connectedHooks);
+      }
+      this.invokeLifecycle(this.updatedHooks);
       deferred.resolve();
     } catch (error) {
       failed = true;
@@ -312,6 +390,107 @@ export abstract class GluonElement extends HTMLElement {
 
   private recordRenderCause(cause: GluonRenderCause): void {
     if (isDevelopment() && renderDebugHook) this.pendingRenderCauses.push(cause);
+  }
+
+  private runOwned<Result>(callback: () => Result): Result {
+    const reportError = this.createComponentErrorReporter();
+    return runWithApplicationContext(
+      this.applicationContext,
+      this,
+      reportError,
+      callback,
+    );
+  }
+
+  private invokeLifecycle(callbacks: readonly ComponentLifecycleCallback[]): void {
+    for (const callback of callbacks) {
+      const reportError = this.createComponentErrorReporter();
+      try {
+        const result = runWithApplicationContext(
+          this.applicationContext,
+          this,
+          reportError,
+          callback,
+        );
+        if (isPromiseLike(result)) {
+          void Promise.resolve(result).catch((error: unknown) => {
+            reportError(error, 'lifecycle');
+          });
+        }
+      } catch (error) {
+        reportError(error, 'lifecycle');
+      }
+    }
+  }
+
+  private reportReactiveError(errorContext: ReactivityErrorContext): void {
+    const source: AppErrorSource = errorContext.source === this.renderEffect
+      ? 'render'
+      : errorContext.phase === 'cleanup'
+        ? 'lifecycle'
+        : 'effect';
+    this.handleComponentError(errorContext.error, source);
+  }
+
+  private handleComponentError(error: unknown, source: AppErrorSource): void {
+    this.createComponentErrorReporter()(error, source);
+  }
+
+  private createComponentErrorReporter(): (
+    error: unknown,
+    source: AppErrorSource,
+  ) => void {
+    const applicationContext = this.applicationContext;
+    const boundaries: CapturedComponentBoundary[] = [];
+    let current = getComposedParent(this);
+    while (current) {
+      if (current instanceof GluonElement && current.errorBoundaries.length > 0) {
+        boundaries.push({
+          element: current,
+          context: current.applicationContext ?? applicationContext,
+          callbacks: [...current.errorBoundaries],
+        });
+      }
+      current = getComposedParent(current);
+    }
+
+    return (error, source) => {
+      for (const captured of boundaries) {
+        for (const boundary of captured.callbacks) {
+          try {
+            const handled = runWithApplicationContext(
+              captured.context,
+              captured.element,
+              (boundaryError) => reportApplicationError(
+                applicationContext,
+                boundaryError,
+                'application',
+                captured.element,
+              ),
+              () => boundary({ error, source, element: this }),
+            );
+            if (handled === true) return;
+          } catch (boundaryError) {
+            reportApplicationError(
+              applicationContext,
+              boundaryError,
+              'application',
+              captured.element,
+            );
+          }
+        }
+      }
+      reportApplicationError(applicationContext, error, source, this);
+    };
+  }
+
+  private hasAncestorErrorBoundary(): boolean {
+    let current = getComposedParent(this);
+    while (current) {
+      if (current instanceof GluonElement && current.errorBoundaries.length > 0) return true;
+      current = getComposedParent(current);
+    }
+    return false;
   }
 
   private capturePreUpgradeProperties(constructor: GluonElementConstructor): void {
@@ -409,6 +588,23 @@ function isDevelopment(): boolean {
   return (
     globalThis as { process?: { env?: { NODE_ENV?: string } } }
   ).process?.env?.NODE_ENV !== 'production';
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  ) && typeof Reflect.get(value, 'then') === 'function';
+}
+
+function getComposedParent(node: Node): Node | null {
+  if (node.parentNode) return node.parentNode;
+  return node instanceof ShadowRoot ? node.host : null;
+}
+
+export function getPublicInstance<Public extends object>(
+  element: GluonElement,
+): Readonly<Public> | undefined {
+  return element[publicInstance] as Readonly<Public> | undefined;
 }
 
 export type GluonElementClass<ElementType extends GluonElement = GluonElement> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,11 @@ export {
 export {
   GluonElement,
   defineElement,
+  getPublicInstance,
   setGluonRenderDebugHook,
+  type ComponentErrorBoundary,
+  type ComponentErrorInfo,
+  type ComponentLifecycleCallback,
   type GluonElementClass,
   type GluonRenderCause,
   type GluonRenderDebugEvent,
@@ -43,6 +47,31 @@ export {
   type PropertyDefinition,
   type PropertyType,
 } from './element.js';
+
+export {
+  createApp,
+  createInjectionKey,
+  dynamicComponent,
+  inject,
+  runWithErrorHandling,
+  warn,
+  type AppConfig,
+  type AppErrorHandler,
+  type AppErrorInfo,
+  type AppErrorSource,
+  type AppMount,
+  type AppPluginCleanup,
+  type AppRoot,
+  type AppRootRenderContext,
+  type AppWarningHandler,
+  type AppWarningInfo,
+  type FunctionalComponent,
+  type GluonApp,
+  type GluonAppPlugin,
+  type GluonPlugin,
+  type GluonPluginFunction,
+  type InjectionKey,
+} from './application.js';
 
 export {
   defineAtom,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,3 +1,5 @@
+import { guardEventListener } from './application-context.js';
+
 const templateResultBrand = Symbol('gluon.template-result');
 const directiveBrand = Symbol('gluon.directive');
 const repeatResultBrand = Symbol('gluon.repeat-result');
@@ -1301,11 +1303,11 @@ function isEventBinding(value: unknown): value is EventBinding {
 function resolveEvent(value: unknown): ResolvedEvent | undefined {
   if (isEventBinding(value)) {
     return {
-      listener: value.listener,
+      listener: guardEventListener(value.listener),
       options: value.options,
     };
   }
-  return isEventListener(value) ? { listener: value } : undefined;
+  return isEventListener(value) ? { listener: guardEventListener(value) } : undefined;
 }
 
 function isUnsafeHtmlResult(value: unknown): value is UnsafeHtmlResult {

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -1,8 +1,14 @@
 import {
+  GluonElement,
+  createApp,
+  createInjectionKey,
   directive,
+  dynamicComponent,
   event,
+  getPublicInstance,
   html,
   repeat,
+  runWithErrorHandling,
   setGluonRenderDebugHook,
   suspendRender,
   unmount,
@@ -11,6 +17,7 @@ import {
   type DirectiveLifecycle,
   type EventBinding,
   type GluonRenderDebugEvent,
+  type GluonPlugin,
   type Key,
   type RepeatResult,
   type TemplateValue,
@@ -54,6 +61,50 @@ const restoreRenderDebugHook = setGluonRenderDebugHook((diagnostic: GluonRenderD
 });
 restoreRenderDebugHook();
 
+const counterKey = createInjectionKey<{ count: number }>('counter');
+const counterPlugin: GluonPlugin<{ initial: number }> = {
+  install(app, options) {
+    app.provide(counterKey, { count: options.initial });
+    return () => undefined;
+  },
+};
+const application = createApp<{ reset(): void }>((context) => {
+  const counter = context.inject(counterKey);
+  context.expose({ reset: () => { counter.count = 0; } });
+  return html`<main>${dynamicComponent(
+    (props: { count: number }) => html`<output>${props.count}</output>`,
+    counter,
+  )}</main>`;
+});
+application.config.errorHandler = ({ error, source }) => { void error; void source; };
+application.config.warnHandler = ({ message, code }) => { void message; void code; };
+application.use(counterPlugin, { initial: 1 });
+application.component<{ label: string }>('label', ({ label }) => html`<span>${label}</span>`);
+application.onMounted(() => undefined).onUnmounted(() => undefined);
+const appMount = application.mount(document.createElement('div'));
+appMount.exposed?.reset();
+void application.run(async () => 'complete');
+void runWithErrorHandling(async () => 'complete');
+appMount.unmount();
+
+class PublicElement extends GluonElement {
+  constructor() {
+    super();
+    this.onConnected(() => undefined);
+    this.onBeforeUpdate(() => undefined);
+    this.onUpdated(() => undefined);
+    this.onDisconnected(() => undefined);
+    this.onErrorCaptured(({ error, source }) => { void error; void source; return true; });
+    this.expose({ reset: () => undefined });
+  }
+
+  protected override render() {
+    return html`<p>Public</p>`;
+  }
+}
+const publicInstance = getPublicInstance<{ reset(): void }>(null as unknown as PublicElement);
+publicInstance?.reset();
+
 // @ts-expect-error keys cannot be null
 repeat(rows, () => null, (row) => row.label);
 
@@ -65,3 +116,5 @@ event(() => undefined, { capture: 'yes' });
 
 // @ts-expect-error unsafe URLs accept strings or URL objects
 unsafeURL(42);
+// @ts-expect-error injection keys retain their value type
+application.provide(counterKey, { count: 'invalid' });

--- a/tests-node/scheduler.spec.ts
+++ b/tests-node/scheduler.spec.ts
@@ -300,6 +300,30 @@ describe('effect scopes and error routing', () => {
     ]);
   });
 
+  it('continues stopping a scope when one effect stop hook throws', () => {
+    const order: string[] = [];
+    const errors: ReactivityErrorContext[] = [];
+    const scope = effectScope({ onError: (context) => { errors.push(context); } });
+
+    scope.run(() => {
+      effect(() => undefined, { onStop: () => { order.push('first'); } });
+      effect(() => undefined, {
+        onStop: () => {
+          order.push('failing');
+          throw new Error('stop failed');
+        },
+      });
+      effect(() => undefined, { onStop: () => { order.push('last'); } });
+      onScopeDispose(() => { order.push('cleanup'); });
+    });
+
+    expect(() => scope.stop()).not.toThrow();
+    expect(order).toEqual(['last', 'failing', 'first', 'cleanup']);
+    expect(errors).toEqual([
+      expect.objectContaining({ phase: 'cleanup' }),
+    ]);
+  });
+
   it('keeps detached scopes alive when their creating scope stops', () => {
     const state = ref(0);
     const parent = effectScope();

--- a/tests/application-runtime.spec.ts
+++ b/tests/application-runtime.spec.ts
@@ -1,0 +1,595 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  GluonElement,
+  createApp,
+  createInjectionKey,
+  defineElement,
+  directive,
+  dynamicComponent,
+  getPublicInstance,
+  html,
+  inject,
+  runWithErrorHandling,
+  warn,
+  type AppErrorInfo,
+  type AppRootRenderContext,
+  type AppWarningInfo,
+  type ComponentErrorInfo,
+  type GluonApp,
+  type PropertyDeclarations,
+} from '../src/index.js';
+import {
+  nextTick,
+  effect,
+  onScopeDispose,
+  reactive,
+  watchEffect,
+} from '@gluonjs/reactivity';
+
+describe('application runtime', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('isolates plugins, providers, component registries, stores, config, and errors', async () => {
+    const storeKey = createInjectionKey<{ name: string }>('store');
+    const themeKey = createInjectionKey<string>('theme');
+    const warningsA: AppWarningInfo[] = [];
+    const warningsB: AppWarningInfo[] = [];
+    const errorsA: AppErrorInfo[] = [];
+    const errorsB: AppErrorInfo[] = [];
+    const cleanups: string[] = [];
+    const stores = new Map<string, { name: string }>();
+
+    const plugin = (
+      app: GluonApp,
+      options: { readonly name: string; readonly theme: string },
+    ) => {
+      const store = reactive({ name: options.name });
+      stores.set(options.name, store);
+      app.provide(storeKey, store);
+      app.provide(themeKey, options.theme);
+      app.component<{ label: string }>('message', ({ label }) => html`
+        <p>${label}:${inject(themeKey)}</p>
+      `);
+      return () => {
+        cleanups.push(options.name);
+      };
+    };
+
+    class ContextFixture extends GluonElement {
+      protected override render() {
+        return html`<span>${inject(themeKey)}</span>`;
+      }
+    }
+    defineElement('gluon-app-context-fixture', ContextFixture);
+
+    const root = (context: AppRootRenderContext<unknown>) => {
+      const store = inject(storeKey);
+      return html`
+        <section>${context.component('message', { label: store.name })}</section>
+        <gluon-app-context-fixture></gluon-app-context-fixture>
+      `;
+    };
+    const appA = createApp(root);
+    const appB = createApp(root);
+    appA.config.errorHandler = (info) => { errorsA.push(info); };
+    appB.config.errorHandler = (info) => { errorsB.push(info); };
+    appA.config.warnHandler = (info) => { warningsA.push(info); };
+    appB.config.warnHandler = (info) => { warningsB.push(info); };
+    appA.config.globalProperties.locale = 'de';
+    appB.config.globalProperties.locale = 'en';
+    appA.use(plugin, { name: 'alpha', theme: 'light' });
+    appA.use(plugin, { name: 'ignored', theme: 'ignored' });
+    appB.use(plugin, { name: 'beta', theme: 'dark' });
+
+    const rootA = document.createElement('div');
+    const rootB = document.createElement('div');
+    document.body.append(rootA, rootB);
+    appA.mount(rootA);
+    appB.mount(rootB);
+    const contextA = rootA.querySelector('gluon-app-context-fixture') as ContextFixture;
+    const contextB = rootB.querySelector('gluon-app-context-fixture') as ContextFixture;
+    await Promise.all([contextA.updateComplete, contextB.updateComplete]);
+
+    expect(rootA.textContent?.trim()).toBe('alpha:light');
+    expect(rootB.textContent?.trim()).toBe('beta:dark');
+    expect(appA.config.globalProperties.locale).toBe('de');
+    expect(appB.config.globalProperties.locale).toBe('en');
+    expect(contextA.shadowRoot?.textContent).toBe('light');
+    expect(contextB.shadowRoot?.textContent).toBe('dark');
+    expect(warningsA).toEqual([expect.objectContaining({ code: 'GLUON_PLUGIN_DUPLICATE' })]);
+    expect(warningsB).toEqual([]);
+
+    stores.get('alpha')!.name = 'alpha-updated';
+    await nextTick();
+    expect(rootA.textContent?.trim()).toBe('alpha-updated:light');
+    expect(rootB.textContent?.trim()).toBe('beta:dark');
+
+    const result = appA.run(() => { throw new Error('alpha failed'); });
+    expect(result).toBeUndefined();
+    expect(errorsA).toEqual([expect.objectContaining({ source: 'async' })]);
+    expect(errorsB).toEqual([]);
+
+    appA.unmount();
+    expect(cleanups).toEqual(['alpha']);
+    expect(rootA.childNodes).toHaveLength(0);
+    expect(rootB.textContent?.trim()).toBe('beta:dark');
+    appB.unmount();
+    expect(cleanups).toEqual(['alpha', 'beta']);
+    await nextTick();
+  });
+
+  it('releases root effects, bindings, refs, hooks, and plugin resources on unmount', async () => {
+    const state = reactive({ count: 0 });
+    const click = vi.fn();
+    const ref: { value?: Element } = {};
+    const order: string[] = [];
+    let renders = 0;
+    let scopeOwned = false;
+    const plugin = () => {
+      order.push('plugin:install');
+      return () => {
+        order.push('plugin:cleanup');
+      };
+    };
+    const app = createApp<{ increment(): void }>((context) => {
+      renders += 1;
+      if (!scopeOwned) {
+        scopeOwned = true;
+        onScopeDispose(() => order.push('scope:dispose'));
+      }
+      context.expose({ increment: () => { state.count += 1; } });
+      return html`<button ...=${{ ref, onClick: click }}>${state.count}</button>`;
+    });
+    app.use(plugin);
+    app.onMounted(() => { order.push('app:mounted'); });
+    app.onUnmounted(() => { order.push('app:unmounted'); });
+    const root = document.createElement('div');
+    document.body.append(root);
+
+    const mount = app.mount(root);
+    const button = ref.value as HTMLButtonElement;
+    expect(mount.exposed).toBeDefined();
+    mount.exposed?.increment();
+    await nextTick();
+    expect(button.textContent).toBe('1');
+    expect(renders).toBe(2);
+    button.click();
+    expect(click).toHaveBeenCalledOnce();
+
+    state.count = 2;
+    mount.unmount();
+    await nextTick();
+    expect(renders).toBe(2);
+    expect(ref.value).toBeUndefined();
+    expect(root.childNodes).toHaveLength(0);
+    button.click();
+    expect(click).toHaveBeenCalledOnce();
+    expect(order).toEqual([
+      'plugin:install',
+      'app:mounted',
+      'scope:dispose',
+      'app:unmounted',
+      'plugin:cleanup',
+    ]);
+    expect(() => app.mount(root)).toThrow(/only be mounted once/i);
+    app.unmount();
+  });
+
+  it('orders component connection, update, disconnection, and public exposure', async () => {
+    const order: string[] = [];
+
+    class LifecycleFixture extends GluonElement {
+      static override readonly properties: PropertyDeclarations = {
+        count: { type: Number, default: 0 },
+      };
+
+      declare count: number;
+
+      constructor() {
+        super();
+        this.onConnected(() => { order.push('connected'); });
+        this.onBeforeUpdate(() => { order.push('before-update'); });
+        this.onUpdated(() => { order.push('updated'); });
+        this.onDisconnected(() => { order.push('disconnected'); });
+        this.expose({ increment: () => { this.count += 1; } });
+      }
+
+      protected override render() {
+        return html`<span>${this.count}</span>`;
+      }
+    }
+
+    defineElement('gluon-app-lifecycle-fixture', LifecycleFixture);
+    const app = createApp(html`<gluon-app-lifecycle-fixture></gluon-app-lifecycle-fixture>`);
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    const element = root.querySelector('gluon-app-lifecycle-fixture') as LifecycleFixture;
+    await element.updateComplete;
+    expect(order).toEqual(['connected', 'updated']);
+
+    const exposed = getPublicInstance<{ increment(): void }>(element);
+    exposed?.increment();
+    await element.updateComplete;
+    expect(element.shadowRoot?.textContent).toBe('1');
+    expect(order).toEqual(['connected', 'updated', 'before-update', 'updated']);
+
+    element.remove();
+    expect(order.at(-1)).toBe('disconnected');
+    root.append(element);
+    await element.updateComplete;
+    expect(element.shadowRoot?.textContent).toBe('1');
+    expect(order.slice(-2)).toEqual(['connected', 'updated']);
+
+    app.unmount();
+    expect(order.at(-1)).toBe('disconnected');
+  });
+
+  it('routes render, effect, event, async, and lifecycle errors through boundaries', async () => {
+    const captured: ComponentErrorInfo[] = [];
+    const applicationErrors: AppErrorInfo[] = [];
+
+    class ErrorChildFixture extends GluonElement {
+      static override readonly properties: PropertyDeclarations = {
+        revision: { type: Number, default: 0 },
+      };
+
+      declare revision: number;
+      readonly state = reactive({ renderFailure: false, effectFailure: false });
+      lifecycleFailure = false;
+      private watcherInstalled = false;
+
+      constructor() {
+        super();
+        this.onUpdated(() => {
+          if (this.lifecycleFailure) throw new Error('lifecycle failed');
+        });
+        this.onDisconnected(() => {
+          this.watcherInstalled = false;
+        });
+      }
+
+      protected override update(): void {
+        if (!this.watcherInstalled) {
+          this.watcherInstalled = true;
+          watchEffect(() => {
+            if (this.state.effectFailure) throw new Error('effect failed');
+          });
+        }
+        super.update();
+      }
+
+      protected override render() {
+        if (this.state.renderFailure) throw new Error('render failed');
+        return html`
+          <button id="event" @click=${() => { throw new Error('event failed'); }}>Event</button>
+          <button id="async" @click=${async () => { throw new Error('async failed'); }}>Async</button>
+          <span>${this.revision}</span>
+        `;
+      }
+    }
+
+    class ErrorBoundaryFixture extends GluonElement {
+      constructor() {
+        super();
+        this.onErrorCaptured((info) => {
+          captured.push(info);
+          return true;
+        });
+      }
+
+      protected override render() {
+        return html`<gluon-app-error-child></gluon-app-error-child>`;
+      }
+    }
+
+    defineElement('gluon-app-error-child', ErrorChildFixture);
+    defineElement('gluon-app-error-boundary', ErrorBoundaryFixture);
+    const app = createApp(html`<gluon-app-error-boundary></gluon-app-error-boundary>`);
+    app.config.errorHandler = (info) => { applicationErrors.push(info); };
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    const boundary = root.querySelector('gluon-app-error-boundary') as ErrorBoundaryFixture;
+    await boundary.updateComplete;
+    const child = boundary.shadowRoot?.querySelector('gluon-app-error-child') as ErrorChildFixture;
+    await child.updateComplete;
+
+    (child.shadowRoot?.querySelector('#event') as HTMLButtonElement).click();
+    (child.shadowRoot?.querySelector('#async') as HTMLButtonElement).click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    child.state.effectFailure = true;
+    await nextTick();
+
+    child.lifecycleFailure = true;
+    child.revision += 1;
+    await child.updateComplete;
+
+    child.lifecycleFailure = false;
+    child.state.renderFailure = true;
+    await expect(child.updateComplete).rejects.toThrow('render failed');
+
+    expect(captured.map((info) => info.source)).toEqual([
+      'event',
+      'async',
+      'effect',
+      'lifecycle',
+      'render',
+    ]);
+    expect(applicationErrors).toEqual([]);
+
+    await app.run(async () => { throw new Error('application async failed'); });
+    expect(applicationErrors).toEqual([expect.objectContaining({ source: 'async' })]);
+    app.unmount();
+  });
+
+  it('routes application warnings and supports injection fallbacks', () => {
+    const missing = createInjectionKey<string>('missing');
+    const warnings: AppWarningInfo[] = [];
+    const app = createApp(() => html`
+      <p>${inject(missing, 'fallback')}${dynamicComponent('missing', {})}</p>
+    `);
+    app.config.warnHandler = (info) => { warnings.push(info); };
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+
+    expect(root.textContent?.trim()).toBe('fallback');
+    expect(warnings).toEqual([expect.objectContaining({ code: 'GLUON_COMPONENT_MISSING' })]);
+    expect(() => app.provide(missing, 'late')).toThrow(/after the application has mounted/i);
+    app.unmount();
+  });
+
+  it('enforces application state and reports root and plugin failures', () => {
+    const errors: AppErrorInfo[] = [];
+    const missing = createInjectionKey<string>('required');
+    const app = createApp(() => html`<p>${inject(missing)}</p>`);
+    app.config.errorHandler = (info) => { errors.push(info); };
+
+    expect(app.mounted).toBe(false);
+    expect(() => app.unmount()).toThrow(/before it is mounted/i);
+    expect(() => app.component('  ', () => html``)).toThrow(/cannot be empty/i);
+    app.use({
+      install() {
+        throw new Error('plugin install failed');
+      },
+    });
+
+    const root = document.createElement('div');
+    document.body.append(root);
+    const mount = app.mount(root);
+    expect(app.mounted).toBe(true);
+    expect(mount.exposed).toBeUndefined();
+    expect(errors.map(({ source }) => source)).toEqual(['plugin', 'render']);
+    expect(errors[1]?.error).toEqual(expect.objectContaining({ message: expect.stringMatching(/required/) }));
+
+    const competingApp = createApp(html`<p>competing</p>`);
+    expect(() => competingApp.mount(root)).toThrow(/already owns/i);
+    expect(() => app.onMounted(() => undefined)).toThrow(/after the application has mounted/i);
+
+    app.unmount();
+    expect(app.mounted).toBe(false);
+
+    const invalidErrors: AppErrorInfo[] = [];
+    const invalidApp = createApp(() => null as never);
+    invalidApp.config.errorHandler = (info) => { invalidErrors.push(info); };
+    const invalidRoot = document.createElement('div');
+    document.body.append(invalidRoot);
+    invalidApp.mount(invalidRoot);
+    expect(invalidErrors).toEqual([
+      expect.objectContaining({ source: 'render', error: expect.any(TypeError) }),
+    ]);
+    invalidApp.unmount();
+  });
+
+  it('contains synchronous and asynchronous hook and cleanup failures', async () => {
+    const errors: AppErrorInfo[] = [];
+    const stopped = vi.fn();
+    const failingDirective = directive<[]>({
+      mount(part) {
+        part.setValue('ready');
+      },
+      update() {},
+      cleanup() {
+        throw new Error('directive cleanup failed');
+      },
+    });
+    const app = createApp<number>((context) => {
+      context.expose(7);
+      effect(() => undefined, {
+        onStop() {
+          stopped();
+          throw new Error('effect cleanup failed');
+        },
+      });
+      onScopeDispose(() => { throw new Error('scope cleanup failed'); });
+      return html`<p>${failingDirective()}</p>`;
+    });
+    app.config.errorHandler = (info) => { errors.push(info); };
+    app.use({
+      install() {
+        return async () => { throw new Error('plugin cleanup failed'); };
+      },
+    });
+    app.onMounted(() => { throw new Error('mounted failed'); });
+    app.onMounted(async () => { throw new Error('async mounted failed'); });
+    app.onUnmounted(() => { throw new Error('unmounted failed'); });
+    app.onUnmounted(async () => { throw new Error('async unmounted failed'); });
+
+    const root = document.createElement('div');
+    document.body.append(root);
+    const mount = app.mount(root);
+    expect(mount.exposed).toBe(7);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    app.unmount();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(stopped).toHaveBeenCalledOnce();
+    expect(errors.map(({ source }) => source)).toEqual([
+      'lifecycle',
+      'lifecycle',
+      'lifecycle',
+      'lifecycle',
+      'lifecycle',
+      'lifecycle',
+      'lifecycle',
+      'plugin',
+    ]);
+    expect(errors.map(({ error }) => (error as Error).message)).toEqual([
+      'mounted failed',
+      'async mounted failed',
+      'effect cleanup failed',
+      'scope cleanup failed',
+      'directive cleanup failed',
+      'unmounted failed',
+      'async unmounted failed',
+      'plugin cleanup failed',
+    ]);
+  });
+
+  it('guards root event listeners and contains warning-handler failures', async () => {
+    const state = reactive({ revision: 0 });
+    const eventContext = createInjectionKey<string>('event-context');
+    const errors: AppErrorInfo[] = [];
+    let eventThis: EventTarget | undefined;
+    let injectedFromEvent: string | undefined;
+    const directListener = function (this: EventTarget) {
+      eventThis = this;
+      injectedFromEvent = inject(eventContext);
+    };
+    const objectListener: EventListenerObject = {
+      handleEvent() {
+        throw new Error('object event failed');
+      },
+    };
+    const app = createApp(() => {
+      warn('root warning', 'ROOT_WARNING');
+      return html`
+        <button id="direct" @click=${directListener}>${state.revision}</button>
+        <button id="object" @click=${objectListener}>object</button>
+        ${dynamicComponent(({ label }: { label: string }) => html`<p>${label}</p>`, { label: 'direct' })}
+      `;
+    });
+    app.config.errorHandler = (info) => { errors.push(info); };
+    app.config.warnHandler = () => { throw new Error('warning handler failed'); };
+    app.provide(eventContext, 'owned');
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+
+    const direct = root.querySelector('#direct') as HTMLButtonElement;
+    direct.click();
+    expect(eventThis).toBe(direct);
+    expect(injectedFromEvent).toBe('owned');
+    (root.querySelector('#object') as HTMLButtonElement).click();
+
+    state.revision += 1;
+    await nextTick();
+    direct.click();
+    expect(root.textContent).toContain('direct');
+
+    const guardedResult = app.run(() => runWithErrorHandling(() => {
+      throw new Error('guarded failed');
+    }, 'application'));
+    expect(guardedResult).toBeUndefined();
+    expect(errors.map(({ source }) => source)).toEqual([
+      'application',
+      'event',
+      'application',
+      'application',
+    ]);
+    app.unmount();
+  });
+
+  it('retains boundary ownership for async event failures after unmount', async () => {
+    const captured: ComponentErrorInfo[] = [];
+    let rejectEvent!: (error: unknown) => void;
+    const pendingEvent = new Promise<void>((_resolve, reject) => {
+      rejectEvent = reject;
+    });
+
+    class DeferredErrorChild extends GluonElement {
+      protected override render() {
+        return html`<button @click=${() => pendingEvent}>deferred</button>`;
+      }
+    }
+    class DeferredErrorBoundary extends GluonElement {
+      constructor() {
+        super();
+        this.onErrorCaptured((info) => {
+          captured.push(info);
+          return true;
+        });
+      }
+
+      protected override render() {
+        return html`<gluon-app-deferred-error-child></gluon-app-deferred-error-child>`;
+      }
+    }
+
+    defineElement('gluon-app-deferred-error-child', DeferredErrorChild);
+    defineElement('gluon-app-deferred-error-boundary', DeferredErrorBoundary);
+    const app = createApp(html`<gluon-app-deferred-error-boundary></gluon-app-deferred-error-boundary>`);
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    const boundary = root.querySelector('gluon-app-deferred-error-boundary') as DeferredErrorBoundary;
+    await boundary.updateComplete;
+    const child = boundary.shadowRoot?.querySelector('gluon-app-deferred-error-child') as DeferredErrorChild;
+    await child.updateComplete;
+
+    (child.shadowRoot?.querySelector('button') as HTMLButtonElement).click();
+    app.unmount();
+    rejectEvent(new Error('deferred event failed'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(captured).toEqual([
+      expect.objectContaining({ source: 'async', element: child }),
+    ]);
+  });
+
+  it('contains unowned failures and failures in application error handlers', async () => {
+    const reportError = vi.fn();
+    const warnFallback = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.stubGlobal('reportError', reportError);
+    try {
+      warn('plain warning');
+      warn('coded warning', 'WARNING_CODE');
+      expect(warnFallback).toHaveBeenNthCalledWith(1, 'plain warning');
+      expect(warnFallback).toHaveBeenNthCalledWith(2, '[WARNING_CODE] coded warning');
+
+      expect(runWithErrorHandling(() => { throw new Error('unowned sync'); })).toBeUndefined();
+      await runWithErrorHandling(async () => { throw new Error('unowned async'); });
+
+      const defaultApp = createApp(html`<p>default</p>`);
+      defaultApp.use(() => { throw new Error('plugin without handler'); });
+
+      const failingHandlerApp = createApp(html`<p>handler</p>`);
+      failingHandlerApp.config.errorHandler = () => { throw new Error('sync handler failed'); };
+      failingHandlerApp.run(() => { throw new Error('owned sync'); });
+      failingHandlerApp.config.errorHandler = async () => { throw new Error('async handler failed'); };
+      await failingHandlerApp.run(async () => { throw new Error('owned async'); });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(reportError.mock.calls.map(([error]) => (error as Error).message)).toEqual([
+        'unowned sync',
+        'unowned async',
+        'plugin without handler',
+        'sync handler failed',
+        'async handler failed',
+      ]);
+    } finally {
+      warnFallback.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+});


### PR DESCRIPTION
Closes #23.

## Summary

- add isolated `createApp` instances with plugins, typed providers, component registries, global config, mount/unmount ownership, and controlled exposure
- add GluonElement lifecycle hooks, captured error boundaries, and automatic sync/async event ownership
- harden scope and renderer cleanup so one failure does not skip remaining application resources
- document the complete application runtime contract and update the README, architecture, roadmap, and changelogs
- add public TypeScript contract tests and multi-app, lifecycle, cleanup, event, warning, and error-path browser coverage

## Verification

- `npm run check`
- `npm audit` — 0 vulnerabilities
- 73 browser tests
- 66 reactivity tests
- Core coverage: 96.72% statements, 93.04% branches, 98.80% functions, 97.72% lines
- Reactivity coverage: 99.07% statements, 95.30% branches, 100% functions, 99.82% lines
- independent focused review completed with no remaining actionable finding