### PR TITLE
Establish the DX benchmark evidence contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- A versioned seven-task Gluon/Vue/React developer-experience benchmark
+  contract, strict raw-run evidence schema, official comparator-selection
+  record, and blocking validator that reports the current zero-run boundary
+  without making an unsupported comparison claim.
 - Reviewed task-oriented examples for all 507 generated public API symbol
   pages, with symbol-specific purpose text and concrete application, lifecycle,
   input/output, ownership, error, and cleanup flows shared through maintained

--- a/benchmarks/dx/evidence/comparator-selection-2026-07-12.json
+++ b/benchmarks/dx/evidence/comparator-selection-2026-07-12.json
@@ -1,0 +1,61 @@
+{
+  "schemaVersion": "1.0.0",
+  "recordedAt": "2026-07-12",
+  "status": "comparator-selection-only",
+  "environment": {
+    "operatingSystem": "macOS 26.3.1 (25D771280a)",
+    "architecture": "arm64",
+    "node": "v22.22.0",
+    "packageManager": "npm 10.9.4",
+    "playwright": "1.61.1",
+    "browsers": {
+      "chromium": "149.0.7827.55",
+      "firefox": "151.0",
+      "webkit": "26.5"
+    }
+  },
+  "sources": [
+    {
+      "framework": "vue",
+      "url": "https://vuejs.org/guide/quick-start.html",
+      "observedGuidance": "The official quick start identifies create-vue as the official project scaffolding tool."
+    },
+    {
+      "framework": "vue",
+      "url": "https://vuejs.org/guide/essentials/component-basics.html",
+      "observedGuidance": "The official component guide uses Single-File Components and script setup for its maintained component examples."
+    },
+    {
+      "framework": "react",
+      "url": "https://react.dev/learn/creating-a-react-app",
+      "observedGuidance": "The official application guide recommends starting new applications with a framework and lists React Router as a full-stack framework that supports SPA, SSR, and SSG applications."
+    },
+    {
+      "framework": "react",
+      "url": "https://react.dev/learn",
+      "observedGuidance": "The official daily component guide uses function components, JSX, props, events, state, and Hooks."
+    }
+  ],
+  "selectedVersions": {
+    "gluon": {
+      "source": "repository source at the run commit",
+      "packageVersion": "0.0.0"
+    },
+    "vue": {
+      "create-vue": "3.22.4",
+      "vue": "3.5.39"
+    },
+    "react": {
+      "create-react-router": "8.2.0",
+      "react-router": "8.2.0",
+      "react": "19.2.7",
+      "react-dom": "19.2.7"
+    }
+  },
+  "versionEvidenceCommand": "npm view create-vue version && npm view vue version && npm view react version && npm view react-dom version && npm view create-react-router version && npm view react-router version",
+  "limitations": [
+    "This record selects comparator lanes and captures versions; it is not a completed benchmark run.",
+    "No task result, win, tie, loss, usability finding, or DX-superiority claim is supported by this record.",
+    "A completed run must conform to benchmarks/dx/schema/run-v1.schema.json and include all 21 framework-task results plus at least one retained human usability pass."
+  ]
+}

