### PR TITLE
Fix clean-runner Playground Pages build

### DIFF
--- a/.github/workflows/playground-pages.yml
+++ b/.github/workflows/playground-pages.yml
@@ -35,6 +35,9 @@ jobs:
           node-version: 22.12.0
           cache: npm
       - run: npm ci --ignore-scripts
+      - run: npm run build:core
+      - run: npm run build:compiler
+      - run: npm run build:vite
       - run: npm run build:playground
       - run: mkdir -p .pages/playground && cp -R examples/playground/dist/. .pages/playground/
       - uses: actions/configure-pages@v5

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -22,6 +22,11 @@ reproduction. Download creates an uncompressed, runnable Vite project with an
 HTML entry, typed Gluon mount, constructable stylesheet adoption, TypeScript
 configuration, aligned `0.0.0` Gluon dependencies, and the template checker.
 
+The GitHub Pages job starts from `npm ci --ignore-scripts`, builds Core (including
+Reactivity), Compiler, and Vite in dependency order, and then runs
+`npm run build:playground`. This matches a clean runner where package `dist`
+directories do not exist before the workflow starts.
+
 Config opens the searchable versioned diagnostic catalog. Diagnostic rows link
 directly into that state. The GitHub Pages workflow deploys the production build
 at `https://marcmalerei.github.io/gluon/playground/`; the bug-report template


### PR DESCRIPTION
Closes #72

## What changed

- builds Core (including Reactivity), Compiler, and Vite before the Playground in the Pages workflow
- documents the clean-runner dependency order

## Root cause

The Pages runner started with npm ci and no workspace dist directories. The Playground Vite config imports the public @gluonjs/vite package entry, whose build requires generated Compiler and Core declarations. Local verification had inherited those artifacts from the full repository build.

## Verification

A separate detached worktree at this commit started without node_modules or package dist directories and passed the exact sequence:

- npm ci --ignore-scripts
- npm run build:core
- npm run build:compiler
- npm run build:vite
- npm run build:playground

The earlier narrower Compiler → Vite sequence was also tested and correctly reproduced the missing @gluonjs/core declaration failure before this final fix.