### PR TITLE
Complete the GLUON GOODS checkout journey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and released versions follow [Semantic Versioning](https://semver.org/).
   and abortable nested progressive streaming in `@gluonjs/ssr`.
 - Route-aware static generation, Vite asset manifests, resource hints,
   request-nonce style carriers, and transactional adopted-sheet hydration.
+- A complete GLUON GOODS bag-to-checkout journey with typed delivery state,
+  order placement, and URL-addressable confirmation.
 
 - A standalone, DOM-free `@gluonjs/reactivity` package with refs, deep and
   shallow object and collection proxies, effects, computed values, dependency

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,7 +18,8 @@ under `examples/shop/dist-static`.
 `generateStaticSite()` accepts explicit public URLs, an asset manifest, and the
 same `renderShopRequest()` used for dynamic requests. GLUON GOODS prerenders
 home, catalog, Orbit Lamp, shipping, and returns. `gluon-static.json` records
-those pages and `/products/:slug` as a dynamic fallback. Hosts serve generated
+those pages and `/products/:slug`, `/checkout`, and `/orders/:id` as dynamic
+stateful fallbacks. Hosts serve generated
 `index.html` files at their recorded URLs and immutable hashed `/assets/` files.
 
 Generated documents contain resource hints, the module entry, SSR state, and

--- a/examples/shop/FEATURES.md
+++ b/examples/shop/FEATURES.md
@@ -9,6 +9,7 @@
 | Adopted stylesheets | Complete responsive shop presentation | Shop browser test + visual QA | Integrated |
 | Native dialog and control accessibility | Search, mobile menu, product choices, and bag | `tests/shop-example.spec.ts` + 390px/320px browser QA | Integrated |
 | Official Store | Per-app bag state, configured line items, persisted bag, derived totals | Store Node/type suites + `tests/shop-example.spec.ts` | Integrated |
+| Store actions + Router forms | Labeled delivery checkout, order summary, atomic order placement, and confirmation URL | Desktop/mobile shop flow + Store snapshot and browser assertions | Integrated purchase path |
 | `Suspense` and async component contract | Abortable product availability loading, explicit pending/error/retry states | Built-ins browser suite + `tests/shop-example.spec.ts` | Integrated |
 | `Teleport` and `Transition` | Application-owned, animated accessible bag overlay | Built-ins context/cleanup suite + shop browser test | Integrated |
 | `KeepAlive` | Route view retention across product back/forward traversal | Built-ins LRU suite + shop node-identity assertion | Integrated |

--- a/examples/shop/README.md
+++ b/examples/shop/README.md
@@ -14,6 +14,7 @@ The current slice uses the public Core, Reactivity, Router, and Store APIs to pr
 - a realistic product catalog and product-detail surface
 - keyboard-operable product configuration
 - a reactive bag with configured line items and quantities
+- a labeled checkout form, exact order summary, and URL-addressable confirmation
 - one isolated Store manager per shop application and persisted configured bag lines
 - abortable product availability with explicit loading, error, timeout, and retry UI
 - cached route views across back/forward traversal
@@ -36,7 +37,8 @@ the product flow.
 
 The production pipeline emits hashed client assets and `gluon-assets.json`, a
 Vite SSR request bundle, and five route-aware static documents with one recorded
-dynamic product fallback. See [static and server deployment](../../docs/deployment.md).
+dynamic product family plus stateful checkout and order fallbacks. See [static
+and server deployment](../../docs/deployment.md).
 
 ## Run
 
@@ -88,12 +90,18 @@ maintained in [FEATURES.md](FEATURES.md). `npm run check:shop-boundaries`
 rejects private or undeclared package imports and `<style>` fallback paths in
 shop source.
 
+The checkout acceptance flow was verified at 390px from product through bag,
+labeled delivery fields, order submission, and confirmation. At 320px the
+confirmation has no horizontal overflow and every visible link/button remains
+at least 44px high. This frontend confirmation does not claim payment-provider
+or fulfillment integration.
+
 ## Reproducible bundle evidence
 
 `npm run measure:shop` performs a production build and reports raw and level-9
 gzip byte counts from the generated files. For this slice, the single browser
 entry that contains Core, Reactivity, Router, Store, async built-ins, and the shop
-is 116,909 bytes raw and 33,371 bytes gzip. The five WebP product/editorial assets total 155,126
+is 137,169 bytes raw and 40,088 bytes gzip. The five WebP product/editorial assets total 155,126
 bytes. These are composition measurements, not a rendering-speed claim. The
 comparative Gluon, Lit, Vue, and Vanilla DOM benchmark belongs to issue #38 and
 must publish its scenarios, browser versions, warm-up, samples, and raw results

--- a/examples/shop/src/app.ts
+++ b/examples/shop/src/app.ts
@@ -24,6 +24,8 @@ import {
   NotFoundPage,
   ProductPage,
   ReturnsPage,
+  CheckoutPage,
+  OrderConfirmationPage,
   ShippingPage,
 } from './pages.js';
 import { createShopStore, type ShopStore } from './state.js';
@@ -91,6 +93,8 @@ export function createShopRoutes(store: ShopStore): readonly RouteRecordRaw[] {
     { path: '/products/:slug', name: 'product', component: () => ProductPage(store) },
     { path: '/shipping', name: 'shipping', component: () => ShippingPage(store) },
     { path: '/returns', name: 'returns', component: () => ReturnsPage(store) },
+    { path: '/checkout', name: 'checkout', component: () => CheckoutPage(store) },
+    { path: '/orders/:id', name: 'order', component: () => OrderConfirmationPage(store) },
     { path: '/:path*', name: 'not-found', component: () => NotFoundPage(store) },
   ];
 }

