### PR TITLE
Optimize generic keyed reconciliation

### DIFF
--- a/benchmarks/results/keyed-reconciliation-5d19308.json
+++ b/benchmarks/results/keyed-reconciliation-5d19308.json
@@ -1,0 +1,105 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-11T20:07:02Z",
+  "issue": 95,
+  "source": {
+    "baselineCommit": "4095745194c2a6ab0281b120de72f8df511ef7f3",
+    "candidateCommit": "5d19308e37b63ee92eb5283cb5035f5916a4912e",
+    "branch": "codex/keyed-head-tail-diff",
+    "workingTreeDirty": false
+  },
+  "environment": {
+    "platform": "darwin",
+    "release": "25.3.0",
+    "cpu": "Apple M4",
+    "logicalCpus": 10,
+    "totalMemoryBytes": 17179869184,
+    "node": "v22.22.0",
+    "npm": "10.9.4",
+    "vitest": "4.1.10",
+    "playwright": "1.61.1",
+    "browser": "chromium",
+    "browserVersion": "149.0.7827.55"
+  },
+  "methodology": {
+    "command": "npm run benchmark:keyed -- --reporter=verbose --compare=.tmp/keyed-baseline-4095745.json --outputJson=.tmp/keyed-optimized-5d19308.json",
+    "rowCount": 1000,
+    "timePerCaseMs": 500,
+    "unit": "milliseconds per operation; lower is faster",
+    "comparison": "candidate throughput divided by baseline throughput",
+    "limitations": "Vitest records aggregate statistics rather than individual samples. Baseline and candidate are consecutive separate browser runs on the same machine, so their distributions remain run-specific.",
+    "workloads": {
+      "reverse": "reverse all 1,000 surviving keyed rows",
+      "blockMove": "move the first 100 surviving keyed rows to the end",
+      "replacementWindow": "remove the first 100 keyed rows and append 100 new keyed rows"
+    }
+  },
+  "results": [
+    {
+      "scenario": "reverse",
+      "baseline": {
+        "hz": 7273.999996531487,
+        "meanMs": 0.13747594177575434,
+        "medianMs": 0.10000002384185791,
+        "p75Ms": 0.19999992847442627,
+        "p99Ms": 0.2999999523162842,
+        "rmePercent": 4.621948536979215,
+        "sampleCount": 3637
+      },
+      "candidate": {
+        "hz": 7514.497098430399,
+        "meanMs": 0.13307610434886938,
+        "medianMs": 0.10000002384185791,
+        "p75Ms": 0.19999992847442627,
+        "p99Ms": 0.20000004768371582,
+        "rmePercent": 4.606294609085653,
+        "sampleCount": 3758
+      },
+      "throughputRatio": 1.033064
+    },
+    {
+      "scenario": "blockMove",
+      "baseline": {
+        "hz": 4374.250301548025,
+        "meanMs": 0.22861060320350327,
+        "medianMs": 0.20000004768371582,
+        "p75Ms": 0.2999999523162842,
+        "p99Ms": 1.3000000715255737,
+        "rmePercent": 2.795912062372204,
+        "sampleCount": 2188
+      },
+      "candidate": {
+        "hz": 5489.9999986910825,
+        "meanMs": 0.1821493625206591,
+        "medianMs": 0.19999992847442627,
+        "p75Ms": 0.20000004768371582,
+        "p99Ms": 1.2999999523162842,
+        "rmePercent": 3.091783825908614,
+        "sampleCount": 2745
+      },
+      "throughputRatio": 1.255072
+    },
+    {
+      "scenario": "replacementWindow",
+      "baseline": {
+        "hz": 2764.8940421194716,
+        "meanMs": 0.3616775126881299,
+        "medianMs": 0.30000007152557373,
+        "p75Ms": 0.3999999761581421,
+        "p99Ms": 2,
+        "rmePercent": 3.1551483554219897,
+        "sampleCount": 1383
+      },
+      "candidate": {
+        "hz": 3119.3761253699,
+        "meanMs": 0.3205769230157901,
+        "medianMs": 0.2999999523162842,
+        "p75Ms": 0.30000007152557373,
+        "p99Ms": 1.899999976158142,
+        "rmePercent": 3.4878876925241844,
+        "sampleCount": 1560
+      },
+      "throughputRatio": 1.128209
+    }
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -287,9 +287,13 @@ the iterable and validates every `PropertyKey` before producing a
 `RepeatResult`. Missing (`null` or `undefined`) and duplicate keys throw before
 the result reaches `render()`. Each accepted key owns a child `NodePart` and an
 internal marker. Reconciliation updates surviving Parts and moves their marker
-and rendered node group into the requested order. It disconnects only keys that
-do not survive. Consequently, a surviving template or Custom Element keeps its
-DOM identity, binding state, and local element state across prepend, append,
+and rendered node group into the requested order. The generic path trims equal
+keyed heads and tails before allocating its middle lookup, retains the longest
+contiguous run whose rendered nodes did not change, and moves only groups
+outside that run. If renderer-owned nodes were changed externally, it falls
+back to the ordinary recovery path. It disconnects only keys that do not
+survive. Consequently, a surviving template or Custom Element keeps its DOM
+identity, binding state, and local element state across prepend, append,
 reverse, sort, and arbitrary moves.
 
 A changed key has no identity relationship to the previous key. Reconciliation
@@ -393,6 +397,8 @@ and stylesheet adoption.
 `npm run benchmark:keyed` provides three Gluon-only Chromium scenarios with
 1,000 rows: full reverse, a 100-row block move, and a 100-row replacement
 window. It is a repeatable regression harness, not a comparative benchmark.
+The retained issue #95 comparison and its interpretation are recorded in
+[`performance.md`](performance.md).
 
 `npm run benchmark:rendering` production-builds a separate comparison surface
 with Gluon, Lit, Vue, and optimized Vanilla DOM implementations. It validates

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -9,8 +9,10 @@ direct insertion when a new part contains one node, fragment batching when it
 contains multiple nodes, one element/comment traversal for every cloned
 template's bindings, precomputed binding priorities, parallel key/value storage
 for keyed repeats, detached keyed-child anchors, and keyed-list fast paths for
-unchanged and reversed order. These shortcuts retain the external-DOM recovery
-and keyed-identity contracts covered by the browser suite.
+unchanged and reversed order. Generic keyed changes trim stable heads and tails,
+retain their longest unchanged contiguous run, and move only the surrounding
+groups. These shortcuts retain the external-DOM recovery and keyed-identity
+contracts covered by the browser suite.
 
 The retained baseline is stored in
 [`benchmarks/results/`](../benchmarks/results/). Its Markdown file summarizes
@@ -149,6 +151,28 @@ rounds, and ten measured samples. The clean `34cd49a` run records zero
 `TreeWalker.nextNode()` accounts for 402 self samples. The profile covers all
 four benchmark workloads and records Chromium 149.0.7827.55 and the exact
 source commit.
+
+## Keyed reconciliation comparison
+
+Issue #95 compares the existing generic keyed path at baseline commit `4095745`
+with implementation commit `5d19308`. Both consecutive Chromium 149 runs used
+the 1,000-row `npm run benchmark:keyed` harness, Vitest 4.1.10, Node 22.22.0,
+and the same recorded Apple M4 environment. Vitest ran every case for 500 ms
+and retained aggregate distribution statistics in
+[`keyed-reconciliation-5d19308.json`](../benchmarks/results/keyed-reconciliation-5d19308.json).
+
+| Scenario | Baseline mean ms/op | Candidate mean ms/op | Throughput ratio |
+| --- | ---: | ---: | ---: |
+| Reverse all rows | 0.1375 | 0.1331 | 1.03× |
+| Move first 100 rows to the end | 0.2286 | 0.1821 | 1.26× |
+| Remove and append 100 rows | 0.3617 | 0.3206 | 1.13× |
+
+The block-move and replacement-window runs support the intended optimization
+on this environment. Full reverse remains on its pre-existing dedicated path;
+its close result is a regression check, not evidence that the new generic path
+made reverse faster. The runs are separate and Vitest retains aggregate
+statistics rather than individual samples, so these ratios are not generalized
+beyond the recorded commits, machine, browser, and workloads.
 
 ## Interpretation and limits
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -327,6 +327,12 @@ interface KeyedChild {
   binding?: Binding;
 }
 
+interface PreviousKeyedChild {
+  readonly child: KeyedChild;
+  readonly index: number;
+  readonly nodes: readonly Node[];
+}
+
 const emptyPartChildren: Array<PartChild | undefined> = [];
 const emptyKeyedChildren: KeyedChild[] = [];
 
@@ -638,40 +644,102 @@ class NodePart implements Part {
       return;
     }
 
-    const previousByKey = new Map(
-      this.keyedChildren.map((child) => [child.key, child] as const),
-    );
-    const nextKeys = new Set(keys);
-    const nextChildren: KeyedChild[] = [];
+    const previousChildren = this.keyedChildren;
+    const previousNodes = this.nodes;
+    const parent = this.marker.parentNode;
+    const nodesInPlace = Boolean(parent && nodesAreInPlace(this.marker, previousNodes));
+    const boundary = nodesInPlace && previousNodes.length > 0
+      ? previousNodes[previousNodes.length - 1]!.nextSibling
+      : this.marker.nextSibling;
+    const nextChildren = new Array<KeyedChild>(keys.length);
+    const reused = new Array<PreviousKeyedChild | undefined>(keys.length);
     const nextNodes: Node[] = [];
 
-    for (const [key, removed] of previousByKey) {
-      if (!nextKeys.has(key)) {
-        if (removed.binding) disconnectBindings([removed.binding]);
-        else removed.part.disconnect();
-        previousByKey.delete(key);
-      }
+    let start = 0;
+    let previousEnd = previousChildren.length;
+    let nextEnd = keys.length;
+
+    while (start < previousEnd && start < nextEnd && previousChildren[start]!.key === keys[start]) {
+      const child = previousChildren[start]!;
+      reused[start] = { child, index: start, nodes: child.part.nodes };
+      this.updateKeyedChild(child, values[start]!, true);
+      nextChildren[start] = child;
+      start += 1;
     }
 
-    for (let index = 0; index < keys.length; index += 1) {
+    while (
+      start < previousEnd
+      && start < nextEnd
+      && previousChildren[previousEnd - 1]!.key === keys[nextEnd - 1]
+    ) {
+      previousEnd -= 1;
+      nextEnd -= 1;
+      const child = previousChildren[previousEnd]!;
+      reused[nextEnd] = { child, index: previousEnd, nodes: child.part.nodes };
+      this.updateKeyedChild(child, values[nextEnd]!, true);
+      nextChildren[nextEnd] = child;
+    }
+
+    const previousByKey = new Map<Key, PreviousKeyedChild>();
+    for (let index = start; index < previousEnd; index += 1) {
+      const child = previousChildren[index]!;
+      previousByKey.set(child.key, { child, index, nodes: child.part.nodes });
+    }
+
+    const nextMiddleKeys = new Set<Key>();
+    for (let index = start; index < nextEnd; index += 1) nextMiddleKeys.add(keys[index]!);
+    for (const [key, { child: removed }] of previousByKey) {
+      if (nextMiddleKeys.has(key)) continue;
+      if (removed.binding) disconnectBindings([removed.binding]);
+      else removed.part.disconnect();
+      previousByKey.delete(key);
+    }
+
+    for (let index = start; index < nextEnd; index += 1) {
       const key = keys[index]!;
       const value = values[index]!;
       const previous = previousByKey.get(key);
-      const child = previous ?? this.createKeyedChild(key, value);
+      const child = previous?.child ?? this.createKeyedChild(key, value);
 
       if (previous) {
         previousByKey.delete(key);
+        reused[index] = previous;
         this.updateKeyedChild(child, value, true);
       }
 
-      nextChildren.push(child);
-      nextNodes.push(...child.part.nodes);
+      nextChildren[index] = child;
     }
 
+    const nextNodeGroups = nextChildren.map((child) => child.part.nodes);
+    for (const nodes of nextNodeGroups) nextNodes.push(...nodes);
     this.keyedChildren = nextChildren;
     this.textNode = undefined;
     this.lastPrimitive = unsetValue;
-    this.replaceNodes(nextNodes);
+    if (!parent || !nodesInPlace) {
+      this.replaceNodes(nextNodes);
+      return;
+    }
+
+    const stable = longestStableKeyedRun(nextNodeGroups, reused);
+    const keep = new Set(nextNodes);
+    for (const node of previousNodes) {
+      if (!keep.has(node) && node.parentNode === parent) parent.removeChild(node);
+    }
+
+    if (stable.length === 0) {
+      moveKeyedNodeGroupsBefore(parent, nextNodeGroups, 0, nextNodeGroups.length, boundary);
+    } else {
+      const stableFirst = nextNodeGroups[stable.start]![0]!;
+      moveKeyedNodeGroupsBefore(parent, nextNodeGroups, 0, stable.start, stableFirst);
+      moveKeyedNodeGroupsBefore(
+        parent,
+        nextNodeGroups,
+        stable.start + stable.length,
+        nextNodeGroups.length,
+        boundary,
+      );
+    }
+    this.nodes = nextNodes;
   }
 
   private updateKeyedInOrder(keys: readonly Key[], values: readonly TemplateValue[]): void {
@@ -2107,6 +2175,81 @@ function nodesAreInPlace(marker: Comment, nodes: readonly Node[]): boolean {
 
 function moveNodesBefore(parent: Node, nodes: readonly Node[], reference: Node | null): void {
   for (const node of nodes) parent.insertBefore(node, reference);
+}
+
+function longestStableKeyedRun(
+  nextNodeGroups: readonly (readonly Node[])[],
+  reused: readonly (PreviousKeyedChild | undefined)[],
+): { readonly start: number; readonly length: number } {
+  let longestStart = 0;
+  let longestLength = 0;
+  let currentStart = 0;
+  let currentLength = 0;
+  let previousIndex = -2;
+
+  for (let index = 0; index < reused.length; index += 1) {
+    const previous = reused[index];
+    const nodes = nextNodeGroups[index]!;
+    const stable = Boolean(
+      previous
+      && nodes.length > 0
+      && sameNodes(previous.nodes, nodes),
+    );
+    if (stable && previous!.index === previousIndex + 1) {
+      currentLength += 1;
+    } else if (stable) {
+      currentStart = index;
+      currentLength = 1;
+    } else {
+      currentLength = 0;
+    }
+    previousIndex = stable ? previous!.index : -2;
+    if (currentLength > longestLength) {
+      longestStart = currentStart;
+      longestLength = currentLength;
+    }
+  }
+
+  return { start: longestStart, length: longestLength };
+}
+
+function sameNodes(left: readonly Node[], right: readonly Node[]): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+function moveKeyedNodeGroupsBefore(
+  parent: Node,
+  groups: readonly (readonly Node[])[],
+  start: number,
+  end: number,
+  boundary: Node | null,
+): void {
+  let reference = boundary;
+  for (let index = end - 1; index >= start; index -= 1) {
+    const nodes = groups[index]!;
+    if (nodes.length === 0) continue;
+    if (!nodesAreImmediatelyBefore(parent, nodes, reference)) {
+      moveNodesBefore(parent, nodes, reference);
+    }
+    reference = nodes[0]!;
+  }
+}
+
+function nodesAreImmediatelyBefore(
+  parent: Node,
+  nodes: readonly Node[],
+  reference: Node | null,
+): boolean {
+  if (nodes[0]?.parentNode !== parent) return false;
+  for (let index = 1; index < nodes.length; index += 1) {
+    if (nodes[index - 1]!.nextSibling !== nodes[index]) return false;
+  }
+  return nodes[nodes.length - 1]!.nextSibling === reference;
 }
 
 function collectNodesUntil(marker: Comment, boundary: Node | null): Node[] {

--- a/tests/keyed-list-conformance.spec.ts
+++ b/tests/keyed-list-conformance.spec.ts
@@ -109,6 +109,68 @@ describe('keyed list renderer conformance', () => {
     expect(moved.textContent?.trim()).toBe('Bee');
   });
 
+  it('moves only displaced keyed groups around the longest stable run', () => {
+    const root = document.createElement('div');
+    const view = (ids: readonly string[]) => html`<ol>${repeat(
+      ids,
+      (id) => id,
+      (id) => html`<li data-id=${id}>${id}</li><li data-detail=${id}>detail</li>`,
+    )}</ol>`;
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    render(view(ids), root);
+
+    const list = root.querySelector('ol')!;
+    const identities = new Map(
+      [...list.children].map((item) => [
+        item.getAttribute('data-id') ?? `detail:${item.getAttribute('data-detail')}`,
+        item,
+      ]),
+    );
+    const insertBefore = vi.spyOn(list, 'insertBefore');
+
+    render(view([...ids.slice(2), ...ids.slice(0, 2)]), root);
+
+    expect(insertBefore).toHaveBeenCalledTimes(4);
+    expect([...list.querySelectorAll('[data-id]')].map((item) => item.getAttribute('data-id'))).toEqual([
+      'c', 'd', 'e', 'a', 'b',
+    ]);
+    for (const [key, item] of identities) {
+      const selector = key.startsWith('detail:')
+        ? `[data-detail="${key.slice(7)}"]`
+        : `[data-id="${key}"]`;
+      expect(list.querySelector(selector)).toBe(item);
+    }
+  });
+
+  it('inserts only the new keyed groups for a bounded replacement window', () => {
+    const root = document.createElement('div');
+    const ids = Array.from({ length: 10 }, (_, index) => String(index));
+    const view = (values: readonly string[]) => html`<ol>${repeat(
+      values,
+      (id) => id,
+      (id) => html`<li data-id=${id}>${id}</li>`,
+    )}</ol>`;
+    render(view(ids), root);
+
+    const list = root.querySelector('ol')!;
+    const survivors = new Map(
+      [...list.children].slice(2).map((item) => [item.getAttribute('data-id'), item]),
+    );
+    const insertBefore = vi.spyOn(list, 'insertBefore');
+
+    render(view([...ids.slice(2), 'new-a', 'new-b']), root);
+
+    expect(insertBefore).toHaveBeenCalledTimes(2);
+    expect([...list.children].map((item) => item.getAttribute('data-id'))).toEqual([
+      ...ids.slice(2),
+      'new-a',
+      'new-b',
+    ]);
+    for (const [id, item] of survivors) {
+      expect(list.querySelector(`[data-id="${id}"]`)).toBe(item);
+    }
+  });
+
   it('cleans a removed keyed child exactly once without cleaning moved survivors', () => {
     const root = document.createElement('div');
     const firstRef = vi.fn<(element: Element | undefined) => void>();


### PR DESCRIPTION
Closes #95.

## What changed

- trim equal keyed heads and tails before building the generic middle lookup
- retain the longest unchanged contiguous keyed run and move only surrounding groups
- preserve the existing external-DOM recovery fallback and cleanup ordering
- cover multi-node block moves, bounded replacement, DOM identity, and exact insertion counts
- retain the Chromium baseline/candidate benchmark evidence and document its limits

## Why

The previous generic keyed path built lookup structures for the full list and passed every rendered node through the general replacement loop. A 100-row rotation could therefore move the 900-row stable run instead of the 100 displaced rows.

## Evidence

Against baseline commit `4095745`, the retained Vitest/Chromium comparison at implementation commit `5d19308` measured:

- 1.26x throughput for moving the first 100 of 1,000 rows to the end
- 1.13x throughput for removing and appending a 100-row window
- 1.03x throughput for the unchanged dedicated full-reverse path

These are separate, environment-specific runs; aggregate statistics and limitations are retained in `benchmarks/results/keyed-reconciliation-5d19308.json`.

## Verification

- `npm run check`
- `npm run benchmark:keyed -- --reporter=verbose --compare=.tmp/keyed-baseline-4095745.json --outputJson=.tmp/keyed-optimized-5d19308.json`
