### PR TITLE
Add async UI and rendering built-ins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,20 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 - The DOM-free `@gluonjs/store` package with inferred state, computed getters,
   actions, inspectable transactions, plugins, safe server snapshots,
   compatible-state HMR, persistence adapters, and isolated testing managers.
+- Core async boundaries and components with loading, nested fallback, timeout,
+  retry, abort, router preload, and explicit server-renderer descriptors.
+- Application-owned Teleport hosts, LRU KeepAlive view caching, cancellable
+  element/component transitions, and keyed FLIP transition groups with
+  reduced-motion behavior.
 - The living mobile-first GLUON GOODS reference shop with responsive
   navigation, catalog and product routes, configurable products, search, a
   reactive bag, generated product imagery, adopted stylesheet-only design, and
   a repository rule requiring applicable Gluon features to grow the same app.
 - GLUON GOODS now owns one official Store instance per application and persists
   configured bag lines without sharing transient UI state between applications.
+- GLUON GOODS now checks typed product availability asynchronously, caches route
+  views, teleports and transitions its accessible bag, and animates keyed bag
+  line changes through public Core APIs.
 - MIT licensing authorized by Marc Malerei.
 - Package topology, release governance, and supply-chain requirements.
 - A machine-readable package contract with independent export validation.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - child, attribute, property, boolean, event, and first-class spread bindings
 - official browser, hash, and memory routing with typed locations and guards
 - typed application-scoped stores with transactions, persistence, HMR, and SSR snapshots
+- async boundaries/components, application-owned teleports, cached views, and transitions
 - a living mobile-first GLUON GOODS reference shop built from public APIs
 - nested templates, index-based arrays, and keyed `repeat()` reconciliation
 - standalone DOM-free reactivity with refs, proxies, effects, and computed values
@@ -183,6 +184,33 @@ patches publish inspectable before/after transactions; plugins can add
 extensions and cleanup; versioned snapshots support safe serialization and
 hydration; and compatible top-level state survives `hotUpdate()`. Persistence
 requires an explicit storage adapter. See the [Store contract](docs/store.md).
+
+## Async UI and rendering built-ins
+
+Core provides deterministic asynchronous and cross-tree composition without a
+second component model:
+
+```ts
+import { KeepAlive, Suspense, Teleport, Transition, html, nothing } from '@gluonjs/core';
+
+const availability = Suspense({
+  source: ({ signal }) => loadAvailability(productId, signal),
+  fallback: html`<p>Checking availability…</p>`,
+  children: (result) => html`<p>${result.label}</p>`,
+  error: (_error, retry) => html`<button @click=${retry}>Retry</button>`,
+});
+
+Teleport({ to: document.body, children: dialog });
+KeepAlive({ cacheKey: route.fullPath, max: 4, children: RouterView() });
+Transition({ transitionKey: open, children: open ? dialog : nothing });
+```
+
+Async components add cached loading, failure, timeout, retry, and `preload()`
+behavior. Teleport retains application context and cleans its external host.
+KeepAlive suspends cached renderer resources and evicts least-recently-used
+entries. Transition and TransitionGroup cancel stale Web Animations and honor
+reduced-motion preferences. A public DOM-free descriptor is available to the
+future server renderer. See [Async UI and rendering built-ins](docs/async-ui.md).
 
 ## Bindings and spreading
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,7 @@ tree-shakable.
 src/
 ├── application.ts      App instances, plugins, providers, registries, mount
 ├── application-context.ts  Context propagation, event guards, errors, warnings
+├── builtins.ts         Suspense, async components, Teleport, KeepAlive, transitions
 ├── model.ts            Controlled native and Custom Element model bindings
 ├── runtime.ts          Template results, compiler plans, Parts, spreading, render
 ├── element.ts          Reactive Custom Element base and definition helper

--- a/docs/async-ui.md
+++ b/docs/async-ui.md
@@ -1,0 +1,125 @@
+# Async UI and rendering built-ins
+
+Gluon Core provides async boundaries, lazy functional components, application-
+owned teleports, cached views, and cancellable transitions. All visible
+built-ins return ordinary `TemplateValue` values and participate in renderer
+cleanup.
+
+## Suspense
+
+`Suspense()` owns one abort controller and monotonically increasing attempt for
+each rendered Part. A source is either a promise or a loader receiving
+`{ signal, attempt }`:
+
+```ts
+const inventory = Suspense({
+  source: ({ signal }) => loadInventory(productId, signal),
+  fallback: html`<p>Checking inventory…</p>`,
+  delay: 50,
+  timeout: 2_000,
+  children: (result) => html`<p>${result.label}</p>`,
+  error: (error, retry) => html`
+    <p>${String(error)}</p>
+    <button @click=${retry}>Retry</button>
+  `,
+});
+```
+
+- `fallback` is explicit and may contain another `Suspense()` boundary.
+- `delay` prevents a fallback flash when cached work resolves quickly.
+- `timeout` aborts the attempt and renders an `AsyncTimeoutError` through the
+  error callback.
+- Retry cancels the previous attempt and starts the same loader with the next
+  attempt number.
+- Source replacement, render suspension, and unmount abort pending work.
+- `sourceKey` keeps one logical request alive across unrelated parent renders
+  while adopting the newest fallback, children, and error callbacks.
+- Late resolutions and rejections from cancelled attempts cannot update the
+  Part.
+
+If no error callback exists, a failed boundary renders `nothing`. A retryable
+source must be a loader rather than one already-settled promise.
+
+## Async components
+
+`defineAsyncComponent()` creates a typed functional component with loading,
+error, timeout, and retry rendering. Resolved component definitions are cached.
+The returned function also exposes:
+
+- `preload()` — shares concurrent preload work and resolves when the component
+  definition is available;
+- `reset()` — clears the resolved definition for HMR or an explicit retry;
+- `resolved` — reports whether calling the component is synchronous.
+
+Routers may use an async component as a normal route component. Servers call
+`preload()` before rendering; the following component call then returns its
+normal synchronous template.
+
+## Teleport
+
+`Teleport({ to, children })` renders through an internal `display: contents`
+host appended to an `Element` or selector target. The host is registered with
+the active Gluon application, so injected context, guarded events, component
+errors, and nested renderer ownership remain attached to the source app even
+when the target is outside its mount root.
+
+Updating `to` moves the same host. Disabling Teleport renders children locally.
+Replacement, suspension, or app unmount disconnects the nested renderer,
+unregisters application ownership, and removes the host.
+
+## KeepAlive
+
+`KeepAlive({ cacheKey, children, max })` stores one renderer host per key. A
+deactivated entry is removed from the live Part and `suspendRender()` releases
+its listeners, refs, and directive resources while retaining DOM and component
+state. Activation renders current inputs into the retained host before it is
+reconnected.
+
+`max` is a positive integer. Once exceeded, the least-recently-used inactive
+entry is permanently unmounted. `onActivated`, `onDeactivated`, and `onEvicted`
+provide deterministic lifecycle evidence. Disconnecting KeepAlive unmounts
+every entry, including the active entry.
+
+## Transition
+
+`Transition()` animates direct element roots with the Web Animations API.
+Replacement runs leave keyframes, renders the latest content, then runs enter
+keyframes. A new update cancels owned animations and uses a generation guard so
+stale completions cannot commit. Supplying `transitionKey` makes ordinary
+updates with the same identity commit synchronously; only identity changes run
+leave/enter.
+
+`TransitionGroup()` composes `repeat()` with unique stable keys. Retained
+elements keep identity, moved elements use FLIP transforms, inserted elements
+use enter keyframes, and removed elements animate a fixed-position visual clone
+before cleanup. A new group update cancels animations and removes outstanding
+clones.
+
+Both APIs accept custom enter/leave keyframes, duration, and easing.
+`reducedMotion: true` disables animation explicitly; the default and
+`'system'` read `prefers-reduced-motion: reduce` and commit immediately.
+
+## Server contract
+
+Built-in directive markers remain private to the browser renderer.
+`getBuiltinServerContract(value)` is the public, DOM-free handoff for issue #35:
+
+- Suspense exposes `resolve()`, including timeout and error/fallback behavior.
+- Teleport exposes target and content for collection or in-place server policy.
+- KeepAlive and transitions expose content because caching and animation are
+  browser lifecycle behavior.
+- TransitionGroup exposes keyed repeated content.
+
+The future server renderer consumes these descriptors rather than inspecting
+private runtime symbols. The descriptor contract itself is covered now; HTML
+streaming and hydration behavior remain owned by issues #35–#37.
+
+## Verification
+
+- `tests/builtins.spec.ts` covers loading, nesting, retry, timeout, abort,
+  router/preload behavior, context ownership, cache retention/eviction,
+  cancellation, reduced motion, keyed identity, and server descriptors.
+- `tests/shop-example.spec.ts` covers async product availability, cached route
+  identity, teleported bag interaction and cleanup, persisted lines, and the
+  customer flow.
+- `tests-node/core.types.ts` covers public inference and invalid calls.

--- a/docs/dom-runtime.md
+++ b/docs/dom-runtime.md
@@ -75,6 +75,11 @@ the update error; it does not promote the failed arguments to active state.
 The legacy factory form remains supported and runs its returned function on
 each application. It has no lifecycle hooks.
 
+Core async, teleport, cache, and transition built-ins use this lifecycle
+contract. Their update cancellation, application ownership, LRU eviction,
+reduced-motion, and server-descriptor behavior is defined in
+[Async UI and rendering built-ins](async-ui.md).
+
 ## Event options
 
 Plain `@event=${listener}` and spread `onEvent`/`@event` values use native

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,6 +67,8 @@ Gluon currently provides:
   failures, scroll restoration, and server snapshots
 - an official DOM-free store with inferred state/getters/actions, transactions,
   plugins, compatible-state HMR, safe snapshots, persistence, and test isolation