--- a/examples/shop/src/components.ts
+++ b/examples/shop/src/components.ts
@@ -178,7 +178,7 @@ function BagDrawer(store: ShopStore): TemplateValue {
           <footer class="bag-summary">
             <div><span>Subtotal</span><strong>${formatPrice(store.bagTotal)}</strong></div>
             <p>Shipping calculated at checkout.</p>
-            ${RouterLink({ to: '/shop', children: 'Continue shopping', attributes: { class: 'primary-button' } })}
+            ${RouterLink({ to: '/checkout', children: 'Checkout', attributes: { class: 'primary-button' } })}
           </footer>
         `}
       </aside>

--- a/examples/shop/src/pages.ts
+++ b/examples/shop/src/pages.ts
@@ -1,5 +1,5 @@
 import { Suspense, html, repeat, type AsyncLoadContext, type TemplateValue } from '@gluonjs/core';
-import { RouterLink, useRoute } from '@gluonjs/router';
+import { RouterLink, useRoute, useRouter } from '@gluonjs/router';
 import {
   categories,
   findProduct,
@@ -144,6 +144,45 @@ export function ReturnsPage(_store: ShopStore): TemplateValue {
     'Returns',
     'Unused objects can be returned within 30 days. Start with a message to hello@example.com and we will provide the closest return route.',
   );
+}
+
+export function CheckoutPage(store: ShopStore): TemplateValue {
+  const router = useRouter();
+  if (store.bag.length === 0) return html`
+    <section class="checkout-empty"><h1>Your bag is empty.</h1>
+      ${RouterLink({ to: '/shop', children: 'Return to the collection', attributes: { class: 'primary-button' } })}
+    </section>`;
+  const field = (name: keyof typeof store.checkout, label: string, type = 'text') => html`
+    <label><span>${label}</span><input name=${name} type=${type} required .value=${store.checkout[name]}
+      @input=${(event: Event) => store.updateCheckout(name, (event.currentTarget as HTMLInputElement).value)}></label>`;
+  return html`
+    <section class="checkout-page" aria-labelledby="checkout-title">
+      <div><p class="eyebrow">Secure checkout</p><h1 id="checkout-title">Delivery details</h1>
+        <form @submit=${(event: Event) => {
+          event.preventDefault();
+          const order = store.placeOrder();
+          void router.push(`/orders/${encodeURIComponent(order.id)}`);
+        }}>
+          ${field('email', 'Email', 'email')}${field('name', 'Full name')}${field('address', 'Address')}
+          <div class="checkout-row">${field('postalCode', 'Postal code')}${field('city', 'City')}</div>
+          <button class="primary-button place-order" type="submit">Place order — ${formatPrice(store.bagTotal)}</button>
+        </form>
+      </div>
+      <aside class="order-summary" aria-label="Order summary"><h2>Order summary</h2>
+        ${repeat(store.bag, (line) => line.key, (line) => html`<div><span>${line.quantity} × ${line.product.name}</span><strong>${formatPrice(line.product.price * line.quantity)}</strong></div>`)}
+        <footer><span>Total</span><strong>${formatPrice(store.bagTotal)}</strong></footer>
+      </aside>
+    </section>`;
+}
+
+export function OrderConfirmationPage(store: ShopStore): TemplateValue {
+  const route = useRoute();
+  const order = store.order;
+  if (!order || route.params.id !== order.id) return NotFoundPage(store);
+  return html`<section class="order-confirmation"><p class="eyebrow">Order confirmed</p>
+    <h1>Thank you, your objects are reserved.</h1><p>Order <strong>${order.id}</strong> is confirmed.</p>
+    <p>We sent the delivery details to ${order.email}.</p><strong class="order-total">${formatPrice(order.total)}</strong>
+    ${RouterLink({ to: '/shop', children: 'Continue shopping', attributes: { class: 'primary-button' } })}</section>`;
 }
 
 function ProductGallery(product: Product): TemplateValue {

--- a/examples/shop/src/state.ts
+++ b/examples/shop/src/state.ts
@@ -14,6 +14,13 @@ export interface BagLine {
   quantity: number;
 }
 
+export interface ShopOrder {
+  readonly id: string;
+  readonly lines: readonly BagLine[];
+  readonly total: number;
+  readonly email: string;
+}
+
 const defaultConfiguration = (): ProductConfiguration => ({
   finish: 'Cobalt',
   temperature: 'Warm 2700K',
@@ -27,6 +34,8 @@ export const shopStoreDefinition = defineStore('shop', () => ({
   searchQuery: '',
   configuration: defaultConfiguration(),
   bag: [] as BagLine[],
+  checkout: { email: '', name: '', address: '', city: '', postalCode: '' },
+  order: null as ShopOrder | null,
 }), {
   getters: (state) => ({
     bagCount: state.bag.reduce((total, line) => total + line.quantity, 0),
@@ -61,6 +70,22 @@ export const shopStoreDefinition = defineStore('shop', () => ({
     removeFromBag(key: string): void {
       const index = store.bag.findIndex((line) => line.key === key);
       if (index >= 0) store.bag.splice(index, 1);
+    },
+    updateCheckout(field: keyof typeof store.checkout, value: string): void {
+      store.checkout[field] = value;
+    },
+    placeOrder(): ShopOrder {
+      if (store.bag.length === 0) throw new Error('An order requires at least one bag line.');
+      const order: ShopOrder = {
+        id: `GG-${String(store.bagCount).padStart(2, '0')}-${String(store.bagTotal)}`,
+        lines: store.bag.map((line) => ({ ...line, configuration: { ...line.configuration } })),
+        total: store.bagTotal,
+        email: store.checkout.email,
+      };
+      store.order = order;
+      store.bag = [];
+      store.bagOpen = false;
+      return order;
     },
   }),
   persist: { paths: ['bag'] },

--- a/examples/shop/src/styles.ts
+++ b/examples/shop/src/styles.ts
@@ -357,6 +357,20 @@ export const shopStyles = css`
     .product-story dt { color: var(--shop-muted); font-size: 12px; }
     .product-story dd { margin: 4px 0 0; }
     .paired-product .product-card { display: block; border: 1px solid var(--shop-rule); }
+    .checkout-page { display: grid; grid-template-columns: minmax(0, 1.2fr) minmax(300px, .8fr); gap: clamp(40px, 8vw, 130px); padding: clamp(42px, 7vw, 100px) var(--shop-gutter); }
+    .checkout-page h1, .order-confirmation h1, .checkout-empty h1 { font-size: clamp(42px, 7vw, 92px); line-height: .94; letter-spacing: -.055em; }
+    .checkout-page form { display: grid; gap: 18px; max-width: 720px; margin-top: 42px; }
+    .checkout-page label { display: grid; gap: 7px; font-size: 12px; }
+    .checkout-page input { min-height: 52px; padding: 0 14px; border: 1px solid var(--shop-rule); background: white; }
+    .checkout-row { display: grid; grid-template-columns: 1fr 1.5fr; gap: 14px; }
+    .place-order { width: 100%; margin-top: 12px; }
+    .order-summary { align-self: start; padding: 28px; border: 1px solid var(--shop-rule); }
+    .order-summary h2 { margin-bottom: 24px; font-size: 22px; }
+    .order-summary > div, .order-summary footer { display: flex; justify-content: space-between; gap: 20px; padding: 15px 0; border-top: 1px solid var(--shop-rule); }
+    .order-summary footer { margin-top: 12px; border-color: var(--shop-black); font-size: 20px; }
+    .order-confirmation, .checkout-empty { min-height: 65vh; padding: clamp(54px, 9vw, 130px) var(--shop-gutter); }
+    .order-confirmation > p { max-width: 620px; margin-top: 22px; font-size: 18px; }
+    .order-total { display: block; margin: 30px 0; font-size: 28px; }
     .paired-product .product-copy strong { font-size: 19px; }
 
     .not-found { display: grid; place-items: start; align-content: center; min-height: 70vh; padding: 70px var(--shop-gutter); }
@@ -455,6 +469,9 @@ export const shopStyles = css`
 
       .bag-line { grid-template-columns: 90px 1fr; padding: 18px; }
       .bag-line > img { width: 90px; }
+      .checkout-page { grid-template-columns: 1fr; padding-top: 36px; }
+      .checkout-row { grid-template-columns: 1fr; }
+      .order-summary { order: -1; }
     }
 
     @media (max-width: 390px) {

--- a/scripts/generate-shop-static.mjs
+++ b/scripts/generate-shop-static.mjs
@@ -7,7 +7,7 @@ const repositoryRoot = resolve(import.meta.dirname, '..');
 const assets = JSON.parse(await readFile(resolve(repositoryRoot, 'examples/shop/dist/gluon-assets.json'), 'utf8'));
 const result = await generateStaticSite({
   routes: ['/', '/shop', '/products/orbit-lamp', '/shipping', '/returns'],
-  dynamicRoutes: ['/products/:slug'],
+  dynamicRoutes: ['/products/:slug', '/checkout', '/orders/:id'],
   outputDirectory: resolve(repositoryRoot, 'examples/shop/dist-static'),
   assets,
   render: (url) => renderShopRequest(url, { assets }),

--- a/tests/shop-example.spec.ts
+++ b/tests/shop-example.spec.ts
@@ -80,6 +80,37 @@ describe('GLUON GOODS reference shop', () => {
     app.unmount();
   });
 
+  it('completes bag checkout and renders a durable order confirmation route', async () => {
+    const { app, router, store } = createShopApplication(createMemoryHistory(['/products/orbit-lamp']), { storage: null });
+    await router.isReady();
+    const root = document.createElement('div');
+    document.body.append(root);
+    app.mount(root);
+    expect(() => store.placeOrder()).toThrow('at least one bag line');
+    root.querySelector<HTMLButtonElement>('.add-to-bag')!.click();
+    await settleShop();
+    document.querySelector<HTMLAnchorElement>('.bag-summary a')!.click();
+    await settleShop();
+    expect(router.currentRoute.value.path).toBe('/checkout');
+    expect(root.querySelector('h1')?.textContent).toBe('Delivery details');
+
+    for (const [name, value] of Object.entries({
+      email: 'ada@example.com', name: 'Ada Lovelace', address: '1 Gluon Way', postalCode: '10115', city: 'Berlin',
+    })) {
+      const input = root.querySelector<HTMLInputElement>(`input[name="${name}"]`)!;
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    root.querySelector<HTMLFormElement>('form')!.requestSubmit();
+    await settleShop();
+    expect(router.currentRoute.value.path).toMatch(/^\/orders\/GG-/);
+    expect(root.querySelector('.order-confirmation')?.textContent).toContain('ada@example.com');
+    expect(root.querySelector('.order-confirmation')?.textContent).toContain('€189');
+    expect(store.bagCount).toBe(0);
+    expect(store.order?.lines[0]?.configuration.finish).toBe('Cobalt');
+    app.unmount();
+  });
+
   it('searches the catalog and exposes a useful empty bag path', async () => {
     const { app, router, store } = createShopApplication(createMemoryHistory(['/']), { storage: null });
     await router.isReady();


### PR DESCRIPTION
## Summary
- add a coherent labeled delivery checkout, exact order summary, Store-owned order placement, and URL-addressable confirmation
- route the existing configured bag into `/checkout` and preserve the purchased line configuration in the confirmation record
- keep checkout/order routes dynamic in mixed static/server deployment metadata
- add responsive Swiss-editorial checkout and confirmation layouts without changing the accepted visual system
- extend the public capability map, deployment docs, shop runbook, and reproducible bundle measurements
- add a browser regression covering product → bag → checkout → confirmation and empty-order rejection

## Verification
- `npm run check`
- browser: 152 tests; 95.40% statements, 90.00% branches, 96.93% functions, 96.99% lines
- production client, server, and five-route static builds; three stateful dynamic fallbacks
- `npm run measure:shop`: 137,169-byte entry, 40,088-byte level-9 gzip, 155,126 bytes across five WebP assets
- in-app Chromium at 390px: existing two-line configured bag → labeled checkout → `GG-02-378` confirmation at `mobile@example.com`
- in-app Chromium at 320px: no horizontal overflow (`scrollWidth = viewport = 320`); every visible link/button was at least 44px high

This is a frontend order-confirmation acceptance flow; it makes no payment-provider or fulfillment claim.

Closes #28