--- a/benchmarks/dx/schema/run-v1.schema.json
+++ b/benchmarks/dx/schema/run-v1.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/marcmalerei/gluon/benchmarks/dx/schema/run-v1.schema.json",
+  "title": "Gluon DX benchmark run",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "specification", "runId", "startedAt", "finishedAt", "sourceCommit", "environment", "frameworks", "tasks", "humanPasses", "limitations"],
+  "properties": {
+    "schemaVersion": { "const": "1.0.0" },
+    "specification": { "const": "benchmarks/dx/specification-v1.json" },
+    "runId": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-z0-9-]+$" },
+    "startedAt": { "type": "string", "format": "date-time" },
+    "finishedAt": { "type": "string", "format": "date-time" },
+    "sourceCommit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operatingSystem", "architecture", "node", "packageManager", "browsers"],
+      "properties": {
+        "operatingSystem": { "type": "string", "minLength": 1 },
+        "architecture": { "type": "string", "minLength": 1 },
+        "node": { "type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "packageManager": { "type": "string", "minLength": 1 },
+        "browsers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["chromium", "firefox", "webkit"],
+          "properties": {
+            "chromium": { "type": "string", "minLength": 1 },
+            "firefox": { "type": "string", "minLength": 1 },
+            "webkit": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    "frameworks": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "$ref": "#/$defs/framework" }
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 21,
+      "maxItems": 21,
+      "items": { "$ref": "#/$defs/task" }
+    },
+    "humanPasses": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["participantId", "brief", "frameworkOrder", "observations", "limitations"],
+        "properties": {
+          "participantId": { "type": "string", "minLength": 1 },
+          "brief": { "type": "string", "minLength": 1 },
+          "frameworkOrder": {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "items": { "enum": ["gluon", "vue", "react"] },
+            "uniqueItems": true
+          },
+          "observations": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+          "limitations": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+        }
+      }
+    },
+    "limitations": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+  },
+  "$defs": {
+    "framework": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "lane", "versions", "scaffoldCommand", "interactiveAnswers", "fixture", "lockfile"],
+      "properties": {
+        "id": { "enum": ["gluon", "vue", "react"] },
+        "lane": { "type": "string", "minLength": 1 },
+        "versions": { "type": "object", "minProperties": 1, "additionalProperties": { "type": "string", "minLength": 1 } },
+        "scaffoldCommand": { "type": "string", "minLength": 1 },
+        "interactiveAnswers": { "type": "array", "items": { "type": "string" } },
+        "fixture": { "type": "string", "minLength": 1 },
+        "lockfile": { "type": "string", "minLength": 1 }
+      }
+    },
+    "commandResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "exitCode", "stdout", "stderr", "durationMs"],
+      "properties": {
+        "command": { "type": "string", "minLength": 1 },
+        "exitCode": { "type": "integer" },
+        "stdout": { "type": "string" },
+        "stderr": { "type": "string" },
+        "durationMs": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["framework", "taskId", "status", "commands", "generatedFiles", "authorCreatedFiles", "authorSourceLines", "configurationLines", "productionDependencies", "developmentDependencies", "publicApis", "frameworkConcepts", "checks", "diagnostics", "browserVisibleOutput", "limitations"],
+      "properties": {
+        "framework": { "enum": ["gluon", "vue", "react"] },
+        "taskId": { "type": "string", "pattern": "^T[1-7]-[a-z-]+$" },
+        "status": { "enum": ["pass", "fail", "not-applicable"] },
+        "commands": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/commandResult" } },
+        "generatedFiles": { "type": "array", "items": { "type": "string" } },
+        "authorCreatedFiles": { "type": "array", "items": { "type": "string" } },
+        "authorSourceLines": { "type": "integer", "minimum": 0 },
+        "configurationLines": { "type": "integer", "minimum": 0 },
+        "productionDependencies": { "type": "array", "items": { "type": "string" } },
+        "developmentDependencies": { "type": "array", "items": { "type": "string" } },
+        "publicApis": { "type": "array", "items": { "type": "string" } },
+        "frameworkConcepts": { "type": "array", "items": { "type": "string" } },
+        "checks": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["typecheck", "build", "browserTest", "accessibility", "hmr", "ssr", "hydration", "cleanup"],
+          "properties": {
+            "typecheck": { "$ref": "#/$defs/check" },
+            "build": { "$ref": "#/$defs/check" },
+            "browserTest": { "$ref": "#/$defs/check" },
+            "accessibility": { "$ref": "#/$defs/check" },
+            "hmr": { "$ref": "#/$defs/check" },
+            "ssr": { "$ref": "#/$defs/check" },
+            "hydration": { "$ref": "#/$defs/check" },
+            "cleanup": { "$ref": "#/$defs/check" }
+          }
+        },
+        "diagnostics": { "type": "array", "items": { "type": "string" } },
+        "browserVisibleOutput": { "type": "array", "items": { "type": "string" } },
+        "limitations": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "evidence"],
+      "properties": {
+        "status": { "enum": ["pass", "fail", "not-applicable"] },
+        "evidence": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      }
+    }
+  }
+}

