### PR TITLE
Upgrade GitHub Pages actions to Node 24 releases

### DIFF
--- a/.github/workflows/playground-pages.yml
+++ b/.github/workflows/playground-pages.yml
@@ -49,10 +49,10 @@ jobs:
       - run: npm run typecheck:docs
       - run: node scripts/validate-docs.mjs
       - run: mkdir -p .pages/playground && cp -R docs-site/dist/. .pages/ && cp -R examples/playground/dist/. .pages/playground/
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: .pages
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -27,7 +27,9 @@ Reactivity), Compiler, and Vite in dependency order, and then builds the
 Playground and versioned documentation. It typechecks every documentation
 example and validates the release tree before publishing both outputs as one
 Pages artifact. This matches a clean runner where package `dist` directories do
-not exist before the workflow starts.
+not exist before the workflow starts. The checkout, Node setup, Pages
+configuration, artifact upload, and deployment steps use their current Node 24
+action majors.
 
 Config opens the searchable versioned diagnostic catalog. Diagnostic rows link
 directly into that state. The GitHub Pages workflow deploys the production build


### PR DESCRIPTION
## Summary

- upgrade `actions/configure-pages` from v5 to v6
- upgrade `actions/upload-pages-artifact` from v3 to v5
- upgrade `actions/deploy-pages` from v4 to v5
- document that the Pages pipeline uses current Node 24 action majors

Closes #76

## Root cause

Successful Gluon Pages run `29154155693` emitted a deprecation annotation because the three previous Pages action majors targeted Node.js 20 and GitHub forced them onto Node.js 24.

## Compatibility evidence

Official action manifests confirm:

- `configure-pages@v6` runs on Node 24
- `upload-pages-artifact@v5` retains the required `path` input and defaults the artifact name to `github-pages`
- `deploy-pages@v5` runs on Node 24 and retains the `page_url` output used by the environment URL

## Verification

- official latest releases: configure-pages v6.0.0, upload-pages-artifact v5.0.0, deploy-pages v5.0.0
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/playground-pages.yml")'`
- `git diff --check`
- final acceptance: successful post-merge Pages deployment without a Node.js 20 annotation