+- async boundaries/components, application-owned teleports, LRU cached views,
+  cancellable transitions, keyed transition groups, and server descriptors
 - the first living GLUON GOODS reference-shop slice with public-package routes,
   responsive navigation, catalog, product configuration, search, and bag flows
 - constructable stylesheet creation and adopted stylesheet management

--- a/examples/shop/FEATURES.md
+++ b/examples/shop/FEATURES.md
@@ -9,5 +9,8 @@
 | Adopted stylesheets | Complete responsive shop presentation | Shop browser test + visual QA | Integrated |
 | Native dialog and control accessibility | Search, mobile menu, product choices, and bag | `tests/shop-example.spec.ts` + 390px/320px browser QA | Integrated |
 | Official Store | Per-app bag state, configured line items, persisted bag, derived totals | Store Node/type suites + `tests/shop-example.spec.ts` | Integrated |
-| Async UI primitives | Inventory loading, lazy media, transition states | Issue #27 | Pending package |
+| `Suspense` and async component contract | Abortable product availability loading, explicit pending/error/retry states | Built-ins browser suite + `tests/shop-example.spec.ts` | Integrated |
+| `Teleport` and `Transition` | Application-owned, animated accessible bag overlay | Built-ins context/cleanup suite + shop browser test | Integrated |
+| `KeepAlive` | Route view retention across product back/forward traversal | Built-ins LRU suite + shop node-identity assertion | Integrated |
+| `TransitionGroup` | Keyed bag line insertion/removal/movement | Built-ins identity/reduced-motion suite + shop bag flow | Integrated |
 | SSR and hydration | Deep product URL server response and hydration | Issues #35–#37 | Pending packages |

--- a/examples/shop/README.md
+++ b/examples/shop/README.md
@@ -15,12 +15,18 @@ The current slice uses the public Core, Reactivity, Router, and Store APIs to pr
 - keyboard-operable product configuration
 - a reactive bag with configured line items and quantities
 - one isolated Store manager per shop application and persisted configured bag lines
+- abortable product availability with explicit loading, error, timeout, and retry UI
+- cached route views across back/forward traversal
+- an application-owned teleported bag with cancellable enter/leave transitions
+- keyed bag-line transitions with system reduced-motion handling
 - modal initial focus, keyboard focus containment, and focus restoration
 - 44px minimum mobile action targets at 390px and 320px
 - constructable stylesheet-only design
 
-The async UI package does not exist yet. Issue #27 will add inventory, media,
-loading, and transition behavior to the same customer journey.
+Async UI is part of Core because it composes renderer Parts and application
+ownership directly. Universal HTML rendering and hydration remain pending in
+issues #35–#37; Core already exposes the DOM-free descriptors those packages
+will consume.
 
 ## Run
 
@@ -71,8 +77,8 @@ shop source.
 
 `npm run measure:shop` performs a production build and reports raw and level-9
 gzip byte counts from the generated files. For this slice, the single browser
-entry that contains Core, Reactivity, Router, Store, and the shop is 106,159 bytes
-raw and 29,921 bytes gzip. The five WebP product/editorial assets total 155,126
+entry that contains Core, Reactivity, Router, Store, async built-ins, and the shop
+is 116,909 bytes raw and 33,371 bytes gzip. The five WebP product/editorial assets total 155,126
 bytes. These are composition measurements, not a rendering-speed claim. The
 comparative Gluon, Lit, Vue, and Vanilla DOM benchmark belongs to issue #38 and
 must publish its scenarios, browser versions, warm-up, samples, and raw results

--- a/examples/shop/src/app.ts
+++ b/examples/shop/src/app.ts
@@ -1,6 +1,6 @@
-import { createApp, html, type GluonApp } from '@gluonjs/core';
+import { KeepAlive, createApp, html, type GluonApp } from '@gluonjs/core';
 import {
-  BagDrawer,
+  BagOverlay,
   SiteFooter,
   SiteHeader,
 } from './components.js';
@@ -68,12 +68,19 @@ export function createShopApplication(
     store.searchOpen = false;
     store.bagOpen = false;
   });
-  const app = createApp(() => html`
-    ${SiteHeader(store)}
-    <main id="main-content">${RouterView()}</main>
-    ${SiteFooter()}
-    ${BagDrawer(store)}
-  `);
+  const app = createApp(() => {
+    const route = router.currentRoute.value;
+    return html`
+      ${SiteHeader(store)}
+      <main id="main-content">${KeepAlive({
+        cacheKey: route.fullPath,
+        max: 4,
+        children: RouterView(),
+      })}</main>
+      ${SiteFooter()}
+      ${BagOverlay(store)}
+    `;
+  });
   app.use(createRouterPlugin(router));
   app.onUnmounted(() => storeManager.dispose());
   return { app, router, storeManager, store };

--- a/examples/shop/src/components.ts
+++ b/examples/shop/src/components.ts
@@ -1,4 +1,12 @@
-import { html, nothing, repeat, type TemplateValue } from '@gluonjs/core';
+import {
+  Teleport,
+  Transition,
+  TransitionGroup,
+  html,
+  nothing,
+  repeat,
+  type TemplateValue,
+} from '@gluonjs/core';
 import { nextTick } from '@gluonjs/reactivity';
 import { RouterLink } from '@gluonjs/router';
 import { categories, formatPrice, products, type Product } from './data.js';