--- a/benchmarks/dx/specification-v1.json
+++ b/benchmarks/dx/specification-v1.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "1.0.0",
+  "benchmarkId": "gluon-dx-application-authoring",
+  "title": "Gluon, Vue, and React application-authoring comparison",
+  "comparisonRule": "Each framework implements the same observable customer and authoring outcomes. Framework-specific syntax and architecture are measured, not normalized away.",
+  "frameworks": [
+    {
+      "id": "gluon",
+      "lane": "create-gluon strict TypeScript application",
+      "selectionSource": "https://github.com/marcmalerei/gluon/tree/main/packages/create-gluon"
+    },
+    {
+      "id": "vue",
+      "lane": "official create-vue application",
+      "selectionSource": "https://vuejs.org/guide/quick-start.html"
+    },
+    {
+      "id": "react",
+      "lane": "officially recommended React Router framework application",
+      "selectionSource": "https://react.dev/learn/creating-a-react-app",
+      "selectionReason": "The retained task is a routed browser application that also renders and hydrates the same route. React's official application-creation guide lists React Router as a recommended full-stack framework with SPA, SSR, and SSG support; the from-scratch lane would require selecting separate routing and server-rendering tools."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "T1-scaffold",
+      "title": "Scaffold the application",
+      "observableOutcomes": [
+        "A strict TypeScript project starts from the recorded scaffold command and answers.",
+        "The project has two navigable routes, shared persisted state, a browser test, and a production build.",
+        "A clean checkout installs, typechecks, tests, and builds without source edits."
+      ]
+    },
+    {
+      "id": "T2-themed-controls",
+      "title": "Add themed accessible controls",
+      "observableOutcomes": [
+        "A labeled text input and named button use the framework lane's supported public styling or component-extension contract.",
+        "Keyboard activation works and the browser test verifies the accessible names and visible focus.",
+        "No fixture copies private library implementation or imports private or deep build paths."
+      ]
+    },
+    {
+      "id": "T3-local-layers",
+      "title": "Create app-local UI layers",
+      "observableOutcomes": [
+        "The application owns one primitive control, one repeated control composition, and one larger page layout.",
+        "Each layer is extended once through its documented public contract.",
+        "The retained browser output is the same checkout flow in all three fixtures, not a component gallery."
+      ]
+    },
+    {
+      "id": "T4-stateful-control",
+      "title": "Build a reusable stateful form control",
+      "observableOutcomes": [
+        "A quantity control accepts a typed structured input, owns local and computed state, validates its value, and participates in a form.",
+        "It emits a typed cancelable public change event, supports default and named content, exposes focus, and releases registered work on teardown.",
+        "Retained invalid-prop, invalid-event, and missing-cleanup variants are checked by the framework's normal diagnostics."
+      ]
+    },
+    {
+      "id": "T5-customer-flow",
+      "title": "Navigate, persist, test, and hot-update",
+      "observableOutcomes": [
+        "A user opens the product route, configures quantity, adds the exact line item, reaches checkout, and returns with back/forward traversal.",
+        "Reload restores the recorded customer state.",
+        "A compatible component or style edit retains route, form, and application state; the HMR observation method is recorded."
+      ]
+    },
+    {
+      "id": "T6-universal-route",
+      "title": "Render and hydrate the same route",
+      "observableOutcomes": [
+        "The product route is rendered on the server and hydrated in the browser from the same public component implementation.",
+        "Hydration retains the server DOM identity and customer interaction works after hydration.",
+        "The run records the server command, browser assertion, hydration diagnostics, and cleanup result."
+      ]
+    },
+    {
+      "id": "T7-plain-html",
+      "title": "Consume the stateful control from plain HTML",
+      "observableOutcomes": [
+        "A plain HTML page uses the stateful quantity control without a framework-specific host wrapper where the selected platform lane permits it.",
+        "The page sets typed public input, supplies default and named content, listens for the native public event, invokes focus, submits the form value, and removes the control.",
+        "If a framework cannot expose that boundary without a wrapper, the retained result records the limitation instead of substituting a different task."
+      ]
+    }
+  ],
+  "measurements": [
+    "commands",
+    "interactiveAnswers",
+    "generatedFiles",
+    "authorCreatedFiles",
+    "authorSourceLines",
+    "configurationLines",
+    "productionDependencies",
+    "developmentDependencies",
+    "publicApis",
+    "frameworkConcepts",
+    "typecheck",
+    "build",
+    "browserTest",
+    "accessibility",
+    "hmr",
+    "ssr",
+    "hydration",
+    "diagnostics",
+    "browserVisibleOutput"
+  ],
+  "comparisonDimensions": [
+    "setupCommands",
+    "configurationFiles",
+    "authoredSource",
+    "dependencies",
+    "requiredConcepts",
+    "diagnosticCoverage",
+    "cleanupEvidence",
+    "taskResult"
+  ],
+  "prohibitedAggregation": "Results are reported per task and dimension. The benchmark must not calculate a single weighted or opaque score."
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -415,6 +415,27 @@ The package has no honest GLUON GOODS customer surface. The production
 configurator and Vue host remain input/evidence fixtures, while the analyzer
 itself remains developer tooling.
 
