### PR TITLE
Add typed props, events, slots, models, and refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and released versions follow [Semantic Versioning](https://semver.org/).
   event/async ownership, deterministic unmount, and controlled exposure.
 - Persistent application mount ownership for `Element` and `ShadowRoot`, with
   deterministic rejection of drainable plain `DocumentFragment` roots.
+- Typed property and event declarations, native and scoped slot contracts,
+  standard and Custom Element model bindings, and deterministic host, callback,
+  element, and exposed-instance refs.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - reactive Custom Elements through `GluonElement`
 - isolated application instances with plugins, providers, lifecycle, dynamic
   functional components, error boundaries, and controlled public exposure
+- typed prop and event declarations, native/scoped slots, model bindings, and
+  deterministic element, callback, component-host, and exposed-instance refs
 - constructable `CSSStyleSheet` creation and `adoptedStyleSheets` adoption only
 - typed `q.<tag>()` Quark factories for `HTMLElementTagNameMap`
 - working Atom, Molecule, and Organism entry points
@@ -246,6 +248,19 @@ Application and component lifecycle, plugin cleanup, dynamic component
 registries, error/warning ownership, event/async protection, and explicit
 public exposure are defined in the
 [Application runtime contract](docs/application-runtime.md).
+
+## Component contracts
+
+`PropertyDeclarations<Props>` and `EventDeclarations<Events>` connect runtime
+validation to TypeScript contracts without replacing browser-native Custom
+Element properties and events. `SlotDeclarations` documents and checks native
+slots, `renderScopedSlot()` covers caller-owned functional slots, and
+`model()` provides controlled bindings for text, checkbox, radio, select, and
+Custom Element models. Renderer refs resolve to real nodes; `exposedRef()` maps
+a component host to only its explicitly exposed public object.
+
+The complete validation, ownership, modifier, fallthrough, and cleanup rules are
+defined in the [Component contracts](docs/component-contracts.md).
 
 ## Adopted stylesheets only
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,7 @@ tree-shakable.
 src/
 ├── application.ts      App instances, plugins, providers, registries, mount
 ├── application-context.ts  Context propagation, event guards, errors, warnings
+├── model.ts            Controlled native and Custom Element model bindings
 ├── runtime.ts          Template results, compiler plans, Parts, spreading, render
 ├── element.ts          Reactive Custom Element base and definition helper
 ├── component.ts        Atom, Molecule, and Organism metadata helpers
@@ -128,6 +129,17 @@ Custom Elements remain the only stateful component instances. Per-app named
 components are functional render functions; they do not own state, lifecycle,
 or a second DOM identity. The complete isolation, ordering, failure, and cleanup
 contract is documented in [Application runtime](application-runtime.md).
+
+## Public component contracts
+
+`element.ts` keeps property, event, native-slot, lifecycle, and public-exposure
+metadata on the Custom Element class. Runtime validation warns through the
+nearest application but preserves the supplied prop or event value. Native slot
+assignment retains Light DOM ownership. `component.ts` provides the scoped-slot
+functional convention, while `model.ts` composes controlled property/event
+spreads over the existing renderer. Element and callback refs remain renderer
+Parts; the exposed-ref adapter resolves only the frozen object published by the
+upgraded Custom Element. See [Component contracts](component-contracts.md).
 
 ### List identity
 

--- a/docs/component-contracts.md
+++ b/docs/component-contracts.md
@@ -1,0 +1,176 @@
+# Component input, output, slot, model, and ref contract
+
+Gluon's stateful component boundary is an autonomous `GluonElement`. Props are
+JavaScript properties with optional attribute transport, public outputs are
+native `CustomEvent` instances, projected content uses native slots, and refs
+resolve to real DOM or Custom Element hosts. Functional components remain typed
+functions without a second instance or lifecycle model.
+
+## Typed properties
+
+Use `PropertyDeclarations<Props>` to check a component's declaration against its
+public property interface:
+
+```ts
+interface CounterProps {
+  count: number;
+  label: string;
+}
+
+class GluonCounter extends GluonElement {
+  static override readonly properties = {
+    count: {
+      type: Number,
+      required: true,
+      reflect: true,
+      validate: (value) => value >= 0 || 'count must be non-negative',
+    },
+    label: { type: String, default: 'Count' },
+  } satisfies PropertyDeclarations<CounterProps>;
+
+  declare count: number;
+  declare label: string;
+}
+```
+
+Defaults, converters, attribute aliases, reflection, `hasChanged`, upgrade
+precedence, and disconnected writes retain the behavior defined by the
+[reactive element contract](reactive-elements.md). `required` checks whether a
+property or mapped attribute was supplied; a default does not count as caller
+input. A validator returns `true`, `false`, or a diagnostic string. Failed
+validation emits `GLUON_PROP_INVALID` and keeps the value, so validation does
+not silently change application state. Missing required input emits
+`GLUON_PROP_REQUIRED`. A validator that throws enters the owning application's
+error channel.
+
+Undeclared attributes are host attributes. They remain on the Custom Element and
+do not fall through into its ShadowRoot. Structured values, callbacks, nodes,
+and functions use property bindings such as `.value=${value}`; attribute
+serialization remains explicit.
+
+## Typed events
+
+Pass an event-detail map to `GluonElement` and check runtime metadata with
+`EventDeclarations<Events>`:
+
+```ts
+interface CounterEvents {
+  change: { value: number };
+}
+
+class GluonCounter extends GluonElement<CounterEvents> {
+  static override readonly events = {
+    change: {
+      cancelable: true,
+      validate: ({ value }) => Number.isFinite(value),
+    },
+  } satisfies EventDeclarations<CounterEvents>;
+
+  commit(value: number): boolean {
+    return this.emit('change', { value });
+  }
+}
+```
+
+The generic map rejects undeclared names and invalid detail values in component
+source. Runtime declarations set default `bubbles`, `composed`, and
+`cancelable` behavior and may validate detail. `bubbles` and `composed` default
+to `true`; `cancelable` defaults to `false`. Call-specific `CustomEventInit`
+values override declaration defaults. Failed validation warns with
+`GLUON_EVENT_INVALID` but still dispatches the event. When a component publishes
+an event declaration set, emitting another name warns with
+`GLUON_EVENT_UNDECLARED`.
+
+Consumers receive ordinary `CustomEvent` objects through native listeners.
+Functional components expose callbacks or render an element that emits an
+event; they do not own an event target.
+
+## Native and scoped slots
+
+Element components declare documentation and validation metadata with
+`SlotDeclarations` and render platform `<slot>` elements:
+
+```ts
+class GluonPanel extends GluonElement {
+  static override readonly slots = {
+    header: { required: true, fallback: true },
+    default: { fallback: true },
+  } satisfies SlotDeclarations<'header' | 'default'>;
+
+  protected render() {
+    return html`
+      <slot name="header"><h2>Untitled</h2></slot>
+      <slot><p>Empty</p></slot>
+    `;
+  }
+}
+```
+
+Required slots are checked after the first successful render of each connection;
+an empty required slot warns with `GLUON_SLOT_REQUIRED`. Assignment,
+`slotchange`, fallback display, and cleanup are native browser behavior. Light
+DOM nodes remain owned by the consumer and are never claimed or replaced by
+Gluon's ShadowRoot renderer.
+
+Scoped slots are JavaScript-only functional-component arguments:
+
+```ts
+const row: ScopedSlot<{ label: string }> = ({ label }) => html`<li>${label}</li>`;
+renderScopedSlot(row, { label: 'First' }, html`<li>Fallback</li>`);
+```
+
+`renderScopedSlot()` invokes the caller-owned function or returns its explicit
+fallback. The surrounding renderer owns the resulting Parts and DOM.
+
+## Two-way models
+
+`model(writable, options)` returns a spread binding. The writable value may be a
+Gluon reactivity `Ref` or any structural `{ value }` object:
+
+```ts
+const name = ref('Ada');
+const accepted = ref(false);
+
+html`
+  <input ...=${model(name, { modifiers: { trim: true } })}>
+  <input type="checkbox" ...=${model(accepted, { kind: 'checkbox' })}>
+`;
+```
+
+| Kind | Controlled property | Update event and value |
+| --- | --- | --- |
+| `text` (default) | `value` | `input`; `change` with `lazy` |
+| `checkbox` boolean | `checked` | `change` → boolean |
+| `checkbox` array | `checked` for the supplied `value` | `change` → new array using `Object.is` membership |
+| `radio` | `checked` for the supplied `value` | checked `change` → supplied value |
+| `select` | `value` | `change` → string or string array for `multiple` |
+| `custom` | `modelValue` by default | `update:modelValue` `CustomEvent.detail` by default |
+
+`trim` removes surrounding whitespace from strings. `number` converts a
+non-empty string with `Number.parseFloat` when conversion succeeds. `lazy`
+changes only the text-model event. A supplied `transform(value, event)` runs
+after built-in modifiers. Custom models may override `property`, `event`, and
+`modifiersProperty`; their frozen modifier record is also assigned to
+`modelValueModifiers` by default.
+
+Model writes use native events and do not synthesize extra `input` or `change`
+events when controlled values render back into a form control.
+
+## Refs and public exposure
+
+`elementRef<ElementType>()` creates an object ref for a real rendered element.
+A structural object ref or callback may also be passed directly through a
+spread's `ref` key. An element-component ref resolves to the stable Custom
+Element host. A functional component has no component-instance ref; refs in its
+result resolve to the concrete nodes rendered by its caller.
+
+`exposedRef(target)` maps a component-host ref to the object published by the
+element's protected `expose()` method. If renderer bindings run while template
+content is still inert, this adapter waits for the already registered Custom
+Element to upgrade before publishing the exposed object.
+
+Replacing, clearing, suspending, or unmounting a renderer owner detaches an
+active callback ref exactly once with `undefined` and clears an active object
+ref. Reconnection may attach the same retained node again. Exposed values reveal
+only the frozen public object; private ShadowRoot nodes and internal element
+state remain inaccessible through that adapter.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -60,6 +60,8 @@ Gluon currently provides:
   retention, and render diagnostics through `GluonElement`
 - isolated application instances with plugins, providers, dynamic functional
   component registries, lifecycle, warnings, error boundaries, and exposure
+- typed prop and event declarations, native and scoped slot contracts,
+  controlled form/Custom Element models, and deterministic public refs
 - constructable stylesheet creation and adopted stylesheet management
 - typed Quark factories for native HTML elements
 - representative Atom, Molecule, and Organism packages

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,4 +1,4 @@
-import type { TemplateResult } from './runtime.js';
+import { nothing, type TemplateResult, type TemplateValue } from './runtime.js';
 
 export type ComponentLayer = 'atom' | 'molecule' | 'organism';
 
@@ -6,6 +6,18 @@ export interface Component<Props = Record<string, never>> {
   (props: Props): TemplateResult;
   readonly layer: ComponentLayer;
   readonly displayName: string;
+}
+
+export type ScopedSlot<Props = Record<string, never>> = (
+  props: Readonly<Props>,
+) => TemplateValue;
+
+export function renderScopedSlot<Props>(
+  slot: ScopedSlot<Props> | undefined,
+  props: Readonly<Props>,
+  fallback: TemplateValue = nothing,
+): TemplateValue {
+  return slot ? slot(props) : fallback;
 }
 
 function defineComponent<Props>(

--- a/src/element.ts
+++ b/src/element.ts
@@ -1,4 +1,4 @@
-import { render, suspendRender, type TemplateResult } from './runtime.js';
+import { render, suspendRender, type RefTarget, type TemplateResult, type TemplateValue } from './runtime.js';
 import { adoptStyles } from './styles/index.js';
 import {
   effect,
@@ -11,6 +11,7 @@ import {
 } from '@gluonjs/reactivity';
 import {
   reportApplicationError,
+  reportApplicationWarning,
   resolveApplicationContext,
   runWithApplicationContext,
   type AppErrorSource,
@@ -29,7 +30,7 @@ export type GluonRenderCause =
   | { readonly type: 'reactive'; readonly dependency: EffectDebuggerEvent };
 
 export interface GluonRenderDebugEvent {
-  readonly element: GluonElement;
+  readonly element: GluonElement<any>;
   readonly causes: readonly GluonRenderCause[];
   readonly dependencies: readonly EffectDebuggerEvent[];
   readonly startedAt: number;
@@ -46,10 +47,34 @@ export type ComponentLifecycleCallback = () => void | PromiseLike<void>;
 export interface ComponentErrorInfo {
   readonly error: unknown;
   readonly source: AppErrorSource;
-  readonly element: GluonElement;
+  readonly element: GluonElement<any>;
 }
 
 export type ComponentErrorBoundary = (info: ComponentErrorInfo) => boolean | void;
+
+export interface EventDeclaration<Detail = unknown> {
+  readonly bubbles?: boolean;
+  readonly composed?: boolean;
+  readonly cancelable?: boolean;
+  readonly validate?: (detail: Detail) => boolean | string;
+}
+
+export type EventDeclarations<Events extends object = Record<string, unknown>> = Readonly<{
+  [Name in keyof Events]?: EventDeclaration<Events[Name]>;
+}>;
+
+export type ComponentEventMap<Events extends object> = {
+  readonly [Name in keyof Events]: CustomEvent<Events[Name]>;
+};
+
+export interface SlotDeclaration {
+  readonly required?: boolean;
+  readonly fallback?: boolean;
+}
+
+export type SlotDeclarations<Names extends string = string> = Readonly<
+  Partial<Record<Names, SlotDeclaration>>
+>;
 
 let renderDebugHook: GluonRenderDebugHook | undefined;
 
@@ -83,19 +108,27 @@ export interface PropertyDeclaration<Value = unknown> {
   readonly default?: Value | (() => Value);
   readonly converter?: PropertyConverter<Value>;
   readonly hasChanged?: (value: Value, oldValue: Value | undefined) => boolean;
+  readonly required?: boolean;
+  readonly validate?: (value: Value) => boolean | string;
 }
 
 export type PropertyDefinition<Value = unknown> = PropertyType | PropertyDeclaration<Value>;
-export type PropertyDeclarations = Readonly<Record<string, PropertyDefinition>>;
+export type PropertyDeclarations<Props extends object = Record<string, unknown>> = Readonly<{
+  [Name in keyof Props]: PropertyDefinition<Props[Name]>;
+}>;
 
-type GluonElementConstructor = typeof GluonElement & {
-  readonly properties?: PropertyDeclarations;
+type GluonElementConstructor = GluonElementClass & {
+  readonly properties?: Readonly<Record<string, PropertyDefinition<any>>>;
+  readonly events?: Readonly<Record<string, EventDeclaration<any>>>;
+  readonly slots?: SlotDeclarations;
   readonly styles?: CSSStyleSheet | readonly CSSStyleSheet[];
 };
 
 const finalizedConstructors = new WeakSet<Function>();
 const declarationCache = new WeakMap<Function, PropertyDeclarations>();
 const styleCache = new WeakMap<Function, readonly CSSStyleSheet[]>();
+const eventDeclarationCache = new WeakMap<Function, EventDeclarations>();
+const slotDeclarationCache = new WeakMap<Function, SlotDeclarations>();
 const propertyValues = Symbol('gluon.property-values');
 const setProperty = Symbol('gluon.set-property');
 const publicInstance = Symbol('gluon.public-instance');
@@ -108,17 +141,22 @@ interface UpdateDeferred {
 }
 
 interface CapturedComponentBoundary {
-  readonly element: GluonElement;
+  readonly element: GluonElement<any>;
   readonly context?: ApplicationContext;
   readonly callbacks: readonly ComponentErrorBoundary[];
 }
 
-export abstract class GluonElement extends HTMLElement {
-  static readonly properties: PropertyDeclarations = {};
+export abstract class GluonElement<
+  Events extends object = Record<string, unknown>,
+> extends HTMLElement {
+  static readonly properties: Readonly<Record<string, PropertyDefinition<any>>> = {};
+  static readonly events: Readonly<Record<string, EventDeclaration<any>>> = {};
+  static readonly slots: SlotDeclarations = {};
   static readonly styles: CSSStyleSheet | readonly CSSStyleSheet[] = [];
 
   protected readonly renderRoot: ShadowRoot;
   private readonly [propertyValues] = new Map<string, unknown>();
+  private readonly providedProperties = new Set<string>();
   private readonly updateId = elementUpdateSequence;
   private connected = false;
   private reflectingAttribute?: string;
@@ -150,7 +188,9 @@ export abstract class GluonElement extends HTMLElement {
 
   static get observedAttributes(): string[] {
     const attributes: string[] = [];
-    for (const [name, definition] of Object.entries(getDeclarations(this as GluonElementConstructor))) {
+    for (const [name, definition] of Object.entries(getDeclarations(
+      this as unknown as GluonElementConstructor,
+    ))) {
       const attribute = getAttributeName(name, normalizeDeclaration(definition));
       if (attribute) attributes.push(attribute);
     }
@@ -161,6 +201,7 @@ export abstract class GluonElement extends HTMLElement {
     if (this.connected) return;
     this.connected = true;
     this.applicationContext = resolveApplicationContext(this);
+    this.validateDeclaredProperties();
     adoptStyles(this.renderRoot, ...getStyles(this.constructor as GluonElementConstructor));
     this.reflectCurrentProperties();
     this.createRenderEffect();
@@ -255,14 +296,28 @@ export abstract class GluonElement extends HTMLElement {
     render(this.render(), this.renderRoot);
   }
 
-  protected emit<Detail>(
-    type: string,
-    detail: Detail,
-    init: Omit<CustomEventInit<Detail>, 'detail'> = {},
+  protected emit<Name extends keyof Events & string>(
+    type: Name,
+    detail: Events[Name],
+    init: Omit<CustomEventInit<Events[Name]>, 'detail'> = {},
   ): boolean {
+    const declarations = getEventDeclarations(this.constructor as GluonElementConstructor);
+    const declaration = declarations[type] as EventDeclaration<Events[Name]> | undefined;
+    if (Object.keys(declarations).length > 0 && !declaration) {
+      reportApplicationWarning(
+        this.applicationContext,
+        `Event "${type}" is not declared by ${this.localName}.`,
+        'GLUON_EVENT_UNDECLARED',
+        this,
+      );
+    }
+    if (declaration?.validate) {
+      this.validateContractValue('event', type, detail, declaration.validate);
+    }
     return this.dispatchEvent(new CustomEvent(type, {
-      bubbles: true,
-      composed: true,
+      bubbles: declaration?.bubbles ?? true,
+      composed: declaration?.composed ?? true,
+      cancelable: declaration?.cancelable ?? false,
       ...init,
       detail,
     }));
@@ -276,6 +331,10 @@ export abstract class GluonElement extends HTMLElement {
     declaration: PropertyDeclaration,
     reflect = true,
   ): void {
+    this.providedProperties.add(name);
+    if (this.connected && declaration.validate) {
+      this.validateContractValue('property', name, value, declaration.validate);
+    }
     const oldValue = this[propertyValues].get(name);
     const hasChanged = declaration.hasChanged ?? defaultHasChanged;
     if (!hasChanged(value, oldValue)) return;
@@ -348,6 +407,7 @@ export abstract class GluonElement extends HTMLElement {
       if (this.connectionRendered) this.invokeLifecycle(this.beforeUpdateHooks);
       this.runOwned(() => this.update());
       if (!this.connectionRendered) {
+        this.validateDeclaredSlots();
         this.connectionRendered = true;
         this.invokeLifecycle(this.connectedHooks);
       }
@@ -493,6 +553,71 @@ export abstract class GluonElement extends HTMLElement {
     return false;
   }
 
+  private validateDeclaredProperties(): void {
+    const declarations = getDeclarations(this.constructor as GluonElementConstructor);
+    for (const [name, definition] of Object.entries(declarations)) {
+      const declaration = normalizeDeclaration(definition);
+      if (declaration.required && !this.providedProperties.has(name)) {
+        reportApplicationWarning(
+          this.applicationContext,
+          `Required property "${name}" is missing on ${this.localName}.`,
+          'GLUON_PROP_REQUIRED',
+          this,
+        );
+      }
+      if (declaration.validate && this[propertyValues].has(name)) {
+        this.validateContractValue(
+          'property',
+          name,
+          this[propertyValues].get(name),
+          declaration.validate,
+        );
+      }
+    }
+  }
+
+  private validateDeclaredSlots(): void {
+    const declarations = getSlotDeclarations(this.constructor as GluonElementConstructor);
+    const slots = [...this.renderRoot.querySelectorAll('slot')];
+    for (const [name, declaration] of Object.entries(declarations)) {
+      if (!declaration?.required) continue;
+      const slotName = name === 'default' ? '' : name;
+      const assigned = slots
+        .filter((slot) => (slot.getAttribute('name') ?? '') === slotName)
+        .some((slot) => slot.assignedNodes().length > 0);
+      if (!assigned) {
+        reportApplicationWarning(
+          this.applicationContext,
+          `Required slot "${name}" is empty on ${this.localName}.`,
+          'GLUON_SLOT_REQUIRED',
+          this,
+        );
+      }
+    }
+  }
+
+  private validateContractValue<Value>(
+    kind: 'property' | 'event',
+    name: string,
+    value: Value,
+    validator: (value: Value) => boolean | string,
+  ): void {
+    try {
+      const result = validator(value);
+      if (result === true) return;
+      reportApplicationWarning(
+        this.applicationContext,
+        typeof result === 'string'
+          ? result
+          : `Invalid ${kind} value for "${name}" on ${this.localName}.`,
+        kind === 'property' ? 'GLUON_PROP_INVALID' : 'GLUON_EVENT_INVALID',
+        this,
+      );
+    } catch (error) {
+      reportApplicationError(this.applicationContext, error, 'application', this);
+    }
+  }
+
   private capturePreUpgradeProperties(constructor: GluonElementConstructor): void {
     const declarations = getDeclarations(constructor);
     for (const [name, definition] of Object.entries(declarations)) {
@@ -602,19 +727,58 @@ function getComposedParent(node: Node): Node | null {
 }
 
 export function getPublicInstance<Public extends object>(
-  element: GluonElement,
+  element: GluonElement<any>,
 ): Readonly<Public> | undefined {
   return element[publicInstance] as Readonly<Public> | undefined;
 }
 
-export type GluonElementClass<ElementType extends GluonElement = GluonElement> = {
-  new (): ElementType;
-} & typeof GluonElement;
+export type ValueRefTarget<Value> =
+  | { value: Value | undefined }
+  | ((value: Value | undefined) => void);
 
-export function defineElement<ElementType extends GluonElement>(
+export function exposedRef<Public extends object>(
+  target: ValueRefTarget<Readonly<Public>>,
+): RefTarget<GluonElement<any>> {
+  let currentElement: GluonElement<any> | undefined;
+  let attached = false;
+  const publish = (value: Readonly<Public> | undefined): void => {
+    if (typeof target === 'function') target(value);
+    else target.value = value;
+    attached = value !== undefined;
+  };
+  return (element) => {
+    currentElement = element;
+    if (!element) {
+      if (attached) publish(undefined);
+      return;
+    }
+    const resolve = (): void => {
+      if (currentElement !== element) return;
+      const value = getPublicInstance<Public>(element);
+      if (value !== undefined) publish(value);
+    };
+    resolve();
+    if (!attached) {
+      void customElements.whenDefined(element.localName).then(() => {
+        queueMicrotask(resolve);
+      });
+    }
+  };
+}
+
+export type GluonElementClass<ElementType extends GluonElement<any> = GluonElement<any>> = {
+  new (): ElementType;
+  readonly prototype: ElementType;
+  readonly properties?: Readonly<Record<string, PropertyDefinition<any>>>;
+  readonly events?: Readonly<Record<string, EventDeclaration<any>>>;
+  readonly slots?: SlotDeclarations;
+  readonly styles?: CSSStyleSheet | readonly CSSStyleSheet[];
+};
+
+export function defineElement<Constructor extends GluonElementClass>(
   tagName: `${string}-${string}`,
-  constructor: GluonElementClass<ElementType>,
-): GluonElementClass<ElementType> {
+  constructor: Constructor,
+): Constructor {
   const existing = customElements.get(tagName);
   if (existing && existing !== constructor) {
     throw new Error(`Custom element "${tagName}" is already defined with another constructor.`);
@@ -671,6 +835,30 @@ function getStyles(constructor: GluonElementConstructor): readonly CSSStyleSheet
   const styles = [...new Set([...inherited, ...ownStyles])];
   styleCache.set(constructor, styles);
   return styles;
+}
+
+function getEventDeclarations(constructor: GluonElementConstructor): EventDeclarations {
+  const cached = eventDeclarationCache.get(constructor);
+  if (cached) return cached;
+  const parent = Object.getPrototypeOf(constructor) as GluonElementConstructor | undefined;
+  const declarations = {
+    ...(parent?.prototype instanceof GluonElement ? getEventDeclarations(parent) : {}),
+    ...(constructor.events ?? {}),
+  } satisfies EventDeclarations;
+  eventDeclarationCache.set(constructor, declarations);
+  return declarations;
+}
+
+function getSlotDeclarations(constructor: GluonElementConstructor): SlotDeclarations {
+  const cached = slotDeclarationCache.get(constructor);
+  if (cached) return cached;
+  const parent = Object.getPrototypeOf(constructor) as GluonElementConstructor | undefined;
+  const declarations = {
+    ...(parent?.prototype instanceof GluonElement ? getSlotDeclarations(parent) : {}),
+    ...(constructor.slots ?? {}),
+  } satisfies SlotDeclarations;
+  slotDeclarationCache.set(constructor, declarations);
+  return declarations;
 }
 
 function normalizeDeclaration(definition: PropertyDefinition): PropertyDeclaration {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   type DirectiveRunner,
   type DirectiveValue,
   type EventBinding,
+  type RefTarget,
   type Key,
   type KeyedItem,
   type PartController,
@@ -27,16 +28,21 @@ export {
   type TemplateValue,
   type UnsafeHtmlResult,
   type UnsafeUrlResult,
+  elementRef,
 } from './runtime.js';
 
 export {
   GluonElement,
   defineElement,
+  exposedRef,
   getPublicInstance,
   setGluonRenderDebugHook,
   type ComponentErrorBoundary,
   type ComponentErrorInfo,
   type ComponentLifecycleCallback,
+  type ComponentEventMap,
+  type EventDeclaration,
+  type EventDeclarations,
   type GluonElementClass,
   type GluonRenderCause,
   type GluonRenderDebugEvent,
@@ -46,6 +52,9 @@ export {
   type PropertyDeclarations,
   type PropertyDefinition,
   type PropertyType,
+  type SlotDeclaration,
+  type SlotDeclarations,
+  type ValueRefTarget,
 } from './element.js';
 
 export {
@@ -78,9 +87,24 @@ export {
   defineAtom,
   defineMolecule,
   defineOrganism,
+  renderScopedSlot,
   type Component,
   type ComponentLayer,
+  type ScopedSlot,
 } from './component.js';
+
+export {
+  model,
+  type CheckboxModelOptions,
+  type CustomModelOptions,
+  type ModelBinding,
+  type ModelModifiers,
+  type ModelOptions,
+  type RadioModelOptions,
+  type SelectModelOptions,
+  type TextModelOptions,
+  type WritableModel,
+} from './model.js';
 
 export {
   mergeProps,

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,190 @@
+export interface WritableModel<Value> {
+  value: Value;
+}
+
+export interface ModelModifiers {
+  readonly trim?: boolean;
+  readonly number?: boolean;
+  readonly lazy?: boolean;
+}
+
+interface BaseModelOptions<Value> {
+  readonly modifiers?: ModelModifiers;
+  readonly transform?: (value: unknown, event: Event) => Value;
+}
+
+export interface TextModelOptions<Value> extends BaseModelOptions<Value> {
+  readonly kind?: 'text';
+}
+
+export type CheckboxModelOptions<Value> = BaseModelOptions<Value> & {
+  readonly kind: 'checkbox';
+} & (Value extends readonly (infer Item)[]
+  ? { readonly value: Item }
+  : Value extends boolean
+    ? { readonly value?: never }
+    : { readonly value?: unknown });
+
+export interface RadioModelOptions<Value> extends BaseModelOptions<Value> {
+  readonly kind: 'radio';
+  readonly value: Value;
+}
+
+export interface SelectModelOptions<Value> extends BaseModelOptions<Value> {
+  readonly kind: 'select';
+}
+
+export interface CustomModelOptions<Value> extends BaseModelOptions<Value> {
+  readonly kind: 'custom';
+  readonly property?: string;
+  readonly event?: string;
+  readonly modifiersProperty?: string;
+}
+
+export type ModelOptions<Value> =
+  | TextModelOptions<Value>
+  | CheckboxModelOptions<Value>
+  | RadioModelOptions<Value>
+  | SelectModelOptions<Value>
+  | CustomModelOptions<Value>;
+
+export type ModelBinding = Readonly<Record<string, unknown>>;
+
+export function model<Value>(
+  source: WritableModel<Value>,
+  options: ModelOptions<Value> = {},
+): ModelBinding {
+  switch (options.kind) {
+    case 'checkbox':
+      return checkboxBinding(source, options);
+    case 'radio':
+      return radioBinding(source, options);
+    case 'select':
+      return selectBinding(source, options);
+    case 'custom':
+      return customBinding(source, options);
+    case 'text':
+    case undefined:
+      return textBinding(source, options);
+  }
+}
+
+function textBinding<Value>(
+  source: WritableModel<Value>,
+  options: TextModelOptions<Value>,
+): ModelBinding {
+  const eventName = options.modifiers?.lazy ? 'onChange' : 'onInput';
+  return Object.freeze({
+    '.value': source.value,
+    [eventName]: (event: Event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+        throw new TypeError('A text model requires an input or textarea event target.');
+      }
+      source.value = resolveValue(target.value, event, options);
+    },
+  });
+}
+
+function checkboxBinding<Value>(
+  source: WritableModel<Value>,
+  options: CheckboxModelOptions<Value>,
+): ModelBinding {
+  const item = (options as BaseModelOptions<Value> & { readonly value?: unknown }).value;
+  const current = source.value;
+  const checked = Array.isArray(current)
+    ? current.some((value) => Object.is(value, item))
+    : Boolean(current);
+  return Object.freeze({
+    '.checked': checked,
+    ...(item === undefined ? {} : { '.value': item }),
+    onChange: (event: Event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLInputElement) || target.type !== 'checkbox') {
+        throw new TypeError('A checkbox model requires a checkbox input event target.');
+      }
+      if (Array.isArray(source.value)) {
+        const values = [...source.value] as unknown[];
+        const index = values.findIndex((value) => Object.is(value, item));
+        if (target.checked && index < 0) values.push(item);
+        if (!target.checked && index >= 0) values.splice(index, 1);
+        source.value = resolveValue(values, event, options);
+      } else {
+        source.value = resolveValue(target.checked, event, options);
+      }
+    },
+  });
+}
+
+function radioBinding<Value>(
+  source: WritableModel<Value>,
+  options: RadioModelOptions<Value>,
+): ModelBinding {
+  return Object.freeze({
+    '.checked': Object.is(source.value, options.value),
+    '.value': options.value,
+    onChange: (event: Event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLInputElement) || target.type !== 'radio') {
+        throw new TypeError('A radio model requires a radio input event target.');
+      }
+      if (target.checked) source.value = resolveValue(options.value, event, options);
+    },
+  });
+}
+
+function selectBinding<Value>(
+  source: WritableModel<Value>,
+  options: SelectModelOptions<Value>,
+): ModelBinding {
+  return Object.freeze({
+    '.value': source.value,
+    onChange: (event: Event) => {
+      const target = event.currentTarget;
+      if (!(target instanceof HTMLSelectElement)) {
+        throw new TypeError('A select model requires a select event target.');
+      }
+      const value = target.multiple
+        ? [...target.selectedOptions].map((option) => option.value)
+        : target.value;
+      source.value = resolveValue(value, event, options);
+    },
+  });
+}
+
+function customBinding<Value>(
+  source: WritableModel<Value>,
+  options: CustomModelOptions<Value>,
+): ModelBinding {
+  const property = options.property ?? 'modelValue';
+  const eventName = options.event ?? `update:${property}`;
+  const modifiersProperty = options.modifiersProperty ?? `${property}Modifiers`;
+  return Object.freeze({
+    [`.${property}`]: source.value,
+    [`.${modifiersProperty}`]: Object.freeze({ ...(options.modifiers ?? {}) }),
+    [`@${eventName}`]: (event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        throw new TypeError('A custom model update must use a CustomEvent.');
+      }
+      source.value = resolveValue(event.detail, event, options);
+    },
+  });
+}
+
+function resolveValue<Value>(
+  value: unknown,
+  event: Event,
+  options: BaseModelOptions<Value>,
+): Value {
+  let nextValue = value;
+  if (options.modifiers?.trim && typeof nextValue === 'string') {
+    nextValue = nextValue.trim();
+  }
+  if (options.modifiers?.number && typeof nextValue === 'string' && nextValue.length > 0) {
+    const numeric = Number.parseFloat(nextValue);
+    if (!Number.isNaN(numeric)) nextValue = numeric;
+  }
+  return options.transform
+    ? options.transform(nextValue, event)
+    : nextValue as Value;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -626,9 +626,15 @@ interface ResolvedEvent {
   readonly options?: boolean | AddEventListenerOptions;
 }
 
-type RefTarget =
-  | { value?: Element }
-  | ((element: Element | undefined) => void);
+export type RefTarget<ElementType extends Element = Element> =
+  | { value: ElementType | undefined }
+  | ((element: ElementType | undefined) => void);
+
+export function elementRef<ElementType extends Element = Element>(): {
+  value: ElementType | undefined;
+} {
+  return { value: undefined };
+}
 
 class SpreadPart implements Part {
   private readonly keys = new Set<string>();

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -4,10 +4,14 @@ import {
   createInjectionKey,
   directive,
   dynamicComponent,
+  elementRef,
   event,
+  exposedRef,
   getPublicInstance,
   html,
+  model,
   repeat,
+  renderScopedSlot,
   runWithErrorHandling,
   setGluonRenderDebugHook,
   suspendRender,
@@ -16,10 +20,14 @@ import {
   unsafeURL,
   type DirectiveLifecycle,
   type EventBinding,
+  type EventDeclarations,
   type GluonRenderDebugEvent,
   type GluonPlugin,
   type Key,
+  type PropertyDeclarations,
   type RepeatResult,
+  type ScopedSlot,
+  type SlotDeclarations,
   type TemplateValue,
 } from '@gluonjs/core';
 
@@ -106,6 +114,71 @@ class PublicElement extends GluonElement {
 }
 const publicInstance = getPublicInstance<{ reset(): void }>(null as unknown as PublicElement);
 publicInstance?.reset();
+
+interface TypedProps {
+  count: number;
+  label: string;
+}
+interface TypedEvents {
+  advance: { id: number };
+}
+class TypedElement extends GluonElement<TypedEvents> {
+  static override readonly properties = {
+    count: { type: Number, required: true, validate: (value) => value >= 0 },
+    label: { type: String, default: 'typed' },
+  } satisfies PropertyDeclarations<TypedProps>;
+
+  static override readonly events = {
+    advance: { cancelable: true, validate: ({ id }) => id > 0 },
+  } satisfies EventDeclarations<TypedEvents>;
+
+  static override readonly slots = {
+    default: { fallback: true },
+    actions: { required: true },
+  } satisfies SlotDeclarations<'default' | 'actions'>;
+
+  fire(): void {
+    this.emit('advance', { id: 1 });
+    // @ts-expect-error emitted details retain their declared type
+    this.emit('advance', { id: 'invalid' });
+    // @ts-expect-error undeclared event names are rejected
+    this.emit('missing', { id: 1 });
+  }
+
+  protected override render() {
+    return html`<slot></slot><slot name="actions"></slot>`;
+  }
+}
+void TypedElement;
+
+const typedSlot: ScopedSlot<{ count: number }> = ({ count }) => html`<b>${count}</b>`;
+renderScopedSlot(typedSlot, { count: 1 });
+// @ts-expect-error scoped slot props retain their type
+renderScopedSlot(typedSlot, { count: 'invalid' });
+
+const typedModel = { value: 'first' };
+model(typedModel, { kind: 'radio', value: 'second' });
+model({ value: false }, { kind: 'checkbox' });
+const arrayModel: { value: string[] } = { value: ['first'] };
+model<string[]>(arrayModel, { kind: 'checkbox', value: 'second' });
+// @ts-expect-error radio model values match the writable model type
+model(typedModel, { kind: 'radio', value: 2 });
+// @ts-expect-error array checkbox models require their item value
+model<string[]>(arrayModel, { kind: 'checkbox' });
+// @ts-expect-error boolean checkbox models do not accept an item value
+model({ value: false }, { kind: 'checkbox', value: 'invalid' });
+
+const buttonRef = elementRef<HTMLButtonElement>();
+buttonRef.value?.disabled;
+const exposedTarget: { value: Readonly<{ reset(): void }> | undefined } = { value: undefined };
+exposedRef(exposedTarget);
+
+const invalidPropertyDeclarations: PropertyDeclarations<TypedProps> = {
+  // @ts-expect-error prop validators receive the declared prop value type
+  count: { validate: (value: string) => value.length > 0 },
+  label: String,
+};
+void invalidPropertyDeclarations;
 
 // @ts-expect-error keys cannot be null
 repeat(rows, () => null, (row) => row.label);

--- a/tests/component-contracts.spec.ts
+++ b/tests/component-contracts.spec.ts
@@ -1,0 +1,387 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from '@gluonjs/reactivity';
+import {
+  GluonElement,
+  createApp,
+  defineElement,
+  elementRef,
+  exposedRef,
+  html,
+  model,
+  render,
+  renderScopedSlot,
+  unmount,
+  type AppErrorInfo,
+  type AppWarningInfo,
+  type EventDeclarations,
+  type PropertyDeclarations,
+  type ScopedSlot,
+  type SlotDeclarations,
+} from '../src/index.js';
+
+describe('typed component contracts', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('validates declared props and events while preserving host fallthrough attributes', async () => {
+    interface Props {
+      count: number;
+      explosive: string;
+      label: string;
+    }
+    interface Events {
+      advance: { value: number };
+    }
+
+    class ContractFixture extends GluonElement<Events> {
+      static override readonly properties = {
+        count: {
+          type: Number,
+          required: true,
+          validate: (value) => value >= 0 || 'count must be non-negative',
+        },
+        explosive: {
+          attribute: false,
+          validate: () => { throw new Error('prop validator failed'); },
+        },
+        label: { type: String, default: 'ready' },
+      } satisfies PropertyDeclarations<Props>;
+
+      static override readonly events = {
+        advance: {
+          cancelable: true,
+          validate: ({ value }) => value >= 0,
+        },
+      } satisfies EventDeclarations<Events>;
+
+      static override readonly slots = {
+        header: { required: true, fallback: true },
+        default: { fallback: true },
+      } satisfies SlotDeclarations<'header' | 'default'>;
+
+      declare count: number;
+      declare explosive: string;
+      declare label: string;
+
+      fire(value: number): boolean {
+        return this.emit('advance', { value });
+      }
+
+      fireUndeclared(): boolean {
+        const emit = this.emit as (type: string, detail: unknown) => boolean;
+        return emit.call(this, 'missing', { value: 1 });
+      }
+
+      protected override render() {
+        return html`
+          <slot name="header"><h2>Fallback header</h2></slot>
+          <output>${this.count}:${this.label}</output>
+          <slot><p>Fallback body</p></slot>
+        `;
+      }
+    }
+
+    defineElement('gluon-component-contract-fixture', ContractFixture);
+    const warnings: AppWarningInfo[] = [];
+    const errors: AppErrorInfo[] = [];
+    const app = createApp(html`
+      <gluon-component-contract-fixture
+        id="complete"
+        .count=${-1}
+        .explosive=${'boom'}
+        data-fallthrough="preserved"
+      >
+        <strong slot="header">Projected header</strong>
+        <span>Projected body</span>
+      </gluon-component-contract-fixture>
+      <gluon-component-contract-fixture id="missing"></gluon-component-contract-fixture>
+    `);
+    app.config.warnHandler = (info) => { warnings.push(info); };
+    app.config.errorHandler = (info) => { errors.push(info); };
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    const complete = root.querySelector('#complete') as ContractFixture;
+    const missing = root.querySelector('#missing') as ContractFixture;
+    await Promise.all([complete.updateComplete, missing.updateComplete]);
+
+    expect(complete.count).toBe(-1);
+    expect(complete.getAttribute('data-fallthrough')).toBe('preserved');
+    expect(complete.shadowRoot?.querySelector('[data-fallthrough]')).toBeNull();
+    expect(warnings.map(({ code }) => code)).toEqual(expect.arrayContaining([
+      'GLUON_PROP_INVALID',
+      'GLUON_PROP_REQUIRED',
+      'GLUON_SLOT_REQUIRED',
+    ]));
+    expect(errors).toEqual([
+      expect.objectContaining({
+        source: 'application',
+        error: expect.objectContaining({ message: 'prop validator failed' }),
+      }),
+    ]);
+
+    complete.count = 2;
+    await complete.updateComplete;
+    expect(complete.count).toBe(2);
+
+    const listener = vi.fn((event: Event) => event.preventDefault());
+    complete.addEventListener('advance', listener);
+    expect(complete.fire(-2)).toBe(false);
+    const emitted = listener.mock.calls[0]?.[0] as CustomEvent<{ value: number }>;
+    expect(emitted.detail).toEqual({ value: -2 });
+    expect(emitted.bubbles).toBe(true);
+    expect(emitted.composed).toBe(true);
+    expect(emitted.cancelable).toBe(true);
+    expect(warnings.at(-1)).toEqual(expect.objectContaining({ code: 'GLUON_EVENT_INVALID' }));
+    complete.fireUndeclared();
+    expect(warnings.at(-1)).toEqual(expect.objectContaining({ code: 'GLUON_EVENT_UNDECLARED' }));
+
+    app.unmount();
+  });
+
+  it('keeps native slot ownership and scoped slot output with their callers', async () => {
+    class SlotFixture extends GluonElement {
+      static override readonly slots = {
+        header: { required: true, fallback: true },
+        default: { fallback: true },
+      } satisfies SlotDeclarations<'header' | 'default'>;
+
+      protected override render() {
+        return html`
+          <slot name="header"><h2>Fallback header</h2></slot>
+          <slot><p>Fallback body</p></slot>
+        `;
+      }
+    }
+
+    defineElement('gluon-native-slot-fixture', SlotFixture);
+    const element = document.createElement('gluon-native-slot-fixture') as SlotFixture;
+    const header = document.createElement('strong');
+    header.slot = 'header';
+    header.textContent = 'Owned by consumer';
+    const body = document.createElement('span');
+    body.textContent = 'Body';
+    element.append(header, body);
+    document.body.append(element);
+    await element.updateComplete;
+
+    const headerSlot = element.shadowRoot?.querySelector('slot[name="header"]') as HTMLSlotElement;
+    const bodySlot = element.shadowRoot?.querySelector('slot:not([name])') as HTMLSlotElement;
+    expect(headerSlot.assignedNodes()).toEqual([header]);
+    expect(bodySlot.assignedNodes()).toEqual([body]);
+    expect(header.parentNode).toBe(element);
+
+    const changed = new Promise<void>((resolve) => {
+      headerSlot.addEventListener('slotchange', () => resolve(), { once: true });
+    });
+    header.remove();
+    await changed;
+    expect(headerSlot.assignedNodes()).toEqual([]);
+    expect(headerSlot.querySelector('h2')?.textContent).toBe('Fallback header');
+    expect(header.isConnected).toBe(false);
+
+    const scoped: ScopedSlot<{ value: string }> = ({ value }) => html`<b>${value}</b>`;
+    const root = document.createElement('div');
+    render(html`
+      ${renderScopedSlot(scoped, { value: 'scoped' })}
+      ${renderScopedSlot(undefined, { value: 'unused' }, html`<i>fallback</i>`)}
+    `, root);
+    expect(root.textContent?.replace(/\s+/g, ' ').trim()).toBe('scoped fallback');
+    unmount(root);
+    expect(root.childNodes).toHaveLength(0);
+  });
+
+  it('binds text, checkbox, radio, select, and custom-element models', async () => {
+    interface ModelEvents {
+      'update:modelValue': string;
+    }
+
+    class CustomModelFixture extends GluonElement<ModelEvents> {
+      static override readonly properties: PropertyDeclarations = {
+        modelValue: { attribute: false },
+        modelValueModifiers: { attribute: false },
+      };
+
+      static override readonly events = {
+        'update:modelValue': {},
+      } satisfies EventDeclarations<ModelEvents>;
+
+      declare modelValue: string;
+      declare modelValueModifiers: Record<string, boolean>;
+
+      updateValue(value: string): void {
+        this.emit('update:modelValue', value);
+      }
+
+      protected override render() {
+        return html`<span>${this.modelValue}</span>`;
+      }
+    }
+
+    defineElement('gluon-custom-model-fixture', CustomModelFixture);
+    const text = ref<string | number>('start');
+    const lazy = ref('lazy');
+    const checked = ref(false);
+    const selectedChecks = ref<string[]>([]);
+    const radio = ref('a');
+    const selected = ref('a');
+    const selectedMany = ref<string[]>(['a']);
+    const custom = ref('before');
+    const app = createApp(() => html`
+      <input id="text" ...=${model(text, { modifiers: { trim: true, number: true } })}>
+      <input id="lazy" ...=${model(lazy, {
+        modifiers: { lazy: true },
+        transform: (value) => String(value).toUpperCase(),
+      })}>
+      <input id="boolean" type="checkbox" ...=${model(checked, { kind: 'checkbox' })}>
+      <input id="check-a" type="checkbox" ...=${model(selectedChecks, { kind: 'checkbox', value: 'a' })}>
+      <input id="check-b" type="checkbox" ...=${model(selectedChecks, { kind: 'checkbox', value: 'b' })}>
+      <input id="radio-a" name="choice" type="radio" ...=${model(radio, { kind: 'radio', value: 'a' })}>
+      <input id="radio-b" name="choice" type="radio" ...=${model(radio, { kind: 'radio', value: 'b' })}>
+      <select id="select" ...=${model(selected, { kind: 'select' })}>
+        <option value="a">A</option><option value="b">B</option>
+      </select>
+      <select id="many" multiple ...=${model(selectedMany, { kind: 'select' })}>
+        <option value="a">A</option><option value="b">B</option>
+      </select>
+      <gluon-custom-model-fixture
+        id="custom"
+        ...=${model(custom, { kind: 'custom', modifiers: { trim: true } })}
+      ></gluon-custom-model-fixture>
+    `);
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+
+    const textInput = root.querySelector('#text') as HTMLInputElement;
+    textInput.value = ' 12.5 ';
+    textInput.dispatchEvent(new Event('input', { bubbles: true }));
+    await nextTick();
+    expect(text.value).toBe(12.5);
+    expect(textInput.value).toBe('12.5');
+
+    const lazyInput = root.querySelector('#lazy') as HTMLInputElement;
+    lazyInput.value = 'changed';
+    lazyInput.dispatchEvent(new Event('input', { bubbles: true }));
+    expect(lazy.value).toBe('lazy');
+    lazyInput.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(lazy.value).toBe('CHANGED');
+
+    const booleanInput = root.querySelector('#boolean') as HTMLInputElement;
+    booleanInput.checked = true;
+    booleanInput.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(checked.value).toBe(true);
+
+    const checkA = root.querySelector('#check-a') as HTMLInputElement;
+    const checkB = root.querySelector('#check-b') as HTMLInputElement;
+    checkA.checked = true;
+    checkA.dispatchEvent(new Event('change', { bubbles: true }));
+    checkB.checked = true;
+    checkB.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(selectedChecks.value).toEqual(['a', 'b']);
+    checkA.checked = false;
+    checkA.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(selectedChecks.value).toEqual(['b']);
+
+    const radioB = root.querySelector('#radio-b') as HTMLInputElement;
+    radioB.checked = true;
+    radioB.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(radio.value).toBe('b');
+    const radioA = root.querySelector('#radio-a') as HTMLInputElement;
+    radioA.checked = false;
+    radioA.dispatchEvent(new Event('change', { bubbles: true }));
+    expect(radio.value).toBe('b');
+
+    const select = root.querySelector('#select') as HTMLSelectElement;
+    select.value = 'b';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(selected.value).toBe('b');
+
+    const many = root.querySelector('#many') as HTMLSelectElement;
+    many.options[0]!.selected = false;
+    many.options[1]!.selected = true;
+    many.dispatchEvent(new Event('change', { bubbles: true }));
+    await nextTick();
+    expect(selectedMany.value).toEqual(['b']);
+
+    const customElement = root.querySelector('#custom') as CustomModelFixture;
+    await customElement.updateComplete;
+    expect(customElement.modelValue).toBe('before');
+    expect(customElement.modelValueModifiers).toEqual({ trim: true });
+    customElement.updateValue(' after ');
+    await nextTick();
+    expect(custom.value).toBe('after');
+    expect(customElement.modelValue).toBe('after');
+
+    app.unmount();
+  });
+
+  it('rejects model event handlers attached to incompatible targets', () => {
+    const handlers = [
+      (model({ value: '' }) as Record<string, EventListener>).onInput,
+      (model({ value: false }, { kind: 'checkbox' }) as Record<string, EventListener>).onChange,
+      (model({ value: 'a' }, { kind: 'radio', value: 'b' }) as Record<string, EventListener>).onChange,
+      (model({ value: 'a' }, { kind: 'select' }) as Record<string, EventListener>).onChange,
+      (model({ value: 'a' }, { kind: 'custom' }) as Record<string, EventListener>)['@update:modelValue'],
+    ];
+
+    for (const handler of handlers) {
+      expect(() => handler?.(new Event('invalid'))).toThrow(TypeError);
+    }
+  });
+
+  it('resolves element, callback, component-host, and exposed-instance refs once per owner', async () => {
+    class RefFixture extends GluonElement {
+      constructor() {
+        super();
+        this.expose({ label: () => 'public' });
+      }
+
+      protected override render() {
+        return html`<span>private</span>`;
+      }
+    }
+
+    defineElement('gluon-component-ref-fixture', RefFixture);
+    const button = elementRef<HTMLButtonElement>();
+    const componentCalls: Array<Element | undefined> = [];
+    const publicCalls: Array<Readonly<{ label(): string }> | undefined> = [];
+    const publicObject: { value: Readonly<{ label(): string }> | undefined } = {
+      value: undefined,
+    };
+    const componentRef = (element: Element | undefined) => { componentCalls.push(element); };
+    const publicRef = exposedRef<{ label(): string }>((value) => { publicCalls.push(value); });
+    const publicObjectRef = exposedRef<{ label(): string }>(publicObject);
+    const app = createApp(html`
+      <button ...=${{ ref: button }}>button</button>
+      <gluon-component-ref-fixture id="component" ...=${{ ref: componentRef }}></gluon-component-ref-fixture>
+      <gluon-component-ref-fixture id="public" ...=${{ ref: publicRef }}></gluon-component-ref-fixture>
+      <gluon-component-ref-fixture id="public-object" ...=${{ ref: publicObjectRef }}></gluon-component-ref-fixture>
+    `);
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    const component = root.querySelector('#component') as RefFixture;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(button.value).toBeInstanceOf(HTMLButtonElement);
+    expect(componentCalls).toEqual([component]);
+    expect(publicCalls).toHaveLength(1);
+    expect(publicCalls[0]?.label()).toBe('public');
+    expect(publicObject.value?.label()).toBe('public');
+
+    app.unmount();
+    expect(button.value).toBeUndefined();
+    expect(componentCalls).toEqual([component, undefined]);
+    expect(publicCalls).toEqual([expect.any(Object), undefined]);
+    expect(publicObject.value).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #24.

## Summary

- add typed property declarations with required and validator diagnostics while preserving Custom Element host fallthrough
- add typed native CustomEvent declarations and detail validation
- add native slot metadata/required-slot warnings and caller-owned scoped-slot rendering
- add controlled text, checkbox, radio, select, and Custom Element model bindings with modifiers
- add typed element refs and upgrade-safe exposed-instance refs with deterministic detach
- document the complete component contract and add public TypeScript/runtime conformance tests

## Verification

- `npm run check`
- `npm audit` — 0 vulnerabilities
- 79 browser tests and 66 reactivity tests
- Core coverage: 96.95% statements, 93.47% branches, 98.93% functions, 97.93% lines
- Reactivity coverage: 99.07% statements, 95.30% branches, 100% functions, 99.82% lines
- `model.ts`: 100% statements/functions/lines, 96.87% branches
- independent review: no actionable findings