@@ -102,8 +110,18 @@ export function CategoryLinks(): TemplateValue {
   `;
 }
 
-export function BagDrawer(store: ShopStore): TemplateValue {
-  if (!store.bagOpen) return nothing;
+export function BagOverlay(store: ShopStore): TemplateValue {
+  return Teleport({
+    to: document.body,
+    children: Transition({
+      duration: 140,
+      transitionKey: store.bagOpen ? 'open' : 'closed',
+      children: store.bagOpen ? BagDrawer(store) : nothing,
+    }),
+  });
+}
+
+function BagDrawer(store: ShopStore): TemplateValue {
   const close = (): void => dismissDialog('bag', () => { store.bagOpen = false; });
   return html`
     <div class="drawer-layer" @click=${(event: Event) => {
@@ -127,7 +145,11 @@ export function BagDrawer(store: ShopStore): TemplateValue {
           </div>
         ` : html`
           <div class="bag-lines">
-            ${repeat(store.bag, (line) => line.key, (line) => html`
+            ${TransitionGroup({
+              items: store.bag,
+              key: (line) => line.key,
+              duration: 140,
+              children: (line) => html`
               <article class="bag-line">
                 <img src=${line.product.image} alt="">
                 <div class="bag-line-copy">
@@ -150,7 +172,8 @@ export function BagDrawer(store: ShopStore): TemplateValue {
                   </div>
                 </div>
               </article>
-            `)}
+              `,
+            })}
           </div>
           <footer class="bag-summary">
             <div><span>Subtotal</span><strong>${formatPrice(store.bagTotal)}</strong></div>

--- a/examples/shop/src/data.ts
+++ b/examples/shop/src/data.ts
@@ -8,6 +8,8 @@ export interface Product {
   readonly description: string;
   readonly image: string;
   readonly alt: string;
+  readonly availability: 'in-stock' | 'low-stock';
+  readonly dispatch: '1–2 days' | '2–3 days';
 }
 
 export const products: readonly Product[] = Object.freeze([
@@ -19,6 +21,8 @@ export const products: readonly Product[] = Object.freeze([
     description: 'Focused light, tuned to your space.',
     image: new URL('../assets/orbit-lamp.webp', import.meta.url).href,
     alt: 'Black Orbit desk lamp with an opal shade and cobalt control',
+    availability: 'in-stock',
+    dispatch: '2–3 days',
   },
   {
     slug: 'field-tote',
@@ -28,6 +32,8 @@ export const products: readonly Product[] = Object.freeze([
     description: 'Structured carry with a place for every module.',
     image: new URL('../assets/field-tote.webp', import.meta.url).href,
     alt: 'Cobalt Field Tote with black leather handles and base',
+    availability: 'low-stock',
+    dispatch: '1–2 days',
   },
   {
     slug: 'stack-tray',
@@ -37,6 +43,8 @@ export const products: readonly Product[] = Object.freeze([
     description: 'A two-level organizer that changes with your desk.',
     image: new URL('../assets/stack-tray.webp', import.meta.url).href,
     alt: 'Cobalt two-tier Stack Tray desktop organizer',
+    availability: 'in-stock',
+    dispatch: '2–3 days',
   },
   {
     slug: 'fold-stool',
@@ -46,6 +54,8 @@ export const products: readonly Product[] = Object.freeze([
     description: 'A compact seat that folds when the room needs to change.',
     image: new URL('../assets/fold-stool.webp', import.meta.url).href,
     alt: 'Black folding stool with a woven seat and tubular frame',
+    availability: 'low-stock',
+    dispatch: '2–3 days',
   },
 ]);
 

--- a/examples/shop/src/pages.ts
+++ b/examples/shop/src/pages.ts
@@ -1,4 +1,4 @@
-import { html, repeat, type TemplateValue } from '@gluonjs/core';
+import { Suspense, html, repeat, type AsyncLoadContext, type TemplateValue } from '@gluonjs/core';
 import { RouterLink, useRoute } from '@gluonjs/router';
 import {
   categories,
@@ -164,6 +164,7 @@ function ProductConfigurator(product: Product, store: ShopStore): TemplateValue 
         <div><h1 id="product-title">${product.name}</h1><p>${product.description}</p></div>
         <strong>${formatPrice(product.price)}</strong>
       </div>
+      ${InventoryStatus(product)}
       ${ChoiceGroup(store, 'Finish', 'finish', ['Graphite', 'Cobalt', 'Bone'])}
       ${ChoiceGroup(store, 'Light temperature', 'temperature', ['Warm 2700K', 'Clear 3200K'])}
       ${ChoiceGroup(store, 'Cable length', 'cable', ['1.5 m', '2.5 m'])}
@@ -180,6 +181,50 @@ function ProductConfigurator(product: Product, store: ShopStore): TemplateValue 
       </ul>
     </section>
   `;
+}
+
+interface InventoryResult {
+  readonly label: string;
+  readonly dispatch: string;
+}
+
+const inventoryCache = new Map<string, InventoryResult>();
+
+function InventoryStatus(product: Product): TemplateValue {
+  return html`<div class="inventory-status" role="status" aria-live="polite">${Suspense({
+    source: (context) => loadInventory(product, context),
+    sourceKey: product.slug,
+    fallback: html`<span class="inventory-pending">Checking workshop availability…</span>`,
+    delay: 50,
+    timeout: 2_000,
+    children: (inventory) => html`
+      <span class=${`inventory-dot inventory-${product.availability}`} aria-hidden="true"></span>
+      <span>${inventory.label} · dispatches in ${inventory.dispatch}</span>
+    `,
+    error: (_error, retry) => html`
+      <span>Availability could not be checked.</span>
+      <button class="inline-link inventory-retry" type="button" @click=${retry}>Retry</button>
+    `,
+  })}</div>`;
+}
+
+function loadInventory(product: Product, { signal }: AsyncLoadContext): Promise<InventoryResult> {
+  const cached = inventoryCache.get(product.slug);
+  if (cached) return Promise.resolve(cached);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const result = {
+        label: product.availability === 'in-stock' ? 'In stock' : 'Low stock',
+        dispatch: product.dispatch,
+      };
+      inventoryCache.set(product.slug, result);
+      resolve(result);
+    }, 320);
+    signal.addEventListener('abort', () => {
+      clearTimeout(timer);
+      reject(new DOMException('Inventory request aborted.', 'AbortError'));
+    }, { once: true });
+  });
 }
 
 function ChoiceGroup<Key extends keyof ProductConfiguration>(

--- a/examples/shop/src/styles.ts
+++ b/examples/shop/src/styles.ts
@@ -344,6 +344,11 @@ export const shopStyles = css`
     .product-facts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; padding: 19px 0; margin: 0; border-bottom: 1px solid var(--shop-rule); list-style: none; font-size: 11px; }
     .product-facts li { padding-right: 8px; border-right: 1px solid var(--shop-rule); }
     .product-facts li:last-child { border-right: 0; }
+    .inventory-status { min-height: 44px; display: flex; align-items: center; gap: 8px; border-top: 1px solid var(--shop-rule); border-bottom: 1px solid var(--shop-rule); font-size: 12px; }
+    .inventory-dot { width: 8px; height: 8px; flex: 0 0 auto; border-radius: 50%; background: var(--shop-action); box-shadow: 0 0 0 1px rgb(17 17 17 / 28%); }
+    .inventory-low-stock { background: #ffb347; }
+    .inventory-pending { color: var(--shop-muted); }
+    .inventory-retry { min-height: 44px; border: 0; background: transparent; color: inherit; }
     .product-story { display: grid; grid-template-columns: 1.2fr 1fr 1fr; gap: clamp(30px, 5vw, 90px); margin-top: 70px; padding-top: 34px; border-top: 1px solid var(--shop-black); }
     .product-story h2 { font-size: 19px; font-weight: 560; }
     .product-story p { max-width: 540px; line-height: 1.7; }

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1,0 +1,866 @@
+import {
+  getActiveApplicationContext,
+  registerApplicationRoot,
+  unregisterApplicationRoot,
+  type ApplicationContext,
+  type FunctionalComponent,
+} from './application-context.js';
+import {
+  directive,
+  html,
+  nothing,
+  repeat,
+  render,
+  suspendRender,
+  unmount,
+  type Key,
+  type PartController,
+  type TemplateValue,
+} from './runtime.js';
+
+export interface AsyncLoadContext {
+  readonly signal: AbortSignal;
+  readonly attempt: number;
+}
+
+export type AsyncSource<Value> =
+  | PromiseLike<Value>
+  | ((context: AsyncLoadContext) => PromiseLike<Value>);
+
+export interface SuspenseProps<Value> {
+  readonly source: AsyncSource<Value>;
+  readonly sourceKey?: Key;
+  readonly fallback: TemplateValue;
+  readonly children: (value: Value) => TemplateValue;
+  readonly error?: (error: unknown, retry: () => void) => TemplateValue;
+  readonly delay?: number;
+  readonly timeout?: number;
+}
+
+export type BuiltinServerContract =
+  | {
+      readonly kind: 'suspense';
+      resolve(): Promise<TemplateValue>;
+    }
+  | {
+      readonly kind: 'teleport';
+      readonly content: TemplateValue;
+      readonly target: Element | string;
+    }
+  | {
+      readonly kind: 'keep-alive' | 'transition' | 'transition-group';
+      readonly content: TemplateValue;
+    };
+
+const builtinServerContracts = new WeakMap<object, BuiltinServerContract>();
+
+/** Returns the DOM-free server behavior for a built-in directive value. */
+export function getBuiltinServerContract(value: unknown): BuiltinServerContract | undefined {
+  return typeof value === 'object' && value !== null
+    ? builtinServerContracts.get(value)
+    : undefined;
+}
+
+export class AsyncTimeoutError extends Error {
+  constructor(readonly timeout: number) {
+    super(`Async boundary timed out after ${timeout} ms.`);
+    this.name = 'AsyncTimeoutError';
+  }
+}
+
+interface AsyncBoundaryState {
+  generation: number;
+  attempt: number;
+  controller?: AbortController;
+  delayTimer?: ReturnType<typeof setTimeout>;
+  timeoutTimer?: ReturnType<typeof setTimeout>;
+  props: SuspenseProps<unknown>;
+  sourceKey?: Key;
+}
+
+const asyncBoundaries = new WeakMap<PartController, AsyncBoundaryState>();
+
+const suspenseDirective = directive<readonly [SuspenseProps<unknown>]>(
+  {
+    mount(part, [props]) {
+      const state: AsyncBoundaryState = {
+        generation: 0,
+        attempt: 0,
+        props,
+        sourceKey: props.sourceKey,
+      };
+      asyncBoundaries.set(part, state);
+      startAsyncBoundary(part, state);
+    },
+    update(part, [props]) {
+      const state = asyncBoundaries.get(part);
+      if (!state) return;
+      if (props.sourceKey !== undefined && Object.is(props.sourceKey, state.sourceKey)) {
+        state.props = props;
+        return;
+      }
+      cancelAsyncBoundary(state);
+      state.props = props;
+      state.sourceKey = props.sourceKey;
+      startAsyncBoundary(part, state);
+    },
+    cleanup() {
+      // update() decides whether a logical source continues; disconnect aborts.
+    },
+    disconnect(part) {
+      const state = asyncBoundaries.get(part);
+      if (state) cancelAsyncBoundary(state);
+      asyncBoundaries.delete(part);
+    },
+  },
+);
+
+/** Renders one explicit fallback while an abortable asynchronous source settles. */
+export function Suspense<Value>(props: SuspenseProps<Value>): TemplateValue {
+  validateDelay(props.delay, 'delay');
+  validateDelay(props.timeout, 'timeout');
+  const value = suspenseDirective(props as SuspenseProps<unknown>);
+  builtinServerContracts.set(value, {
+    kind: 'suspense',
+    resolve: () => resolveSuspenseForServer(props),
+  });
+  return value;
+}
+
+async function resolveSuspenseForServer<Value>(props: SuspenseProps<Value>): Promise<TemplateValue> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const source = typeof props.source === 'function'
+      ? props.source({ signal: controller.signal, attempt: 1 })
+      : props.source;
+    const result = props.timeout === undefined
+      ? await source
+      : await Promise.race([
+          source,
+          new Promise<Value>((_resolve, reject) => {
+            timer = setTimeout(() => {
+              controller.abort();
+              reject(new AsyncTimeoutError(props.timeout!));
+            }, props.timeout);
+          }),
+        ]);
+    return props.children(result);
+  } catch (error) {
+    return props.error?.(error, () => undefined) ?? props.fallback;
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function startAsyncBoundary(
+  part: PartController,
+  state: AsyncBoundaryState,
+): void {
+  const props = state.props;
+  state.generation += 1;
+  state.attempt += 1;
+  const generation = state.generation;
+  const controller = new AbortController();
+  state.controller = controller;
+  const retry = () => {
+    if (asyncBoundaries.get(part) !== state) return;
+    cancelAsyncBoundary(state);
+    startAsyncBoundary(part, state);
+  };
+
+  const delay = props.delay ?? 0;
+  if (delay === 0) part.setValue(props.fallback);
+  else {
+    state.delayTimer = setTimeout(() => {
+      if (isCurrentAsyncState(state, generation)) part.setValue(state.props.fallback);
+    }, delay);
+  }
+
+  if (props.timeout !== undefined) {
+    state.timeoutTimer = setTimeout(() => {
+      if (!isCurrentAsyncState(state, generation)) return;
+      controller.abort();
+      clearAsyncTimers(state);
+      part.setValue(renderAsyncError(state.props, new AsyncTimeoutError(props.timeout!), retry));
+    }, props.timeout);
+  }
+
+  let source: PromiseLike<unknown>;
+  try {
+    source = typeof props.source === 'function'
+      ? props.source({ signal: controller.signal, attempt: state.attempt })
+      : props.source;
+  } catch (error) {
+    clearAsyncTimers(state);
+    state.controller = undefined;
+    part.setValue(renderAsyncError(state.props, error, retry));
+    return;
+  }
+
+  void Promise.resolve(source).then(
+    (value) => {
+      if (!isCurrentAsyncState(state, generation)) return;
+      clearAsyncTimers(state);
+      state.controller = undefined;
+      part.setValue(state.props.children(value));
+    },
+    (error: unknown) => {
+      if (!isCurrentAsyncState(state, generation) || controller.signal.aborted) return;
+      clearAsyncTimers(state);
+      state.controller = undefined;
+      part.setValue(renderAsyncError(state.props, error, retry));
+    },
+  );
+}
+
+function renderAsyncError(
+  props: SuspenseProps<unknown>,
+  error: unknown,
+  retry: () => void,
+): TemplateValue {
+  return props.error?.(error, retry) ?? nothing;
+}
+
+function cancelAsyncBoundary(state: AsyncBoundaryState): void {
+  state.generation += 1;
+  state.controller?.abort();
+  state.controller = undefined;
+  clearAsyncTimers(state);
+}
+
+function clearAsyncTimers(state: AsyncBoundaryState): void {
+  if (state.delayTimer !== undefined) clearTimeout(state.delayTimer);
+  if (state.timeoutTimer !== undefined) clearTimeout(state.timeoutTimer);
+  state.delayTimer = undefined;
+  state.timeoutTimer = undefined;
+}
+
+function isCurrentAsyncState(state: AsyncBoundaryState, generation: number): boolean {
+  return state.generation === generation && !state.controller?.signal.aborted;
+}
+
+export interface AsyncComponentOptions<Props> {
+  readonly loader: (context: AsyncLoadContext) => PromiseLike<
+    FunctionalComponent<Props> | { readonly default: FunctionalComponent<Props> }
+  >;
+  readonly loading: (props: Readonly<Props>) => TemplateValue;
+  readonly error?: (
+    error: unknown,
+    retry: () => void,
+    props: Readonly<Props>,
+  ) => TemplateValue;
+  readonly delay?: number;
+  readonly timeout?: number;
+}
+
+export type AsyncComponent<Props> = FunctionalComponent<Props> & {
+  preload(): Promise<void>;
+  reset(): void;
+  readonly resolved: boolean;
+};
+
+/** Defines a lazy functional component that can be preloaded by routers or servers. */
+export function defineAsyncComponent<Props>(
+  options: AsyncComponentOptions<Props>,
+): AsyncComponent<Props> {
+  validateDelay(options.delay, 'delay');
+  validateDelay(options.timeout, 'timeout');
+  let resolved: FunctionalComponent<Props> | undefined;
+  let preloadPromise: Promise<void> | undefined;
+  let generation = 0;
+  const sourceKey = Symbol('gluon.async-component');
+
+  const load = async (context: AsyncLoadContext): Promise<FunctionalComponent<Props>> => {
+    if (resolved) return resolved;
+    const loadGeneration = generation;
+    const loaded = await options.loader(context);
+    const component = typeof loaded === 'function' ? loaded : loaded.default;
+    if (typeof component !== 'function') {
+      throw new TypeError('An async component loader must resolve to a functional component.');
+    }
+    if (loadGeneration !== generation) {
+      throw new Error('The async component was reset before its loader completed.');
+    }
+    resolved = component;
+    return component;
+  };
+
+  const component = ((props: Readonly<Props>) => {
+    if (resolved) return resolved(props);
+    return Suspense({
+      source: load,
+      sourceKey,
+      fallback: options.loading(props),
+      children: (loaded) => loaded(props),
+      error: options.error
+        ? (error, retry) => options.error!(error, retry, props)
+        : undefined,
+      delay: options.delay,
+      timeout: options.timeout,
+    });
+  }) as AsyncComponent<Props>;
+
+  Object.defineProperties(component, {
+    preload: {
+      value: () => {
+        if (resolved) return Promise.resolve();
+        if (!preloadPromise) {
+          const controller = new AbortController();
+          preloadPromise = load({ signal: controller.signal, attempt: 1 })
+            .then(() => undefined)
+            .finally(() => { preloadPromise = undefined; });
+        }
+        return preloadPromise;
+      },
+    },
+    reset: {
+      value: () => {
+        generation += 1;
+        resolved = undefined;
+        preloadPromise = undefined;
+      },
+    },
+    resolved: { get: () => resolved !== undefined },
+  });
+  return component;
+}
+
+export interface TeleportProps {
+  readonly to: Element | string;
+  readonly children: TemplateValue;
+  readonly disabled?: boolean;
+}
+
+interface TeleportState {
+  readonly host: HTMLElement;
+  readonly context?: ApplicationContext;
+}
+
+const teleports = new WeakMap<PartController, TeleportState>();
+
+const teleportDirective = directive<readonly [TeleportProps]>(
+  {
+    mount(part, [props]) {
+      const state = createOwnedHost('gluon-teleport');
+      teleports.set(part, state);
+      updateTeleport(part, props, state);
+    },
+    update(part, [props]) {
+      const state = teleports.get(part);
+      if (state) updateTeleport(part, props, state);
+    },
+    cleanup() {
+      // The host survives argument updates and is released by disconnect().
+    },
+    disconnect(part) {
+      const state = teleports.get(part);
+      if (!state) return;
+      releaseOwnedHost(state);
+      teleports.delete(part);
+    },
+  },
+);
+
+/** Renders content in another DOM target while retaining application ownership. */
+export function Teleport(props: TeleportProps): TemplateValue {
+  if (props.disabled) return props.children;
+  const value = teleportDirective(props);
+  builtinServerContracts.set(value, {
+    kind: 'teleport',
+    content: props.children,
+    target: props.to,
+  });
+  return value;
+}
+
+function updateTeleport(part: PartController, props: TeleportProps, state: TeleportState): void {
+  const target = resolveTeleportTarget(props.to, state.host.ownerDocument);
+  if (state.host.parentNode !== target) target.append(state.host);
+  renderOwnedValue(state.host, props.children);
+  part.setValue(nothing);
+}
+
+function resolveTeleportTarget(target: Element | string, document: Document): Element {
+  if (typeof target !== 'string') return target;
+  const resolved = document.querySelector(target);
+  if (!resolved) throw new Error(`Teleport target "${target}" was not found.`);
+  return resolved;
+}
+
+export interface KeepAliveProps {
+  readonly cacheKey: Key;
+  readonly children: TemplateValue;
+  readonly max?: number;
+  readonly onActivated?: (key: Key, host: HTMLElement) => void;
+  readonly onDeactivated?: (key: Key, host: HTMLElement) => void;
+  readonly onEvicted?: (key: Key) => void;
+}
+
+interface KeepAliveEntry extends TeleportState {
+  readonly key: Key;
+  used: number;
+}
+
+interface KeepAliveState {
+  readonly entries: Map<Key, KeepAliveEntry>;
+  active?: KeepAliveEntry;
+  sequence: number;
+  props: KeepAliveProps;
+}
+
+const keepAliveStates = new WeakMap<PartController, KeepAliveState>();
+
+const keepAliveDirective = directive<readonly [KeepAliveProps]>(
+  {
+    mount(part, [props]) {
+      validateKeepAliveMax(props.max);
+      const state: KeepAliveState = { entries: new Map(), sequence: 0, props };
+      keepAliveStates.set(part, state);
+      updateKeepAlive(part, props, state);
+    },
+    update(part, [props]) {
+      validateKeepAliveMax(props.max);
+      const state = keepAliveStates.get(part);
+      if (state) updateKeepAlive(part, props, state);
+    },
+    cleanup() {
+      // Entries remain cached between updates and are released on disconnect.
+    },
+    disconnect(part) {
+      const state = keepAliveStates.get(part);
+      if (!state) return;
+      if (state.active) state.props.onDeactivated?.(state.active.key, state.active.host);
+      for (const entry of state.entries.values()) {
+        releaseOwnedHost(entry);
+        state.props.onEvicted?.(entry.key);
+      }
+      state.entries.clear();
+      keepAliveStates.delete(part);
+    },
+  },
+);
+
+/** Caches rendered view hosts by key and suspends inactive renderer resources. */
+export function KeepAlive(props: KeepAliveProps): TemplateValue {
+  const value = keepAliveDirective(props);
+  builtinServerContracts.set(value, { kind: 'keep-alive', content: props.children });
+  return value;
+}
+
+function updateKeepAlive(
+  part: PartController,
+  props: KeepAliveProps,
+  state: KeepAliveState,
+): void {
+  state.props = props;
+  let entry = state.entries.get(props.cacheKey);
+  if (!entry) {
+    entry = { ...createOwnedHost('gluon-keep-alive'), key: props.cacheKey, used: 0 };
+    state.entries.set(props.cacheKey, entry);
+  }
+
+  if (state.active && state.active !== entry) {
+    suspendRender(state.active.host);
+    props.onDeactivated?.(state.active.key, state.active.host);
+  }
+
+  entry.used = ++state.sequence;
+  renderOwnedValue(entry.host, props.children);
+  part.setValue(entry.host);
+  if (state.active !== entry) props.onActivated?.(entry.key, entry.host);
+  state.active = entry;
+  evictKeepAliveEntries(state, props.max ?? Number.POSITIVE_INFINITY);
+}
+
+function evictKeepAliveEntries(state: KeepAliveState, max: number): void {
+  while (state.entries.size > max) {
+    const candidate = [...state.entries.values()]
+      .filter((entry) => entry !== state.active)
+      .sort((left, right) => left.used - right.used)[0];
+    if (!candidate) return;
+    state.entries.delete(candidate.key);
+    releaseOwnedHost(candidate);
+    state.props.onEvicted?.(candidate.key);
+  }
+}
+
+function validateKeepAliveMax(max: number | undefined): void {
+  if (max !== undefined && (!Number.isInteger(max) || max < 1)) {
+    throw new TypeError('KeepAlive max must be a positive integer.');
+  }
+}
+
+export interface TransitionOptions {
+  readonly duration?: number;
+  readonly easing?: string;
+  readonly enter?: readonly Keyframe[];
+  readonly leave?: readonly Keyframe[];
+  readonly reducedMotion?: boolean | 'system';
+}
+
+export interface TransitionProps extends TransitionOptions {
+  readonly children: TemplateValue;
+  readonly transitionKey?: Key;
+}
+
+interface TransitionState extends TeleportState {
+  generation: number;
+  animations: Animation[];
+  activeKey?: Key;
+}
+
+const transitionStates = new WeakMap<PartController, TransitionState>();
+const defaultEnter: readonly Keyframe[] = [
+  { opacity: 0, transform: 'translateY(4px)' },
+  { opacity: 1, transform: 'translateY(0)' },
+];
+const defaultLeave: readonly Keyframe[] = [
+  { opacity: 1, transform: 'translateY(0)' },
+  { opacity: 0, transform: 'translateY(4px)' },
+];
+
+const transitionDirective = directive<readonly [TransitionProps]>(
+  {
+    mount(part, [props]) {
+      validateTransitionOptions(props);
+      const state: TransitionState = {
+        ...createOwnedHost('gluon-transition'),
+        generation: 0,
+        animations: [],
+        activeKey: props.transitionKey,
+      };
+      transitionStates.set(part, state);
+      renderOwnedValue(state.host, props.children);
+      part.setValue(state.host);
+      if (!prefersReducedMotion(state.host, props.reducedMotion)) {
+        void animateElements(state, elementsIn(state.host), props.enter ?? defaultEnter, props);
+      }
+    },
+    update(part, [props]) {
+      validateTransitionOptions(props);
+      const state = transitionStates.get(part);
+      if (state) void updateTransition(part, props, state);
+    },
+    cleanup(part) {
+      const state = transitionStates.get(part);
+      if (state) cancelAnimations(state);
+    },
+    disconnect(part) {
+      const state = transitionStates.get(part);
+      if (!state) return;
+      cancelAnimations(state);
+      releaseOwnedHost(state);
+      transitionStates.delete(part);
+    },
+  },
+);
+
+/** Animates replacement of element or component content with cancellation. */
+export function Transition(props: TransitionProps): TemplateValue {
+  const value = transitionDirective(props);
+  builtinServerContracts.set(value, { kind: 'transition', content: props.children });
+  return value;
+}
+
+async function updateTransition(
+  part: PartController,
+  props: TransitionProps,
+  state: TransitionState,
+): Promise<void> {
+  const generation = ++state.generation;
+  cancelAnimations(state, false);
+  if (props.transitionKey !== undefined && Object.is(props.transitionKey, state.activeKey)) {
+    renderOwnedValue(state.host, props.children);
+    part.setValue(state.host);
+    return;
+  }
+  state.activeKey = props.transitionKey;
+  if (prefersReducedMotion(state.host, props.reducedMotion)) {
+    renderOwnedValue(state.host, props.children);
+    part.setValue(state.host);
+    return;
+  }
+
+  await animateElements(state, elementsIn(state.host), props.leave ?? defaultLeave, props);
+  if (state.generation !== generation) return;
+  renderOwnedValue(state.host, props.children);
+  part.setValue(state.host);
+  await animateElements(state, elementsIn(state.host), props.enter ?? defaultEnter, props);
+}
+
+export interface TransitionGroupProps<Item> extends TransitionOptions {
+  readonly items: Iterable<Item>;
+  readonly key: (item: Item, index: number) => Key;
+  readonly children: (item: Item, index: number) => TemplateValue;
+}
+
+interface TransitionGroupArgs {
+  readonly items: readonly unknown[];
+  readonly keys: readonly Key[];
+  readonly children: (item: unknown, index: number) => TemplateValue;
+  readonly options: TransitionOptions;
+}
+
+interface TransitionGroupState extends TransitionState {
+  readonly tokens: Map<Key, string>;
+  tokenSequence: number;
+  clones: HTMLElement[];
+}
+
+const transitionGroupStates = new WeakMap<PartController, TransitionGroupState>();
+const transitionGroupHosts = new WeakMap<HTMLElement, TransitionGroupState>();
+
+const transitionGroupDirective = directive<readonly [TransitionGroupArgs]>(
+  {
+    mount(part, [args]) {
+      validateTransitionOptions(args.options);
+      const state: TransitionGroupState = {
+        ...createOwnedHost('gluon-transition-group'),
+        generation: 0,
+        animations: [],
+        tokens: new Map(),
+        tokenSequence: 0,
+        clones: [],
+      };
+      transitionGroupStates.set(part, state);
+      transitionGroupHosts.set(state.host, state);
+      renderTransitionGroup(state, args);
+      part.setValue(state.host);
+      if (!prefersReducedMotion(state.host, args.options.reducedMotion)) {
+        void animateElements(state, groupElements(state.host), args.options.enter ?? defaultEnter, args.options);
+      }
+    },
+    update(part, [args]) {
+      validateTransitionOptions(args.options);
+      const state = transitionGroupStates.get(part);
+      if (state) updateTransitionGroup(part, args, state);
+    },
+    cleanup(part) {
+      const state = transitionGroupStates.get(part);
+      if (state) cancelTransitionGroup(state);
+    },
+    disconnect(part) {
+      const state = transitionGroupStates.get(part);
+      if (!state) return;
+      cancelTransitionGroup(state);
+      releaseOwnedHost(state);
+      transitionGroupStates.delete(part);
+    },
+  },
+);
+
+/** Animates keyed insertion, removal, and movement while repeat() retains identity. */
+export function TransitionGroup<Item>(props: TransitionGroupProps<Item>): TemplateValue {
+  const items = [...props.items];
+  const keys = items.map(props.key);
+  validateGroupKeys(keys);
+  const args = {
+    items,
+    keys,
+    children: props.children as (item: unknown, index: number) => TemplateValue,
+    options: props,
+  };
+  const value = transitionGroupDirective(args);
+  builtinServerContracts.set(value, {
+    kind: 'transition-group',
+    get content() {
+      return repeat(items, (_item, index) => keys[index]!, props.children);
+    },
+  });
+  return value;
+}
+
+function updateTransitionGroup(
+  part: PartController,
+  args: TransitionGroupArgs,
+  state: TransitionGroupState,
+): void {
+  const reduced = prefersReducedMotion(state.host, args.options.reducedMotion);
+  const before = groupRects(state.host);
+  const retained = new Set(args.keys);
+  if (!reduced) createLeavingClones(state, retained, args.options);
+  renderTransitionGroup(state, args);
+  part.setValue(state.host);
+  if (reduced) return;
+
+  const after = groupRects(state.host);
+  for (const [key, element] of groupEntries(state.host)) {
+    const previous = before.get(key);
+    const current = after.get(key);
+    if (!current) continue;
+    if (!previous) {
+      state.animations.push(playAnimation(element, args.options.enter ?? defaultEnter, args.options));
+      continue;
+    }
+    const x = previous.left - current.left;
+    const y = previous.top - current.top;
+    if (x || y) {
+      state.animations.push(playAnimation(element, [
+        { transform: `translate(${x}px, ${y}px)` },
+        { transform: 'translate(0, 0)' },
+      ], args.options));
+    }
+  }
+}
+
+function renderTransitionGroup(state: TransitionGroupState, args: TransitionGroupArgs): void {
+  const entries = args.items.map((item, index) => ({ item, key: args.keys[index]!, index }));
+  renderOwnedValue(state.host, repeat(
+    entries,
+    (entry) => entry.key,
+    (entry) => {
+      let token = state.tokens.get(entry.key);
+      if (!token) {
+        token = String(++state.tokenSequence);
+        state.tokens.set(entry.key, token);
+      }
+      return html`<gluon-transition-item data-gluon-transition-key=${token} style="display: contents">${args.children(entry.item, entry.index)}</gluon-transition-item>`;
+    },
+  ));
+  const current = new Set(args.keys);
+  for (const key of state.tokens.keys()) if (!current.has(key)) state.tokens.delete(key);
+}
+
+function createLeavingClones(
+  state: TransitionGroupState,
+  retained: ReadonlySet<Key>,
+  options: TransitionOptions,
+): void {
+  for (const [key, element] of groupEntries(state.host)) {
+    if (retained.has(key)) continue;
+    const rect = element.getBoundingClientRect();
+    const clone = element.cloneNode(true) as HTMLElement;
+    Object.assign(clone.style, {
+      position: 'fixed',
+      left: `${rect.left}px`,
+      top: `${rect.top}px`,
+      width: `${rect.width}px`,
+      height: `${rect.height}px`,
+      margin: '0',
+      pointerEvents: 'none',
+      zIndex: '2147483647',
+    });
+    state.host.ownerDocument.body.append(clone);
+    state.clones.push(clone);
+    const animation = playAnimation(clone, options.leave ?? defaultLeave, options);
+    state.animations.push(animation);
+    void animation.finished.catch(() => undefined).finally(() => {
+      clone.remove();
+      const index = state.clones.indexOf(clone);
+      if (index >= 0) state.clones.splice(index, 1);
+    });
+  }
+}
+
+function groupEntries(host: HTMLElement): Array<[Key, HTMLElement]> {
+  const entries: Array<[Key, HTMLElement]> = [];
+  for (const [key, token] of transitionGroupStatesForHost(host)?.tokens ?? []) {
+    const wrapper = host.querySelector<HTMLElement>(`[data-gluon-transition-key="${token}"]`);
+    const element = wrapper?.firstElementChild;
+    if (element instanceof HTMLElement) entries.push([key, element]);
+  }
+  return entries;
+}
+
+function transitionGroupStatesForHost(host: HTMLElement): TransitionGroupState | undefined {
+  return transitionGroupHosts.get(host);
+}
+
+function groupElements(host: HTMLElement): HTMLElement[] {
+  return groupEntries(host).map(([, element]) => element);
+}
+
+function groupRects(host: HTMLElement): Map<Key, DOMRect> {
+  return new Map(groupEntries(host).map(([key, element]) => [key, element.getBoundingClientRect()]));
+}
+
+function createOwnedHost(tagName: string): TeleportState {
+  const host = document.createElement(tagName);
+  host.style.display = 'contents';
+  const context = getActiveApplicationContext();
+  if (context) registerApplicationRoot(host, context);
+  return { host, context };
+}
+
+function releaseOwnedHost(state: TeleportState): void {
+  try {
+    unmount(state.host);
+  } finally {
+    if (state.context) unregisterApplicationRoot(state.host, state.context);
+    state.host.remove();
+    if ('clones' in state) transitionGroupHosts.delete(state.host);
+  }
+}
+
+function renderOwnedValue(host: HTMLElement, value: TemplateValue): void {
+  render(html`${value}`, host);
+}
+
+function elementsIn(host: HTMLElement): HTMLElement[] {
+  return [...host.children].filter((node): node is HTMLElement => node instanceof HTMLElement);
+}
+
+async function animateElements(
+  state: TransitionState,
+  elements: readonly HTMLElement[],
+  keyframes: readonly Keyframe[],
+  options: TransitionOptions,
+): Promise<void> {
+  const animations = elements.map((element) => playAnimation(element, keyframes, options));
+  state.animations.push(...animations);
+  await Promise.all(animations.map((animation) => animation.finished.catch(() => undefined)));
+  state.animations = state.animations.filter((animation) => !animations.includes(animation));
+}
+
+function playAnimation(
+  element: HTMLElement,
+  keyframes: readonly Keyframe[],
+  options: TransitionOptions,
+): Animation {
+  return element.animate([...keyframes], {
+    duration: options.duration ?? 180,
+    easing: options.easing ?? 'ease',
+    fill: 'both',
+  });
+}
+
+function cancelAnimations(state: TransitionState, increment = true): void {
+  if (increment) state.generation += 1;
+  for (const animation of state.animations) animation.cancel();
+  state.animations.length = 0;
+}
+
+function cancelTransitionGroup(state: TransitionGroupState): void {
+  cancelAnimations(state);
+  for (const clone of state.clones) clone.remove();
+  state.clones.length = 0;
+}
+
+function prefersReducedMotion(
+  host: HTMLElement,
+  preference: boolean | 'system' | undefined,
+): boolean {
+  if (typeof preference === 'boolean') return preference;
+  return host.ownerDocument.defaultView?.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+}
+
+function validateTransitionOptions(options: TransitionOptions): void {
+  validateDelay(options.duration, 'duration');
+}
+
+function validateDelay(value: number | undefined, name: string): void {
+  if (value !== undefined && (!Number.isFinite(value) || value < 0)) {
+    throw new TypeError(`${name} must be a finite non-negative number.`);
+  }
+}
+
+function validateGroupKeys(keys: readonly Key[]): void {
+  const seen = new Set<Key>();
+  for (const key of keys) {
+    if ((typeof key !== 'string' && typeof key !== 'number' && typeof key !== 'symbol') || seen.has(key)) {
+      throw new Error('TransitionGroup keys must be unique strings, numbers, or symbols.');
+    }
+    seen.add(key);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,28 @@ export {
 } from './props.js';
 
 export {
+  AsyncTimeoutError,
+  KeepAlive,
+  Suspense,
+  Teleport,
+  Transition,
+  TransitionGroup,
+  defineAsyncComponent,
+  getBuiltinServerContract,
+  type AsyncComponent,
+  type AsyncComponentOptions,
+  type AsyncLoadContext,
+  type AsyncSource,
+  type BuiltinServerContract,
+  type KeepAliveProps,
+  type SuspenseProps,
+  type TeleportProps,
+  type TransitionGroupProps,
+  type TransitionOptions,
+  type TransitionProps,
+} from './builtins.js';
+
+export {
   adoptStyles,
   createStyleSheet,
   css,

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -1,12 +1,19 @@
 import {
   GluonElement,
+  KeepAlive,
+  Suspense,
+  Teleport,
+  Transition,
+  TransitionGroup,
   createApp,
   createInjectionKey,
   directive,
+  defineAsyncComponent,
   dynamicComponent,
   elementRef,
   event,
   exposedRef,
+  getBuiltinServerContract,
   getPublicInstance,
   html,
   model,
@@ -44,6 +51,36 @@ const keyed: RepeatResult = repeat(
 );
 
 html`<section>${keyed}</section>`;
+
+const asyncGreeting = defineAsyncComponent<{ name: string }>({
+  loader: async ({ signal, attempt }) => {
+    signal.aborted;
+    attempt.toFixed();
+    return ({ name }) => html`<p>Hello ${name}</p>`;
+  },
+  loading: ({ name }) => html`<p>Loading ${name}</p>`,
+  error: (error, retry, { name }) => html`<button @click=${retry}>${name}${String(error)}</button>`,
+  delay: 10,
+  timeout: 1_000,
+});
+const asyncView: TemplateValue = asyncGreeting({ name: 'Ada' });
+const serverContract = getBuiltinServerContract(asyncView);
+if (serverContract?.kind === 'suspense') void serverContract.resolve();
+void asyncGreeting.preload();
+asyncGreeting.reset();
+Suspense({
+  source: async ({ signal }) => signal.aborted ? 'stopped' : 'ready',
+  fallback: 'Loading',
+  children: (value) => html`<p>${value.toUpperCase()}</p>`,
+});
+Teleport({ to: document.body, children: asyncView });
+KeepAlive({ cacheKey: 'route:/', max: 4, children: asyncView });
+Transition({ transitionKey: 'open', children: asyncView, reducedMotion: 'system' });
+TransitionGroup({
+  items: rows,
+  key: (row) => row.id,
+  children: (row) => html`<p>${row.label}</p>`,
+});
 
 const lifecycleDefinition: DirectiveLifecycle<[string]> = {
   mount(part, [value]) {
@@ -191,5 +228,9 @@ event(() => undefined, { capture: 'yes' });
 
 // @ts-expect-error unsafe URLs accept strings or URL objects
 unsafeURL(42);
+// @ts-expect-error async component props retain their declared type
+asyncGreeting({ name: 42 });
+// @ts-expect-error KeepAlive cache sizes are numeric
+KeepAlive({ cacheKey: 'route', max: 'four', children: '' });
 // @ts-expect-error injection keys retain their value type
 application.provide(counterKey, { count: 'invalid' });

--- a/tests/builtins.spec.ts
+++ b/tests/builtins.spec.ts
@@ -1,0 +1,432 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AsyncTimeoutError,
+  GluonElement,
+  KeepAlive,
+  Suspense,
+  Teleport,
+  Transition,
+  TransitionGroup,
+  createApp,
+  createInjectionKey,
+  defineAsyncComponent,
+  defineElement,
+  html,
+  getBuiltinServerContract,
+  inject,
+  isTemplateResult,
+  render,
+  unmount,
+  type Key,
+} from '../src/index.js';
+import { nextTick, reactive } from '@gluonjs/reactivity';
+import {
+  RouterView,
+  createMemoryHistory,
+  createRouter,
+  createRouterPlugin,
+} from '@gluonjs/router';
+
+describe('async UI built-ins', () => {
+  it('renders explicit loading, resolved, nested, and aborted states deterministically', async () => {
+    const container = document.createElement('div');
+    let resolveOuter!: (value: string) => void;
+    let resolveInner!: (value: string) => void;
+    const outer = new Promise<string>((resolve) => { resolveOuter = resolve; });
+    const inner = new Promise<string>((resolve) => { resolveInner = resolve; });
+    let aborted = false;
+    const aborting = ({ signal }: { signal: AbortSignal }) => new Promise<string>(() => {
+      signal.addEventListener('abort', () => { aborted = true; });
+    });
+
+    render(html`${Suspense({
+      source: outer,
+      fallback: html`<p>Outer loading</p>`,
+      children: (value) => html`<section>${value}${Suspense({
+        source: inner,
+        fallback: html`<span>Inner loading</span>`,
+        children: (nested) => html`<strong>${nested}</strong>`,
+      })}</section>`,
+    })}`, container);
+    expect(container.textContent).toBe('Outer loading');
+    resolveOuter('Outer ready');
+    await settleAsync();
+    expect(container.textContent).toBe('Outer readyInner loading');
+    resolveInner('Inner ready');
+    await settleAsync();
+    expect(container.textContent).toBe('Outer readyInner ready');
+
+    render(html`${Suspense({
+      source: aborting,
+      fallback: 'Waiting',
+      children: (value) => value,
+    })}`, container);
+    unmount(container);
+    expect(aborted).toBe(true);
+  });
+
+  it('supports synchronous failure, asynchronous retry, delay, and timeout error states', async () => {
+    const container = document.createElement('div');
+    let attempt = 0;
+    const source = async () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('inventory unavailable');
+      return 'Available';
+    };
+    render(html`${Suspense({
+      source,
+      fallback: html`<p>Checking</p>`,
+      children: (value) => html`<p>${value}</p>`,
+      error: (error, retry) => html`<button @click=${retry}>${(error as Error).message}</button>`,
+    })}`, container);
+    await settleAsync();
+    expect(container.querySelector('button')?.textContent).toBe('inventory unavailable');
+    container.querySelector('button')!.click();
+    await settleAsync();
+    expect(container.textContent).toBe('Available');
+
+    render(html`${Suspense({
+      source: () => new Promise(() => undefined),
+      fallback: 'Delayed fallback',
+      children: (value) => String(value),
+      delay: 30,
+      timeout: 5,
+      error: (error) => html`<p>${error instanceof AsyncTimeoutError ? error.timeout : 'wrong'}</p>`,
+    })}`, container);
+    expect(container.textContent).toBe('');
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(container.textContent).toBe('5');
+  });
+
+  it('retains keyed logical work across parent renders and adopts current callbacks', async () => {
+    const container = document.createElement('div');
+    let resolve!: (value: string) => void;
+    let calls = 0;
+    let aborted = 0;
+    const source = ({ signal }: { signal: AbortSignal }) => {
+      calls += 1;
+      signal.addEventListener('abort', () => { aborted += 1; });
+      return new Promise<string>((done) => { resolve = done; });
+    };
+    let prefix = 'First';
+    const view = () => html`${Suspense({
+      source,
+      sourceKey: 'inventory:orbit',
+      fallback: `${prefix} fallback`,
+      children: (value) => `${prefix} ${value}`,
+    })}`;
+    render(view(), container);
+    prefix = 'Latest';
+    render(view(), container);
+    expect(calls).toBe(1);
+    expect(aborted).toBe(0);
+    resolve('ready');
+    await settleAsync();
+    expect(container.textContent).toBe('Latest ready');
+    unmount(container);
+    expect(aborted).toBe(0);
+  });
+
+  it('defines preloadable components for router and server render contracts', async () => {
+    const loader = vi.fn(async () => ({
+      default: ({ label }: Readonly<{ label: string }>) => html`<h1>${label}</h1>`,
+    }));
+    const AsyncPage = defineAsyncComponent({
+      loader,
+      loading: () => html`<p>Loading route</p>`,
+      error: (error, retry) => html`<button @click=${retry}>${String(error)}</button>`,
+      timeout: 100,
+    });
+    expect(AsyncPage.resolved).toBe(false);
+    await Promise.all([AsyncPage.preload(), AsyncPage.preload()]);
+    expect(loader).toHaveBeenCalledOnce();
+    expect(AsyncPage.resolved).toBe(true);
+    expect(isTemplateResult(AsyncPage({ label: 'Server ready' }))).toBe(true);
+
+    const router = createRouter({
+      history: createMemoryHistory(['/async']),
+      routes: [{ path: '/async', component: () => AsyncPage({ label: 'Async route' }) }],
+    });
+    await router.isReady();
+    const root = document.createElement('div');
+    const app = createApp(() => html`<main>${RouterView()}</main>`);
+    app.use(createRouterPlugin(router));
+    app.mount(root);
+    expect(root.textContent).toBe('Async route');
+    app.unmount();
+
+    AsyncPage.reset();
+    expect(AsyncPage.resolved).toBe(false);
+    const delayed = document.createElement('div');
+    render(html`${AsyncPage({ label: 'Reloaded' })}`, delayed);
+    expect(delayed.textContent).toBe('Loading route');
+    await settleAsync();
+    expect(delayed.textContent).toBe('Reloaded');
+
+    let recoveryAttempt = 0;
+    const RecoveringPage = defineAsyncComponent<Record<string, never>>({
+      loader: async () => {
+        recoveryAttempt += 1;
+        if (recoveryAttempt === 1) throw new Error('component chunk failed');
+        return () => html`<p>Recovered component</p>`;
+      },
+      loading: () => 'Loading component',
+      error: (_error, retry) => html`<button @click=${retry}>Retry component</button>`,
+    });
+    const recoveryRoot = document.createElement('div');
+    render(html`${RecoveringPage({})}`, recoveryRoot);
+    await settleAsync();
+    expect(recoveryRoot.querySelector('button')?.textContent).toBe('Retry component');
+    recoveryRoot.querySelector('button')!.click();
+    await settleAsync();
+    expect(recoveryRoot.textContent).toBe('Recovered component');
+  });
+
+  it('rejects invalid timing and loader contracts', async () => {
+    expect(() => Suspense({
+      source: Promise.resolve('ok'),
+      fallback: '',
+      children: (value) => value,
+      delay: -1,
+    })).toThrow('finite non-negative');
+    expect(() => defineAsyncComponent({
+      loader: async () => (() => html``),
+      loading: () => '',
+      timeout: Number.POSITIVE_INFINITY,
+    })).toThrow('finite non-negative');
+
+    const invalid = defineAsyncComponent({
+      loader: async () => ({ default: 'invalid' as never }),
+      loading: () => 'Loading',
+    });
+    await expect(invalid.preload()).rejects.toThrow('functional component');
+
+    type EmptyProps = Readonly<Record<string, never>>;
+    let release!: (component: (props: EmptyProps) => ReturnType<typeof html>) => void;
+    const resetWhilePending = defineAsyncComponent<Record<string, never>>({
+      loader: () => new Promise<(props: EmptyProps) => ReturnType<typeof html>>((resolve) => {
+        release = resolve;
+      }),
+      loading: () => 'Loading',
+    });
+    const pending = resetWhilePending.preload();
+    resetWhilePending.reset();
+    release(() => html`<p>Too late</p>`);
+    await expect(pending).rejects.toThrow('reset before its loader completed');
+  });
+
+  it('exposes DOM-free server contracts for every built-in', async () => {
+    const suspense = Suspense({
+      source: Promise.resolve('server'),
+      fallback: 'fallback',
+      children: (value) => html`<p>${value}</p>`,
+    });
+    const suspenseContract = getBuiltinServerContract(suspense);
+    expect(suspenseContract?.kind).toBe('suspense');
+    if (suspenseContract?.kind === 'suspense') {
+      expect(isTemplateResult(await suspenseContract.resolve())).toBe(true);
+    }
+
+    const failed = Suspense({
+      source: Promise.reject(new Error('server failure')),
+      fallback: 'server fallback',
+      children: String,
+    });
+    const failedContract = getBuiltinServerContract(failed);
+    if (failedContract?.kind === 'suspense') {
+      expect(await failedContract.resolve()).toBe('server fallback');
+    }
+
+    const values = [
+      Teleport({ to: '#overlay', children: 'teleported' }),
+      KeepAlive({ cacheKey: 'route', children: 'cached' }),
+      Transition({ children: 'transitioned' }),
+      TransitionGroup({ items: ['a'], key: String, children: String }),
+    ];
+    expect(values.map((value) => getBuiltinServerContract(value)?.kind)).toEqual([
+      'teleport',
+      'keep-alive',
+      'transition',
+      'transition-group',
+    ]);
+    expect(getBuiltinServerContract('ordinary')).toBeUndefined();
+  });
+});
+
+describe('Teleport and KeepAlive', () => {
+  it('retains application context in a teleport and cleans the target on unmount', () => {
+    const target = document.createElement('aside');
+    target.id = 'overlay-root';
+    document.body.append(target);
+    const key = createInjectionKey<string>('teleport-value');
+    let observed = '';
+    const app = createApp(() => html`${Teleport({
+      to: '#overlay-root',
+      children: html`<button @click=${() => { observed = inject(key); }}>Read context</button>`,
+    })}`);
+    app.provide(key, 'owned');
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    target.querySelector('button')!.click();
+    expect(observed).toBe('owned');
+    expect(root.textContent).toBe('');
+    expect(target.querySelector('gluon-teleport')).not.toBeNull();
+    app.unmount();
+    expect(target.children).toHaveLength(0);
+    target.remove();
+    root.remove();
+  });
+
+  it('moves and disables teleports and reports missing targets', () => {
+    const root = document.createElement('div');
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    document.body.append(first, second);
+    render(html`${Teleport({ to: first, children: html`<p>Moved</p>` })}`, root);
+    expect(first.textContent).toBe('Moved');
+    render(html`${Teleport({ to: second, children: html`<p>Moved again</p>` })}`, root);
+    expect(first.textContent).toBe('');
+    expect(second.textContent).toBe('Moved again');
+    render(html`${Teleport({ to: second, disabled: true, children: html`<p>Local</p>` })}`, root);
+    expect(root.textContent).toBe('Local');
+    expect(second.textContent).toBe('');
+    expect(() => render(html`${Teleport({ to: '#absent', children: 'No target' })}`, root))
+      .toThrow('was not found');
+    unmount(root);
+    first.remove();
+    second.remove();
+  });
+
+  it('preserves cached component state and releases least-recently-used entries', async () => {
+    class StatefulElement extends GluonElement {
+      protected override render() {
+        return html`<input value="initial">`;
+      }
+    }
+    if (!customElements.get('gluon-keep-alive-fixture')) {
+      defineElement('gluon-keep-alive-fixture', StatefulElement);
+    }
+    const state = reactive({ key: 'one', max: 2 });
+    const activated: Key[] = [];
+    const deactivated: Key[] = [];
+    const evicted: Key[] = [];
+    const root = document.createElement('div');
+    document.body.append(root);
+    const app = createApp(() => html`${KeepAlive({
+      cacheKey: state.key,
+      max: state.max,
+      children: html`<gluon-keep-alive-fixture></gluon-keep-alive-fixture>`,
+      onActivated: (key) => activated.push(key),
+      onDeactivated: (key) => deactivated.push(key),
+      onEvicted: (key) => evicted.push(key),
+    })}`);
+    app.mount(root);
+    await nextTick();
+    const first = root.querySelector('gluon-keep-alive-fixture')!;
+    const firstInput = first.shadowRoot!.querySelector('input')!;
+    firstInput.value = 'retained';
+
+    state.key = 'two';
+    await nextTick();
+    const second = root.querySelector('gluon-keep-alive-fixture')!;
+    expect(second).not.toBe(first);
+    state.key = 'one';
+    await nextTick();
+    expect(root.querySelector('gluon-keep-alive-fixture')).toBe(first);
+    expect(root.querySelector('input')?.value ?? first.shadowRoot!.querySelector('input')!.value).toBe('retained');
+    expect(activated).toEqual(['one', 'two', 'one']);
+    expect(deactivated).toEqual(['one', 'two']);
+
+    state.max = 1;
+    state.key = 'three';
+    await nextTick();
+    expect(evicted).toContain('one');
+    expect(evicted).toContain('two');
+    app.unmount();
+    expect(evicted).toContain('three');
+    root.remove();
+    expect(() => KeepAlive({ cacheKey: 'bad', max: 0, children: '' })).not.toThrow();
+    expect(() => render(html`${KeepAlive({ cacheKey: 'bad', max: 0, children: '' })}`, root))
+      .toThrow('positive integer');
+  });
+});
+
+describe('Transition and TransitionGroup', () => {
+  it('cancels replaced animations and applies the latest transition content', async () => {
+    const root = document.createElement('div');
+    const cancel = vi.spyOn(Animation.prototype, 'cancel');
+    let value = 'One';
+    const view = () => html`${Transition({
+      children: html`<p>${value}</p>`,
+      duration: 2,
+    })}`;
+    render(view(), root);
+    value = 'Two';
+    render(view(), root);
+    value = 'Three';
+    render(view(), root);
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(root.textContent).toBe('Three');
+    expect(cancel).toHaveBeenCalled();
+    cancel.mockRestore();
+    unmount(root);
+  });
+
+  it('bypasses animations for reduced motion and validates durations', () => {
+    const root = document.createElement('div');
+    const animate = vi.spyOn(Element.prototype, 'animate');
+    render(html`${Transition({
+      children: html`<p>Still</p>`,
+      reducedMotion: true,
+    })}`, root);
+    expect(root.textContent).toBe('Still');
+    expect(animate).not.toHaveBeenCalled();
+    expect(() => render(html`${Transition({ children: '', duration: -1 })}`, root))
+      .toThrow('finite non-negative');
+    animate.mockRestore();
+  });
+
+  it('retains keyed identity through reorder and removes entries with reduced motion', () => {
+    const root = document.createElement('div');
+    const view = (items: readonly number[]) => html`${TransitionGroup({
+      items,
+      key: (item) => item,
+      reducedMotion: true,
+      children: (item) => html`<p data-key=${String(item)}>${item}</p>`,
+    })}`;
+    render(view([1, 2]), root);
+    const first = root.querySelector('[data-key="1"]');
+    render(view([2, 1]), root);
+    expect(root.querySelector('[data-key="1"]')).toBe(first);
+    expect([...root.querySelectorAll('p')].map((node) => node.textContent)).toEqual(['2', '1']);
+    render(view([2]), root);
+    expect(root.querySelector('[data-key="1"]')).toBeNull();
+    expect(() => TransitionGroup({ items: [1, 1], key: (item) => item, children: String }))
+      .toThrow('unique');
+  });
+
+  it('animates group insertion, movement, and leaving snapshots', async () => {
+    const root = document.createElement('div');
+    document.body.append(root);
+    const view = (items: readonly string[]) => html`${TransitionGroup({
+      items,
+      key: (item) => item,
+      duration: 2,
+      children: (item) => html`<div data-item=${item}>${item}</div>`,
+    })}`;
+    render(view(['a', 'b']), root);
+    render(view(['b', 'c']), root);
+    expect(root.textContent).toBe('bc');
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(document.body.textContent).not.toContain('a');
+    unmount(root);
+    root.remove();
+  });
+});
+
+async function settleAsync(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}

--- a/tests/shop-example.spec.ts
+++ b/tests/shop-example.spec.ts
@@ -26,24 +26,31 @@ describe('GLUON GOODS reference shop', () => {
     await settleShop();
     expect(router.currentRoute.value.path).toBe('/products/orbit-lamp');
     expect(root.querySelector('#product-title')?.textContent).toBe('Orbit Lamp');
+    const productPage = root.querySelector('.product-page');
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(root.querySelector('.inventory-status')?.textContent).toContain('Checking workshop availability');
+    await new Promise((resolve) => setTimeout(resolve, 280));
+    expect(root.querySelector('.inventory-status')?.textContent).toContain('In stock · dispatches in 2–3 days');
 
     root.querySelector<HTMLInputElement>('input[name="finish"]:not(:checked)')!.click();
     root.querySelector<HTMLButtonElement>('.add-to-bag')!.click();
     await settleShop();
-    expect(root.querySelector('[role="dialog"] #bag-title')?.textContent).toBe('Bag 1');
-    expect(root.querySelector('.bag-line p')?.textContent).toContain('Graphite');
-    root.querySelector<HTMLButtonElement>('[aria-label="Increase quantity"]')!.click();
+    expect(document.querySelector('[role="dialog"] #bag-title')?.textContent).toBe('Bag 1');
+    expect(document.querySelector('.bag-line p')?.textContent).toContain('Graphite');
+    document.querySelector<HTMLButtonElement>('[aria-label="Increase quantity"]')!.click();
     await settleShop();
-    expect(root.querySelector('#bag-title')?.textContent).toBe('Bag 2');
+    expect(document.querySelector('#bag-title')?.textContent).toBe('Bag 2');
 
-    root.querySelector<HTMLButtonElement>('[aria-label="Close bag"]')!.click();
+    document.querySelector<HTMLButtonElement>('[aria-label="Close bag"]')!.click();
     router.back();
     await settleShop();
     expect(router.currentRoute.value.path).toBe('/');
     router.forward();
     await settleShop();
     expect(router.currentRoute.value.path).toBe('/products/orbit-lamp');
+    expect(root.querySelector('.product-page')).toBe(productPage);
     app.unmount();
+    expect(document.querySelector('gluon-teleport')).toBeNull();
   });
 
   it('exposes functional mobile navigation and catalog filters', async () => {
@@ -103,11 +110,12 @@ describe('GLUON GOODS reference shop', () => {
 
     root.querySelector<HTMLButtonElement>('.bag-action')!.click();
     await settleShop();
-    expect(root.querySelector('.empty-bag')?.textContent).toContain('ready for something useful');
-    root.querySelector<HTMLAnchorElement>('.empty-bag a')!.click();
+    expect(document.querySelector('.empty-bag')?.textContent).toContain('ready for something useful');
+    document.querySelector<HTMLAnchorElement>('.empty-bag a')!.click();
     await settleShop();
     expect(router.currentRoute.value.path).toBe('/shop');
-    expect(root.querySelector('.bag-drawer')).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    expect(document.querySelector('.bag-drawer')).toBeNull();
     app.unmount();
   });
 
@@ -124,16 +132,16 @@ describe('GLUON GOODS reference shop', () => {
     root.querySelector<HTMLButtonElement>('.add-to-bag')!.click();
     await settleShop();
     expect(document.activeElement?.getAttribute('aria-label')).toBe('Close bag');
-    root.querySelector<HTMLButtonElement>('[aria-label="Decrease quantity"]')!.click();
+    document.querySelector<HTMLButtonElement>('[aria-label="Decrease quantity"]')!.click();
     await settleShop();
-    expect(root.querySelector('.empty-bag')).not.toBeNull();
+    expect(document.querySelector('.empty-bag')).not.toBeNull();
 
-    root.querySelector<HTMLButtonElement>('[aria-label="Close bag"]')!.click();
+    document.querySelector<HTMLButtonElement>('[aria-label="Close bag"]')!.click();
     root.querySelector<HTMLButtonElement>('.add-to-bag')!.click();
     await settleShop();
-    root.querySelector<HTMLButtonElement>('.remove-line')!.click();
+    document.querySelector<HTMLButtonElement>('.remove-line')!.click();
     await settleShop();
-    expect(root.querySelector('.empty-bag')).not.toBeNull();
+    expect(document.querySelector('.empty-bag')).not.toBeNull();
 
     await router.push('/shipping');
     await settleShop();
@@ -173,8 +181,8 @@ describe('GLUON GOODS reference shop', () => {
     second.app.mount(secondRoot);
     secondRoot.querySelector<HTMLButtonElement>('.bag-action')!.click();
     await settleShop();
-    expect(secondRoot.querySelector('.bag-line h3')?.textContent).toBe('Stack Tray');
-    expect(secondRoot.querySelector('.bag-line p')?.textContent).toContain('Cobalt');
+    expect(document.querySelector('.bag-line h3')?.textContent).toBe('Stack Tray');
+    expect(document.querySelector('.bag-line p')?.textContent).toContain('Cobalt');
     isolatedA.storeManager.dispose();
     isolatedB.storeManager.dispose();
     second.app.unmount();


### PR DESCRIPTION
## Summary

- add deterministic `Suspense` and preloadable async functional components with delay, timeout, retry, abort, and logical source identity
- add application-owned `Teleport`, LRU `KeepAlive`, cancellable `Transition`, and keyed `TransitionGroup` primitives
- expose typed DOM-free server descriptors for all built-ins
- integrate async availability, cached route views, a teleported/animated bag, and keyed line transitions into GLUON GOODS
- document lifecycle, ownership, SSR handoff, reduced-motion, and bundle composition

## Validation

- `npm run check`
- `npm run measure:shop` — 116,909 bytes raw / 33,371 bytes gzip for the complete entry
- In-app Browser QA at the default desktop viewport and 390×844
- Pending → resolved inventory, configured Bag, focus, route cache/back, mobile layout, and console health verified

Closes #27