+## Developer-experience evidence boundary
+
+The issue #107 comparison is an evidence system, not a framework runtime or an
+application dependency. Its versioned task contract and completed-run JSON
+schema live under `benchmarks/dx`; they do not enter Core, UI, Router, Store,
+SSR, Compiler, Vite, Devtools, language-server, or GLUON GOODS bundles.
+
+The contract compares one checkout customer flow through seven identical
+observable tasks in Gluon, the official `create-vue` lane, and the React Router
+framework lane selected from React's official application guidance. It retains
+raw commands, files, authored/configuration lines, dependencies, concepts,
+diagnostics, browser results, universal-rendering evidence, cleanup evidence,
+and human observations. Results remain separate per task and dimension; no
+single weighted score is an architectural input or accepted output.
+
+`npm run check:dx-scorecard` currently validates the contract and comparator-
+selection record only. A completed evidence run cannot be inferred from that
+gate: it requires 21 framework-task records, exact run versions and lockfiles,
+all automated evidence, and at least one retained human usability pass. See
+[`dx-benchmark.md`](dx-benchmark.md) for the current verified boundary.
+
 ## Verification boundaries
 
 The machine-readable [`package-contract.json`](../package-contract.json) defines

--- a/docs/dx-benchmark.md
+++ b/docs/dx-benchmark.md
@@ -1,0 +1,94 @@
+# Developer-experience benchmark
+
+Issue [#107](https://github.com/marcmalerei/gluon/issues/107) requires a
+task-level, reproducible comparison of Gluon, Vue, and React. The versioned
+contract is
+[`benchmarks/dx/specification-v1.json`](../benchmarks/dx/specification-v1.json),
+and completed evidence must conform to
+[`benchmarks/dx/schema/run-v1.schema.json`](../benchmarks/dx/schema/run-v1.schema.json).
+
+This repository does not currently contain a completed DX benchmark run. The
+only retained record selects the comparator lanes and captures the environment
+and package versions observed on 12 July 2026. It supports no win, tie, loss,
+usability, or general DX-superiority claim.
+
+## Comparator lanes
+
+- Gluon uses the maintained strict-TypeScript `create-gluon` lane from the run
+  commit.
+- Vue uses the official `create-vue` lane. The selection follows Vue's
+  [Quick Start](https://vuejs.org/guide/quick-start.html), while component work
+  follows the official
+  [Components Basics](https://vuejs.org/guide/essentials/component-basics.html)
+  Single-File Component direction.
+- React uses the React Router framework lane. React's official
+  [application-creation guide](https://react.dev/learn/creating-a-react-app)
+  recommends starting new applications with a framework and lists React Router
+  as a full-stack framework that supports SPA, SSR, and SSG operation. That lane
+  matches the retained routed SPA plus server-rendering task without adding an
+  unmeasured, author-selected routing and SSR stack. Daily component work follows
+  React's official [Learn](https://react.dev/learn) function-component and Hooks
+  direction.
+
+Exact selected versions and the command used to query them are retained in
+[`comparator-selection-2026-07-12.json`](../benchmarks/dx/evidence/comparator-selection-2026-07-12.json).
+A completed run must pin its own versions and lockfiles; it must not inherit
+"latest" from this orientation record.
+
+## Identical task outcomes
+
+Every framework implements the same seven outcomes:
+
+1. scaffold a strict TypeScript application with routing, persisted state,
+   browser testing, and a production build;
+2. add a themed accessible input and button through public contracts;
+3. create and extend an app-local primitive, repeated composition, and page
+   layout in the same checkout flow;
+4. build the same typed, validated, cleanup-owning quantity form control;
+5. navigate, persist, test the customer flow, and retain state through a
+   compatible hot update;
+6. server-render and hydrate the same product route;
+7. consume the stateful control from plain HTML without a framework wrapper
+   where the selected platform lane permits it, or retain the framework's
+   limitation as the result.
+
+The JSON specification is authoritative for the detailed observable outcomes.
+Syntax and architecture remain framework-specific because those differences are
+part of the measurement.
+
+## Evidence contract
+
+A completed run contains exactly 21 framework-task results and records:
+
+- the OS, architecture, Node, package manager, Playwright engine versions,
+  source commit, start time, and finish time;
+- exact framework, scaffold, production, and development package versions plus
+  the fixture lockfiles;
+- commands, interactive answers, stdout, stderr, exit status, and duration;
+- generated and author-created files, authored source lines, configuration
+  lines, dependencies, public APIs, and required framework concepts;
+- typecheck, build, browser, accessibility, HMR, SSR, hydration, cleanup, and
+  diagnostic evidence;
+- browser-visible output and explicit limitations;
+- at least one usability pass using the same written brief, including
+  participant count/order, discoverability and diagnostic observations, and
+  limitations.
+
+Results are compared per task and per dimension. No combined or weighted score
+is accepted. A final report must label every dimension as win, tie, or loss from
+the retained raw evidence. Every Gluon loss needs a linked scoped issue or an
+accepted non-goal.
+
+## Automation and current boundary
+
+Run `npm run check:dx-scorecard` to verify the task inventory, official source
+selection, strict run schema, raw-evidence fields, and the orientation record.
+The command is part of `npm run check`, so pull requests and `main` execute it in
+the repository quality job.
+
+That command currently reports zero completed runs. Clean-install fixtures,
+non-human measurement execution, HMR observation, the retained human pass, and
+the final comparison remain acceptance work in #107. The dependent public APIs
+are tracked by #108 through #115. The epic must remain open until those slices
+are complete, all three fixtures satisfy every task without private substitutes,
+and a complete run is retained and validated.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -97,6 +97,23 @@ counterexample. The gate rejects any authorized generated, modified, or deleted
 file. It measures fixture syntax only and proves behavioral equivalence for no
 candidate class.
 
+## Developer-experience benchmark contract gate
+
+`npm run check:dx-scorecard` validates the issue #107 comparison contract: the
+seven identical observable tasks, three selected framework lanes, 19 raw
+measurement fields, official Vue and React selection sources, strict completed-
+run schema, mandatory 21 framework-task records, and at least one human
+usability pass. The command rejects an opaque combined score and any orientation
+record that implies completed results.
+
+The command is part of `npm run check`, so the repository quality job runs it on
+every pull request and `main` push. The current retained evidence is comparator
+selection only and the validator reports zero completed runs. Clean-install
+fixtures, fresh measurement execution, HMR observation, human evidence, and the
+final per-dimension report remain required before issue #107 can close. The full
+contract and current boundary are documented in
+[`dx-benchmark.md`](dx-benchmark.md).
+
 ## Bundle budgets
 
 `quality-budgets.json` is the reviewed budget source. `npm run check:budgets`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -232,6 +232,7 @@ editing, testing, debugging, and production building.
 | [#32](https://github.com/marcmalerei/gluon/issues/32) | Versioned Devtools protocol, opt-in runtime bridge, Vite integration, and browser inspector are implemented. |
 | [#33](https://github.com/marcmalerei/gluon/issues/33) | Build `@gluonjs/test-utils`. |
 | [#34](https://github.com/marcmalerei/gluon/issues/34) | Shareable Playground, downloadable starters, and versioned searchable diagnostic reference are implemented. |
+| [#107](https://github.com/marcmalerei/gluon/issues/107) | Retain the task-level Gluon, Vue, and React DX comparison and implement the scoped UI-authoring improvements supported by its evidence. |
 
 ### Exit gate
 
@@ -244,6 +245,15 @@ editing, testing, debugging, and production building.
   performance information through a versioned protocol.
 - Consumer tests use public utilities with deterministic scheduler and cleanup control.
 - Diagnostics have stable codes, documentation, and shareable playground fixtures.
+- The DX comparison retains all seven equivalent tasks, exact framework lanes
+  and versions, raw per-dimension results, clean-install automation, and human
+  limitations; no general superiority claim is accepted without that evidence.
+
+The versioned issue #107 benchmark contract is documented in
+[`dx-benchmark.md`](dx-benchmark.md). Its current retained record selects the
+comparator lanes only and supports no task result. Issues #108 through #115 are
+the planned implementation slices; #107 remains open until those applicable
+slices and a complete comparison run are proven.
 
 ## M4 — Universal Rendering
 

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "check:vue-analyzer-fixtures": "npm run build:vue-analyzer && node scripts/generate-vue-analyzer-fixtures.mjs --check",
     "check:vue-analyzer-clean-install": "npm run build:vue-analyzer && node scripts/validate-vue-analyzer-clean-install.mjs",
     "check:vue-codemod-decision": "node scripts/validate-vue-codemod-decision.mjs",
+    "check:dx-scorecard": "node scripts/validate-dx-scorecard.mjs",
     "check:vscode-client": "node --check editors/vscode/extension.cjs",
     "check:language-server-cli": "node scripts/validate-language-server-cli.mjs",
     "check:diagnostics": "node scripts/validate-diagnostic-catalog.mjs",
@@ -163,7 +164,7 @@
     "release:verify-registry": "node scripts/verify-registry-release.mjs",
     "check:release-contract": "node scripts/validate-release-contract.mjs",
     "check:release-artifacts": "node scripts/build-release-artifacts.mjs --check-state",
-    "check": "npm run typecheck && npm run check:shop-boundaries && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run build && npm run check:quality-budgets && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:diagnostics && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:docs && npm run check:release-contract && npm run check:release-artifacts"
+    "check": "npm run typecheck && npm run check:shop-boundaries && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run build && npm run check:quality-budgets && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:diagnostics && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-contract && npm run check:release-artifacts"
   },
   "devDependencies": {
     "@cyclonedx/cdxgen": "12.7.1",

--- a/scripts/validate-dx-scorecard.mjs
+++ b/scripts/validate-dx-scorecard.mjs
@@ -1,0 +1,93 @@
+import { access, readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+const root = resolve(import.meta.dirname, '..');
+const specificationPath = resolve(root, 'benchmarks/dx/specification-v1.json');
+const schemaPath = resolve(root, 'benchmarks/dx/schema/run-v1.schema.json');
+const evidenceDirectory = resolve(root, 'benchmarks/dx/evidence');
+const specification = JSON.parse(await readFile(specificationPath, 'utf8'));
+const schema = JSON.parse(await readFile(schemaPath, 'utf8'));
+const evidenceNames = (await readdir(evidenceDirectory)).filter((name) => name.endsWith('.json')).sort();
+const ajv = new Ajv2020({ allErrors: true, strict: true });
+addFormats(ajv);
+const validateRun = ajv.compile(schema);
+
+assert(specification.schemaVersion === '1.0.0', 'specification schema version must be 1.0.0');
+assert(specification.benchmarkId === 'gluon-dx-application-authoring', 'unexpected benchmark identifier');
+assert(specification.frameworks.length === 3, 'the comparison must define exactly three frameworks');
+assertSet(specification.frameworks.map(({ id }) => id), ['gluon', 'react', 'vue'], 'frameworks');
+assert(specification.tasks.length === 7, 'the comparison must define exactly seven tasks');
+assertSet(specification.tasks.map(({ id }) => id), [
+  'T1-scaffold',
+  'T2-themed-controls',
+  'T3-local-layers',
+  'T4-stateful-control',
+  'T5-customer-flow',
+  'T6-universal-route',
+  'T7-plain-html',
+], 'task IDs');
+for (const task of specification.tasks) {
+  assert(task.observableOutcomes.length >= 3, `${task.id} must define at least three observable outcomes`);
+}
+assert(specification.measurements.length === 19, 'all 19 issue #107 measurements must remain explicit');
+assert(specification.comparisonDimensions.length >= 8, 'comparison dimensions must remain disaggregated');
+assert(specification.prohibitedAggregation.includes('must not calculate a single'), 'opaque score prohibition is missing');
+
+const sources = new Map(specification.frameworks.map(({ id, selectionSource }) => [id, new URL(selectionSource)]));
+assert(sources.get('vue').hostname === 'vuejs.org', 'Vue selection must use official vuejs.org guidance');
+assert(sources.get('react').hostname === 'react.dev', 'React selection must use official react.dev guidance');
+assert(specification.frameworks.find(({ id }) => id === 'react').selectionReason.length > 100, 'React lane selection requires a recorded rationale');
+
+assert(schema.$schema === 'https://json-schema.org/draft/2020-12/schema', 'run schema must use JSON Schema 2020-12');
+assert(schema.properties.schemaVersion.const === specification.schemaVersion, 'run and specification schema versions differ');
+assert(schema.properties.tasks.minItems === 21 && schema.properties.tasks.maxItems === 21, 'a run must retain all 21 framework-task results');
+assert(schema.properties.humanPasses.minItems === 1, 'a run must retain at least one human usability pass');
+assert(schema.$defs.task.additionalProperties === false, 'task evidence must reject undeclared fields');
+assert(schema.$defs.commandResult.required.includes('exitCode'), 'command evidence must retain exit codes');
+
+assert(evidenceNames.length > 0, 'at least one comparator-selection or completed-run record is required');
+for (const name of evidenceNames) {
+  const evidence = JSON.parse(await readFile(resolve(evidenceDirectory, name), 'utf8'));
+  assert(evidence.schemaVersion === specification.schemaVersion, `${name} uses an unsupported schema version`);
+  if (evidence.status === 'comparator-selection-only') {
+    assert(evidence.sources.length === 4, `${name} must retain the four official selection sources`);
+    for (const source of evidence.sources) {
+      const url = new URL(source.url);
+      assert(['vuejs.org', 'react.dev'].includes(url.hostname), `${name} includes a non-official comparator source`);
+    }
+    assert(evidence.limitations.some((value) => value.includes('not a completed benchmark run')), `${name} must not imply completed results`);
+    assert(evidence.limitations.some((value) => value.includes('No task result, win, tie, loss')), `${name} must prohibit unsupported comparison claims`);
+    continue;
+  }
+  assert(validateRun(evidence), `${name} does not match the completed-run schema:\n${ajv.errorsText(validateRun.errors, { separator: '\n' })}`);
+  assertSet(evidence.frameworks.map(({ id }) => id), ['gluon', 'react', 'vue'], `${name} framework runs`);
+  const expectedPairs = specification.tasks.flatMap(({ id }) =>
+    ['gluon', 'vue', 'react'].map((framework) => `${framework}:${id}`));
+  assertSet(evidence.tasks.map(({ framework, taskId }) => `${framework}:${taskId}`), expectedPairs, `${name} framework-task results`);
+  assert(!containsOpaqueScore(evidence), `${name} contains a prohibited aggregate or weighted score field`);
+}
+
+await Promise.all([
+  access(resolve(root, 'docs/dx-benchmark.md')),
+  access(resolve(root, 'docs/quality-gates.md')),
+  access(resolve(root, 'docs/roadmap.md')),
+]);
+
+console.log(`DX benchmark contract valid: ${specification.tasks.length} tasks, ${specification.measurements.length} measurements, ${evidenceNames.length} orientation record(s), 0 completed runs`);
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`DX benchmark contract: ${message}`);
+}
+
+function assertSet(actual, expected, label) {
+  assert(JSON.stringify([...actual].sort()) === JSON.stringify([...expected].sort()), `${label} do not match the accepted contract`);
+}
+
+function containsOpaqueScore(value) {
+  if (Array.isArray(value)) return value.some(containsOpaqueScore);
+  if (value === null || typeof value !== 'object') return false;
+  return Object.entries(value).some(([key, nested]) =>
+    /^(?:aggregate|combined|overall|weighted)(?:Score)?$/i.test(key) || containsOpaqueScore(nested));
+}


### PR DESCRIPTION
## Summary

- define the versioned seven-task Gluon, Vue, and React DX benchmark
- add a strict raw-run schema and official comparator-selection record
- validate the contract in the repository quality gate
- document that zero completed runs currently exist and no comparison claim is supported

## Why

Issue #107 permits the scorecard specification and baseline fixtures to start before its dependent UI slices. This PR establishes the evidence boundary those slices will populate without closing the epic or claiming completion.

## Validation

- npm run check:dx-scorecard
- npm run check:docs
- git diff --check

## Scope

Partial delivery for #107. The epic remains open until #108-#115, clean-install fixtures, all 21 framework-task results, the human usability pass, and the final per-dimension report are complete.