### PR TITLE
Restrict applications to persistent mount roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 - Isolated application instances with plugins, typed providers, dynamic
   functional components, lifecycle hooks, warnings, error boundaries,
   event/async ownership, deterministic unmount, and controlled exposure.
+- Persistent application mount ownership for `Element` and `ShadowRoot`, with
+  deterministic rejection of drainable plain `DocumentFragment` roots.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ const mount = app.mount(document.querySelector('#app')!);
 mount.unmount();
 ```
 
+Application mount roots are persistent `Element` or `ShadowRoot` instances;
+plain `DocumentFragment` objects are drainable and therefore rejected.
+
 Application and component lifecycle, plugin cleanup, dynamic component
 registries, error/warning ownership, event/async protection, and explicit
 public exposure are defined in the

--- a/docs/application-runtime.md
+++ b/docs/application-runtime.md
@@ -36,6 +36,11 @@ mount.exposed?.increment();
 mount.unmount();
 ```
 
+The mount container is a persistent `Element` or `ShadowRoot`. A plain
+`DocumentFragment` is rejected: inserting it into another node drains its
+children, so it cannot continue owning renderer state, application context, or
+later reactive updates.
+
 An application has three states: created, mounted, and unmounted. Plugins,
 providers, functional component registrations, and application hooks are
 registered while created. One application mounts once. A container can own one

--- a/src/application-context.ts
+++ b/src/application-context.ts
@@ -72,9 +72,11 @@ export type AppRoot<Public = unknown> =
   | TemplateResult
   | ((context: AppRootRenderContext<Public>) => TemplateResult);
 
+export type AppContainer = Element | ShadowRoot;
+
 export interface AppMount<Public = unknown> {
   readonly app: GluonApp<Public>;
-  readonly container: Element | DocumentFragment;
+  readonly container: AppContainer;
   readonly exposed: Readonly<Public> | undefined;
   unmount(): void;
 }
@@ -88,7 +90,7 @@ export interface GluonApp<Public = unknown> {
   component<Props>(name: string, component: FunctionalComponent<Props>): this;
   onMounted(callback: () => void | PromiseLike<void>): this;
   onUnmounted(callback: () => void | PromiseLike<void>): this;
-  mount(container: Element | DocumentFragment): AppMount<Public>;
+  mount(container: AppContainer): AppMount<Public>;
   unmount(): void;
   run<Result>(callback: () => Result | PromiseLike<Result>): Result | Promise<Result | undefined> | undefined;
 }

--- a/src/application.ts
+++ b/src/application.ts
@@ -17,6 +17,7 @@ import {
   unregisterApplicationRoot,
   warn,
   type AppConfig,
+  type AppContainer,
   type AppErrorSource,
   type AppMount,
   type AppPluginCleanup,
@@ -45,6 +46,7 @@ export {
   runActiveGuarded as runWithErrorHandling,
   warn,
   type AppConfig,
+  type AppContainer,
   type AppErrorHandler,
   type AppErrorInfo,
   type AppErrorSource,
@@ -107,7 +109,7 @@ class GluonAppImpl<Public> implements GluonApp<Public> {
   private readonly unmountedHooks: Array<() => void | PromiseLike<void>> = [];
   private readonly updateId = applicationSequence;
   private state: 'created' | 'mounted' | 'unmounted' = 'created';
-  private container?: Element | DocumentFragment;
+  private container?: AppContainer;
   private scope?: EffectScope;
   private runner?: ReactiveEffectRunner<void | undefined>;
   private publicExposure?: Readonly<Public>;
@@ -174,8 +176,11 @@ class GluonAppImpl<Public> implements GluonApp<Public> {
     return this;
   }
 
-  mount(container: Element | DocumentFragment): AppMount<Public> {
+  mount(container: AppContainer): AppMount<Public> {
     if (this.state !== 'created') throw new Error('A Gluon application can only be mounted once.');
+    if (!(container instanceof Element || container instanceof ShadowRoot)) {
+      throw new TypeError('A Gluon application mount requires a persistent Element or ShadowRoot.');
+    }
     if (mountedContainers.has(container)) throw new Error('The mount container already owns a Gluon application.');
     this.state = 'mounted';
     this.container = container;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export {
   runWithErrorHandling,
   warn,
   type AppConfig,
+  type AppContainer,
   type AppErrorHandler,
   type AppErrorInfo,
   type AppErrorSource,

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -86,6 +86,8 @@ appMount.exposed?.reset();
 void application.run(async () => 'complete');
 void runWithErrorHandling(async () => 'complete');
 appMount.unmount();
+// @ts-expect-error plain DocumentFragments are drainable and cannot own an application
+application.mount(document.createDocumentFragment());
 
 class PublicElement extends GluonElement {
   constructor() {

--- a/tests/application-runtime.spec.ts
+++ b/tests/application-runtime.spec.ts
@@ -344,6 +344,38 @@ describe('application runtime', () => {
     app.unmount();
   });
 
+  it('accepts persistent ShadowRoots and rejects drainable DocumentFragments', async () => {
+    let fragmentRenders = 0;
+    const fragmentApp = createApp(() => {
+      fragmentRenders += 1;
+      return html`<p>fragment</p>`;
+    });
+    const fragment = document.createDocumentFragment();
+    expect(() => fragmentApp.mount(fragment as never)).toThrow(/persistent Element or ShadowRoot/i);
+    expect(fragmentApp.mounted).toBe(false);
+    expect(fragmentRenders).toBe(0);
+    expect(fragment.childNodes).toHaveLength(0);
+
+    const valueKey = createInjectionKey<string>('shadow-value');
+    class ShadowContextFixture extends GluonElement {
+      protected override render() {
+        return html`<span>${inject(valueKey)}</span>`;
+      }
+    }
+    defineElement('gluon-shadow-context-fixture', ShadowContextFixture);
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    document.body.append(host);
+    const shadowApp = createApp(html`<gluon-shadow-context-fixture></gluon-shadow-context-fixture>`);
+    shadowApp.provide(valueKey, 'owned');
+    shadowApp.mount(shadowRoot);
+    const fixture = shadowRoot.querySelector('gluon-shadow-context-fixture') as ShadowContextFixture;
+    await fixture.updateComplete;
+    expect(fixture.shadowRoot?.textContent).toBe('owned');
+    shadowApp.unmount();
+    expect(shadowRoot.childNodes).toHaveLength(0);
+  });
+
   it('enforces application state and reports root and plugin failures', () => {
     const errors: AppErrorInfo[] = [];
     const missing = createInjectionKey<string>('required');


### PR DESCRIPTION
Closes #54.

## Summary

- add the public `AppContainer = Element | ShadowRoot` contract
- reject drainable plain `DocumentFragment` roots before mount state or rendering changes
- verify ShadowRoot application context and cleanup
- document the persistent-root ownership requirement

## Verification

- `npm run check`
- `npm audit` — 0 vulnerabilities
- 74 browser tests and 66 reactivity tests
- Core coverage: 96.72% statements, 93.07% branches, 98.80% functions, 97.73% lines
- independent review: no actionable findings