### PR TITLE
Add template-native functional component composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- The public `compose(component, props)\`body\`` functional-component authoring
+  path, compiler/language-tooling boundaries, retained Gluon/React/Vue
+  checkout-dialog comparison, generated starter and Playground examples, and
+  GLUON GOODS RouterLink adoption without another renderer or host.
+
 - A versioned seven-task Gluon/Vue/React developer-experience benchmark
   contract, strict raw-run evidence schema, official comparator-selection
   record, and blocking validator that reports the current zero-run boundary

--- a/benchmarks/dx/evidence/template-composition-2026-07-12.json
+++ b/benchmarks/dx/evidence/template-composition-2026-07-12.json
@@ -1,0 +1,69 @@
+{
+  "schemaVersion": "1.0.0",
+  "specification": "benchmarks/dx/specification-v1.json",
+  "recordedAt": "2026-07-12",
+  "status": "implementation-slice-only",
+  "trackingIssue": 111,
+  "applicableTask": "T3-local-layers",
+  "fixtureDirectory": "benchmarks/dx/template-composition",
+  "observables": [
+    "Checkout",
+    "Delivery",
+    "Confirm order",
+    "Email",
+    "Place order",
+    "Close"
+  ],
+  "frameworks": [
+    {
+      "id": "gluon-current",
+      "lane": "direct functional calls",
+      "fixture": "benchmarks/dx/template-composition/gluon-current.ts",
+      "nonEmptyLines": 28,
+      "tokens": 202,
+      "maximumIndentation": 4,
+      "callSiteChildrenProperties": 2
+    },
+    {
+      "id": "gluon-compose",
+      "lane": "compose(Component, props) tagged body",
+      "fixture": "benchmarks/dx/template-composition/gluon-compose.ts",
+      "nonEmptyLines": 28,
+      "tokens": 213,
+      "maximumIndentation": 4,
+      "callSiteChildrenProperties": 0
+    },
+    {
+      "id": "react",
+      "lane": "React JSX comparator selected by the parent contract",
+      "fixture": "benchmarks/dx/template-composition/react.tsx",
+      "nonEmptyLines": 29,
+      "tokens": 250,
+      "maximumIndentation": 6,
+      "callSiteChildrenProperties": 0
+    },
+    {
+      "id": "vue",
+      "lane": "Vue SFC template comparator selected by the parent contract",
+      "fixture": "benchmarks/dx/template-composition/vue.vue",
+      "nonEmptyLines": 16,
+      "tokens": 192,
+      "maximumIndentation": 6,
+      "callSiteChildrenProperties": 0
+    }
+  ],
+  "verificationCommands": [
+    "npm run check:template-composition",
+    "npm run typecheck:core-api",
+    "npm run test:browser -- --run tests/components-and-utilities.spec.ts",
+    "npm run test:ssr -- --run tests-node/ssr.spec.ts",
+    "npm run test:vite -- --run tests-node/compiler-vite.spec.ts",
+    "npm run test:language-server -- --run tests-node/language-server.spec.ts"
+  ],
+  "limitations": [
+    "This record covers the issue #111 composition implementation slice only; it is not a completed benchmark run.",
+    "It does not contain all 21 framework-task results required by benchmarks/dx/schema/run-v1.schema.json.",
+    "No human usability pass was run, so no readability, win, tie, loss, usability, or general DX-superiority claim is supported.",
+    "The React and Vue files compare the nested checkout/dialog syntax only; they are not completed parent-scorecard applications."
+  ]
+}

--- a/benchmarks/dx/template-composition/alternatives/component-blocks.ts.txt
+++ b/benchmarks/dx/template-composition/alternatives/component-blocks.ts.txt
@@ -1,0 +1,6 @@
+// Rejected compile-time block syntax, retained for the checkout/dialog comparison.
+component Shell({ heading: 'Checkout', actions, dialog }) {
+  component Panel({ title: 'Delivery', onSubmit: submit }) {
+    html`<label>Email <input name="email" type="email" required></label>`
+  }
+}

--- a/benchmarks/dx/template-composition/alternatives/interpolated-tags.ts.txt
+++ b/benchmarks/dx/template-composition/alternatives/interpolated-tags.ts.txt
@@ -1,0 +1,6 @@
+// Rejected compiler syntax, retained for the checkout/dialog comparison.
+html`<${Shell} heading="Checkout" .actions=${actions} .dialog=${dialog}>
+  <${Panel} title="Delivery" @submit=${submit}>
+    <label>Email <input name="email" type="email" required></label>
+  </${Panel}>
+</${Shell}>`;

--- a/benchmarks/dx/template-composition/evidence.json
+++ b/benchmarks/dx/template-composition/evidence.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-07-12",
+  "metrics": {
+    "gluon-current": {
+      "nonEmptyLines": 28,
+      "tokens": 202,
+      "maximumIndentation": 4,
+      "explicitChildrenProperties": 4,
+      "callSiteChildrenProperties": 2
+    },
+    "gluon-compose": {
+      "nonEmptyLines": 28,
+      "tokens": 213,
+      "maximumIndentation": 4,
+      "explicitChildrenProperties": 2,
+      "callSiteChildrenProperties": 0
+    },
+    "react": {
+      "nonEmptyLines": 29,
+      "tokens": 250,
+      "maximumIndentation": 6,
+      "explicitChildrenProperties": 2,
+      "callSiteChildrenProperties": 0
+    },
+    "vue": {
+      "nonEmptyLines": 16,
+      "tokens": 192,
+      "maximumIndentation": 6,
+      "explicitChildrenProperties": 0,
+      "callSiteChildrenProperties": 0
+    }
+  }
+}

--- a/benchmarks/dx/template-composition/gluon-compose.ts
+++ b/benchmarks/dx/template-composition/gluon-compose.ts
@@ -1,0 +1,33 @@
+import { compose, html, type TemplateResult } from '@gluonjs/core';
+
+interface ShellProps {
+  readonly heading: string;
+  readonly actions: TemplateResult;
+  readonly dialog: TemplateResult;
+  readonly children: TemplateResult;
+}
+
+interface PanelProps {
+  readonly title: string;
+  readonly onSubmit: (event: Event) => void;
+  readonly children: TemplateResult;
+}
+
+function Shell({ heading, actions, dialog, children }: ShellProps): TemplateResult {
+  return html`<main><h1>${heading}</h1>${children}${actions}${dialog}</main>`;
+}
+
+function Panel({ title, onSubmit, children }: PanelProps): TemplateResult {
+  return html`<form id="checkout" @submit=${onSubmit}><h2>${title}</h2>${children}</form>`;
+}
+
+export const checkout = compose(Shell, {
+  heading: 'Checkout',
+  actions: html`<button form="checkout">Place order</button>`,
+  dialog: html`<dialog open aria-labelledby="confirm-title"><h2 id="confirm-title">Confirm order</h2><button>Close</button></dialog>`,
+})`
+  ${compose(Panel, {
+    title: 'Delivery',
+    onSubmit: (event) => event.preventDefault(),
+  })`<label>Email <input name="email" type="email" required></label>`}
+`;

--- a/benchmarks/dx/template-composition/gluon-current.ts
+++ b/benchmarks/dx/template-composition/gluon-current.ts
@@ -1,0 +1,33 @@
+import { html, type TemplateResult } from '@gluonjs/core';
+
+interface ShellProps {
+  readonly heading: string;
+  readonly actions: TemplateResult;
+  readonly dialog: TemplateResult;
+  readonly children: TemplateResult;
+}
+
+interface PanelProps {
+  readonly title: string;
+  readonly onSubmit: (event: Event) => void;
+  readonly children: TemplateResult;
+}
+
+function Shell({ heading, actions, dialog, children }: ShellProps): TemplateResult {
+  return html`<main><h1>${heading}</h1>${children}${actions}${dialog}</main>`;
+}
+
+function Panel({ title, onSubmit, children }: PanelProps): TemplateResult {
+  return html`<form id="checkout" @submit=${onSubmit}><h2>${title}</h2>${children}</form>`;
+}
+
+export const checkout = Shell({
+  heading: 'Checkout',
+  actions: html`<button form="checkout">Place order</button>`,
+  dialog: html`<dialog open aria-labelledby="confirm-title"><h2 id="confirm-title">Confirm order</h2><button>Close</button></dialog>`,
+  children: Panel({
+    title: 'Delivery',
+    onSubmit: (event) => event.preventDefault(),
+    children: html`<label>Email <input name="email" type="email" required></label>`,
+  }),
+});

--- a/benchmarks/dx/template-composition/react.tsx
+++ b/benchmarks/dx/template-composition/react.tsx
@@ -1,0 +1,34 @@
+import type { FormEvent, ReactNode } from 'react';
+
+interface ShellProps {
+  readonly heading: string;
+  readonly actions: ReactNode;
+  readonly dialog: ReactNode;
+  readonly children: ReactNode;
+}
+
+interface PanelProps {
+  readonly title: string;
+  readonly onSubmit: (event: FormEvent) => void;
+  readonly children: ReactNode;
+}
+
+function Shell({ heading, actions, dialog, children }: ShellProps) {
+  return <main><h1>{heading}</h1>{children}{actions}{dialog}</main>;
+}
+
+function Panel({ title, onSubmit, children }: PanelProps) {
+  return <form id="checkout" onSubmit={onSubmit}><h2>{title}</h2>{children}</form>;
+}
+
+export const checkout = (
+  <Shell
+    heading="Checkout"
+    actions={<button form="checkout">Place order</button>}
+    dialog={<dialog open aria-labelledby="confirm-title"><h2 id="confirm-title">Confirm order</h2><button>Close</button></dialog>}
+  >
+    <Panel title="Delivery" onSubmit={(event) => event.preventDefault()}>
+      <label>Email <input name="email" type="email" required /></label>
+    </Panel>
+  </Shell>
+);

--- a/benchmarks/dx/template-composition/tsconfig.json
+++ b/benchmarks/dx/template-composition/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["react"]
+  },
+  "include": ["gluon-current.ts", "gluon-compose.ts", "react.tsx"]
+}

--- a/benchmarks/dx/template-composition/tsconfig.vue.json
+++ b/benchmarks/dx/template-composition/tsconfig.vue.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.vue"]
+}

--- a/benchmarks/dx/template-composition/vue-checkout-shell.vue
+++ b/benchmarks/dx/template-composition/vue-checkout-shell.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+defineProps<{ heading: string }>();
+defineSlots<{ default(): unknown; actions(): unknown; dialog(): unknown }>();
+</script>
+
+<template><main><h1>{{ heading }}</h1><slot /><slot name="actions" /><slot name="dialog" /></main></template>

--- a/benchmarks/dx/template-composition/vue-delivery-panel.vue
+++ b/benchmarks/dx/template-composition/vue-delivery-panel.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ title: string }>();
+defineEmits<{ submit: [event: Event] }>();
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template><form id="checkout" @submit="$emit('submit', $event)"><h2>{{ title }}</h2><slot /></form></template>

--- a/benchmarks/dx/template-composition/vue.vue
+++ b/benchmarks/dx/template-composition/vue.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import CheckoutShell from './vue-checkout-shell.vue';
+import DeliveryPanel from './vue-delivery-panel.vue';
+
+function submit(event: Event): void {
+  event.preventDefault();
+}
+</script>
+
+<template>
+  <CheckoutShell heading="Checkout">
+    <template #actions><button form="checkout">Place order</button></template>
+    <template #dialog><dialog open aria-labelledby="confirm-title"><h2 id="confirm-title">Confirm order</h2><button>Close</button></dialog></template>
+    <DeliveryPanel title="Delivery" @submit="submit">
+      <label>Email <input name="email" type="email" required></label>
+    </DeliveryPanel>
+  </CheckoutShell>
+</template>

--- a/docs-site/api-examples.json
+++ b/docs-site/api-examples.json
@@ -1541,12 +1541,15 @@
       "module": "@gluonjs/core",
       "code": [
         "import {",
+        "  compose,",
         "  defineAtom,",
         "  html,",
         "  mergeProps,",
         "  renderScopedSlot,",
         "  type ClassValue,",
+        "  type ComponentTemplateTag,",
         "  type ComponentLayer,",
+        "  type CompositionProps,",
         "  type FunctionalComponent,",
         "  type MergeableProps,",
         "  type ScopedSlot,",
@@ -1561,8 +1564,13 @@
         "const layer: ComponentLayer = 'atom';",
         "const ProductActions: FunctionalComponent<{ productId: string }> = ({ productId }) =>",
         "  html`<div ...=${props}>${renderScopedSlot(actions, { productId })}</div>`;",
+        "interface PanelProps { title: string; children: import('@gluonjs/core').TemplateValue }",
+        "const Panel: FunctionalComponent<PanelProps> = ({ title, children }) => html`<section><h2>${title}</h2>${children}</section>`;",
+        "const panelProps: CompositionProps<PanelProps> = { title: 'Checkout' };",
+        "const panel: ComponentTemplateTag = compose(Panel, panelProps);",
+        "const checkout = panel`<p>Delivery</p>`;",
         "const Actions = defineAtom((props: { productId: string }) => html`${ProductActions(props)}`, 'ProductActions');",
-        "console.log(layer, Actions.layer, Actions({ productId: 'orbit-lamp' }));"
+        "console.log(layer, checkout, Actions.layer, Actions({ productId: 'orbit-lamp' }));"
       ]
     },
     "core-model-binding": {
@@ -2246,6 +2254,10 @@
     "src/type-aliases/ComponentLayer.md": {
       "recipe": "core-component-props",
       "description": "Identify whether a layered UI component is an Atom, Molecule, or Organism:"
+    },
+    "src/type-aliases/CompositionProps.md": {
+      "recipe": "core-component-props",
+      "description": "Derive the typed prop object supplied before a compose template body becomes the component's children:"
     },
     "src/type-aliases/ComponentLifecycleCallback.md": {
       "recipe": "core-element-contract",
@@ -3900,6 +3912,10 @@
       "recipe": "core-application",
       "description": "Create one application owner for providers, plugins, error handling, public API exposure, mounting, and deterministic unmounting:"
     },
+    "src/functions/compose.md": {
+      "recipe": "core-component-props",
+      "description": "Pass a native HTML template body as typed children to one ordinary functional-component call without adding a host or renderer:"
+    },
     "src/functions/defineAtom.md": {
       "recipe": "core-component-layers",
       "description": "Label a small reusable rendering function as an Atom while preserving its exact typed props:"
@@ -3979,6 +3995,10 @@
     "src/interfaces/Component.md": {
       "recipe": "core-component-layers",
       "description": "Call a typed functional component while retaining its architectural layer and stable display name for tooling:"
+    },
+    "src/interfaces/ComponentTemplateTag.md": {
+      "recipe": "core-component-props",
+      "description": "Retain the standard tagged-template call signature returned by compose for typed functional children:"
     },
     "src/interfaces/ComponentErrorInfo.md": {
       "recipe": "core-element-contract",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,10 +147,17 @@ The package's black-box and ownership rules are documented in its
 ## Vite transform and HMR boundary
 
 `@gluonjs/compiler` parses application TypeScript or JavaScript and records the
-original `html`/`css` template boundaries and expression offsets. Its
+original `html`/`css` template boundaries, `compose()` template bodies, and
+expression offsets. Its
 high-resolution map remains chained through Vite, so a generated runtime
 location resolves to the author module and expression. The compiler does not
 replace Gluon's public runtime template format.
+
+`compose(component, props)\`body\`` is a Core helper, not a second renderer.
+It builds `body` with `html` and calls the supplied function once with that
+result as `children`. Functional ownership, DOM identity, SSR/hydration,
+Devtools, test utilities, and HMR therefore observe the same result as a direct
+call. RFC 0004 fixes this boundary.
 
 `@gluonjs/vite` transforms application modules inside the resolved Vite root.
 Development transforms route exported functions, Store definitions,

--- a/docs/component-contracts.md
+++ b/docs/component-contracts.md
@@ -6,6 +6,28 @@ native `CustomEvent` instances, projected content uses native slots, and refs
 resolve to real DOM or Custom Element hosts. Functional components remain typed
 functions without a second instance or lifecycle model.
 
+## Template-native functional composition
+
+`compose(component, props)\`body\`` is the optional nested authoring path for a
+functional component whose props accept `children`. It invokes the same
+function directly and passes an ordinary `html` result as `children`:
+
+```ts
+compose(AppShell, { header, navigation })`
+  ${compose(Card, { title: 'Delivery', actions })`
+    <label>Email <input name="email" type="email" required></label>
+  `}
+`;
+```
+
+TypeScript checks required, optional, callback, and excess props at the
+`compose()` call. Named or scoped content remains a typed prop. The HTML body
+may use native elements, bindings, spreads, models, refs, conditionals,
+`repeat()`, or `Suspense()` exactly as any `html` template. Direct calls remain
+supported. The accepted contract and measured limitations are in
+[RFC 0004](rfcs/0004-template-native-functional-composition.md) and the
+[comparison evidence](template-composition-evidence.md).
+
 ## Typed properties
 
 Use `PropertyDeclarations<Props>` to check a component's declaration against its

--- a/docs/dx-benchmark.md
+++ b/docs/dx-benchmark.md
@@ -7,10 +7,12 @@ contract is
 and completed evidence must conform to
 [`benchmarks/dx/schema/run-v1.schema.json`](../benchmarks/dx/schema/run-v1.schema.json).
 
-This repository does not currently contain a completed DX benchmark run. The
-only retained record selects the comparator lanes and captures the environment
-and package versions observed on 12 July 2026. It supports no win, tie, loss,
-usability, or general DX-superiority claim.
+This repository does not currently contain a completed DX benchmark run. One
+retained record selects the comparator lanes and captures the environment and
+package versions observed on 12 July 2026. A second, explicitly partial record
+captures issue #111's nested checkout/dialog syntax measurements for the
+T3-local-layers implementation slice. Neither supports a win, tie, loss,
+usability, readability, or general DX-superiority claim.
 
 ## Comparator lanes
 
@@ -92,3 +94,9 @@ the final comparison remain acceptance work in #107. The dependent public APIs
 are tracked by #108 through #115. The epic must remain open until those slices
 are complete, all three fixtures satisfy every task without private substitutes,
 and a complete run is retained and validated.
+
+Issue #111's partial fixture and raw metrics live under
+`benchmarks/dx/template-composition`; its canonical slice record is
+`benchmarks/dx/evidence/template-composition-2026-07-12.json`. It deliberately
+does not satisfy the completed-run schema, invent the other 20 framework-task
+results, or claim the required human pass.

--- a/docs/language-tooling.md
+++ b/docs/language-tooling.md
@@ -2,8 +2,8 @@
 
 `@gluonjs/language-server` is the shared template-analysis boundary for editor
 and CI workflows. It parses TypeScript or JavaScript source without executing
-it, recognizes imported aliases of Gluon's public `html`, `svg`, and `css`
-tags, and performs a two-pass project analysis so Custom Element declarations
+it, recognizes imported aliases of Gluon's public `html`, `svg`, `css`, and
+`compose` tags, and performs a two-pass project analysis so Custom Element declarations
 are available across files.
 
 ## Commands
@@ -34,6 +34,13 @@ the same facts through `CustomElementDeclaration` values or convert standard
 Custom Elements Manifest data with `declarationsFromCustomElementsManifest()`.
 Definitions and
 renames link the tag string and every open template occurrence.
+
+Inside `compose(Component, props)\`body\``, Gluon supplies the same native HTML
+diagnostics, completion, hover, semantic tokens, and source ranges as `html`.
+The built-in TypeScript service owns the component identifier, props and
+callbacks, completion, hover, definition, rename, and outer TypeScript
+formatting. The Gluon server preserves body whitespace and does not create a
+virtual proprietary document.
 
 ## Diagnostic contract
 

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -37,6 +37,16 @@ accessibility responsibilities are separated in
 [`accessibility.md`](accessibility.md), and deterministic retention evidence is
 defined in [`memory-retention.md`](memory-retention.md).
 
+## Template composition gate
+
+`npm run check:template-composition` verifies the retained Gluon current-call,
+Gluon `compose()`, React JSX, and Vue template checkout/dialog fixtures. It
+checks observable parity, committed tokens/lines/indentation/children counts,
+TypeScript and vue-tsc validity, Vue SFC parsing, compiler recognition, and
+unchanged source-map content. The canonical `implementation-slice-only` record
+uses the parent DX evidence format, reports zero human participants, and makes
+no completed-run or general readability claim.
+
 ## Generated API example gate
 
 `npm run docs:api` generates TypeDoc Markdown for every public package entry

--- a/docs/rfcs/0004-template-native-functional-composition.md
+++ b/docs/rfcs/0004-template-native-functional-composition.md
@@ -1,0 +1,93 @@
+# RFC 0004: Template-native functional-component composition
+
+- **Status:** Accepted
+- **Decision date:** 2026-07-12
+- **Tracking issue:** [#111](https://github.com/marcmalerei/gluon/issues/111)
+- **Parent:** [#107](https://github.com/marcmalerei/gluon/issues/107)
+- **Depends on:** [RFC 0002](0002-unified-component-model.md)
+- **Supersedes:** Nothing
+
+## Decision
+
+Gluon adds one optional public authoring helper:
+
+```ts
+compose(AppShell, { header, navigation })`
+  ${compose(Card, { title: 'Delivery', actions })`
+    <label>Email <input name="email" type="email" required></label>
+  `}
+`;
+```
+
+`compose(component, props)` returns a standard JavaScript tagged-template
+function. The body is created with the existing public `html()` API and passed
+to `component({ ...props, children: body })`. This is exactly one ordinary
+functional-component call. The helper creates no component instance, host,
+lifecycle, context, event system, renderer, file format, or serialization
+format. Components remain importable functions and direct calls remain valid.
+
+`CompositionProps<Props>` removes only `children` from the supplied object.
+Required and optional props, callback parameter types, excess properties, and
+whether the component accepts `TemplateValue` children are therefore checked by
+TypeScript at the `compose()` call. Named content and scoped content remain
+typed props. The body is an ordinary `html` template, so native elements,
+callbacks, spreads, `model()`, refs, conditionals, `repeat()`, and `Suspense()`
+retain their existing contracts.
+
+## Compared alternatives
+
+The retained checkout and confirmation-dialog fixtures live under
+`benchmarks/dx/template-composition`. Each contains the observables Checkout,
+Delivery, Confirm order, Email, Place order, and Close.
+
+| Alternative | Example boundary | Decision |
+| --- | --- | --- |
+| Current calls | `Shell({ ..., children: Panel({ ..., children: html\`…\` }) })` | Retained and supported; repeated object properties obscure the visual body boundary. |
+| Tagged component body | `compose(Shell, props)\`${compose(Panel, props)\`…\`}\`` | Accepted. It is valid TypeScript, uses the existing HTML template direction, and preserves stock TypeScript expression tooling. |
+| Interpolated component tags | `html\`<${Shell}>…</${Shell}>\`` | Rejected. TypeScript cannot assign tag attributes to a component props type without a virtual-language transform, and the HTML parser cannot own this syntax directly. |
+| `component` blocks | `component Shell(props) { component Panel(props) { html\`…\` } }` | Rejected. This adds proprietary JavaScript grammar and requires a separate parser/formatter boundary. |
+
+The two rejected versions are retained in `alternatives/` against the same
+checkout/dialog content. JSX-only and Vue SFC-only designs remain non-goals.
+
+## Compiler and editor contract
+
+The compiler recognizes aliased `compose()` tags as template boundaries. It
+records the original body and interpolation locations, runs the existing inline
+style diagnostic, and emits the source unchanged in production. Its
+high-resolution source map continues to name the author file and content.
+This is a versioned additive Core API amendment, not a renderer amendment.
+
+The Gluon language server recognizes the same aliased boundary for native-tag
+diagnostics, completion, hover, semantic tokens, and source locations.
+TypeScript remains authoritative for the component symbol, props, callback
+types, completion, hover, definition, and rename; the maintained VS Code client
+runs beside the built-in TypeScript language service. Because the source is a
+`.ts`/`.js` template literal, the TypeScript formatter owns the outer call and
+literal boundary; Gluon preserves body whitespace and does not rewrite it.
+
+## Runtime compatibility
+
+The result of `compose()` is the direct component result, so CSR, SSR,
+streaming, hydration, static generation, Devtools, and test utilities receive
+the same public `TemplateValue` and observable DOM/component tree as direct
+calls. HMR sees the same imported/exported function identities. Compatible
+function/template edits retain the existing owner state. The existing reload
+boundary still applies to incompatible Custom Element tag, superclass, form
+association, initialization, schema, or stylesheet-count changes.
+
+## Evidence and limitations
+
+`npm run check:template-composition` typechecks the Gluon and React fixtures,
+runs `vue-tsc` over the Vue fixtures, parses the Vue SFC, verifies fixture
+observable parity, checks committed line/token/indentation/children metrics,
+and proves compiler/source-map recognition. Core type tests retain missing,
+invalid, callback, content, and excess-prop failures at the call site. Browser,
+SSR, Vite/compiler, language-server, generated-starter, Playground, shop, and
+full quality suites cover their respective boundaries.
+
+No human participant tested these fixtures during this issue. Participant
+count is therefore zero and there are no human usability findings. The metric
+report makes no general readability or DX-superiority claim. It proves the
+narrow result that the accepted fixture removes both call-site `children:`
+properties while keeping the surrounding TypeScript/HTML contracts.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -9,6 +9,7 @@ accepted RFC without a superseding RFC.
 | [0001](0001-gluon-1.0-product-scope.md) | Accepted | Gluon 1.0 product scope and non-goals |
 | [0002](0002-unified-component-model.md) | Accepted | Unified component and Custom Element model |
 | [0003](0003-report-only-vue-migration-analyzer.md) | Accepted | Bounded, static, report-only Vue migration analysis |
+| [0004](0004-template-native-functional-composition.md) | Accepted | Template-native functional-component composition through `compose()` |
 
 ## Process
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -233,6 +233,7 @@ editing, testing, debugging, and production building.
 | [#33](https://github.com/marcmalerei/gluon/issues/33) | Build `@gluonjs/test-utils`. |
 | [#34](https://github.com/marcmalerei/gluon/issues/34) | Shareable Playground, downloadable starters, and versioned searchable diagnostic reference are implemented. |
 | [#107](https://github.com/marcmalerei/gluon/issues/107) | Retain the task-level Gluon, Vue, and React DX comparison and implement the scoped UI-authoring improvements supported by its evidence. |
+| [#111](https://github.com/marcmalerei/gluon/issues/111) | Add `compose(Component, props)\`body\`` as the template-native functional composition path with compiler, editor, universal-rendering, generator, Playground, and GLUON GOODS evidence. |
 
 ### Exit gate
 
@@ -250,8 +251,9 @@ editing, testing, debugging, and production building.
   limitations; no general superiority claim is accepted without that evidence.
 
 The versioned issue #107 benchmark contract is documented in
-[`dx-benchmark.md`](dx-benchmark.md). Its current retained record selects the
-comparator lanes only and supports no task result. Issues #108 through #115 are
+[`dx-benchmark.md`](dx-benchmark.md). Its retained records select the comparator
+lanes and preserve the explicitly partial #111 syntax slice; neither is a
+completed 21-result run. Issues #108 through #115 are
 the planned implementation slices; #107 remains open until those applicable
 slices and a complete comparison run are proven.
 

--- a/docs/template-composition-evidence.md
+++ b/docs/template-composition-evidence.md
@@ -1,0 +1,66 @@
+# Template composition comparison evidence
+
+Captured 2026-07-12 on Node 22.22.0, npm 10.9.4, TypeScript 5.7.x,
+React 19.2.7 with `@types/react` 19.2.17, Vue 3.5.39, and vue-tsc 3.3.7.
+The selected React comparator follows the official React JSX and props/children
+guides; the Vue comparator follows the official component and slot guides:
+
+- <https://react.dev/learn/writing-markup-with-jsx>
+- <https://react.dev/learn/passing-props-to-a-component>
+- <https://vuejs.org/guide/essentials/component-basics.html>
+- <https://vuejs.org/guide/components/slots.html>
+
+## Retained measurements
+
+`evidence.json` is the machine-reviewed source. A token is one TypeScript
+scanner token for `.ts`/`.tsx`, or one identifier, number, or non-whitespace
+punctuation token for the SFC. Lines exclude blank lines. Maximum indentation
+is the largest leading-space count. Call-site children count includes only
+object-literal `children` property assignments.
+
+| Fixture | Non-empty lines | Tokens | Max indentation | Call-site `children:` |
+| --- | ---: | ---: | ---: | ---: |
+| Gluon current calls | 28 | 202 | 4 | 2 |
+| Gluon `compose()` | 28 | 213 | 4 | 0 |
+| React JSX | 29 | 250 | 6 | 0 |
+| Vue template | 16 | 192 | 6 | 0 |
+
+The chosen Gluon fixture removes two call-site `children:` properties. It has
+the same line count, eleven more scanner tokens, and the same measured maximum
+indentation as the current Gluon fixture. These measurements do not prove that
+one syntax is more readable.
+
+## Diagnostics and edit task
+
+The retained type fixture checks missing `title`, an invalid callback, an
+unknown prop, and body content passed to a component without a children prop.
+`tsc` consumes each `@ts-expect-error`; an unused directive would fail the gate.
+The language-server fixture checks native ARIA and void-element mistakes at the
+original line inside `compose()`. Compiler tests map an expression back to the
+original author file. React and Vue comparator sources are valid under their
+retained typecheck commands; this slice makes no cross-framework diagnostic
+quality ranking.
+
+The common edit task is to insert a phone input after the retained email input.
+In every fixture the insertion point is the visible nested body; no component
+definition, runtime registration, or build configuration changes. The Gluon
+path adds the line inside the `compose()` body without adding `children:`.
+
+## User-test finding
+
+No human usability pass was run for issue #111 (zero participants). There is no
+discoverability or preference result and no readability claim. Parent issue
+#107 still owns the required retained human pass before any general DX
+superiority conclusion.
+
+## Reproduction
+
+```sh
+npm ci
+npm run check:template-composition
+npm run typecheck:core-api
+npm run test:browser -- --run tests/components-and-utilities.spec.ts
+npm run test:ssr -- --run tests-node/ssr.spec.ts
+npm run test:vite -- --run tests-node/compiler-vite.spec.ts
+npm run test:language-server -- --run tests-node/language-server.spec.ts
+```

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -21,6 +21,9 @@ both files into a URL-safe `#p=` payload, so reload and copying retain the exact
 reproduction. Download creates an uncompressed, runnable Vite project with an
 HTML entry, typed Gluon mount, constructable stylesheet adoption, TypeScript
 configuration, aligned `0.0.0` Gluon dependencies, and the template checker.
+The default project also exercises `compose(Component, props)\`body\`` so the
+browser analyzer and downloaded project retain template-native functional
+composition at original TypeScript locations.
 
 The GitHub Pages job starts from `npm ci --ignore-scripts`, builds Core (including
 Reactivity), Compiler, and Vite in dependency order, and then builds the

--- a/examples/playground/src/project.ts
+++ b/examples/playground/src/project.ts
@@ -4,15 +4,28 @@ export interface PlaygroundProject {
 }
 
 export const defaultProject: PlaygroundProject = Object.freeze({
-  app: `import { html } from '@gluonjs/core';
+  app: `import { compose, html, type TemplateValue } from '@gluonjs/core';
 
-export function Counter(count: number, increment: () => void) {
+interface CounterFrameProps {
+  readonly count: number;
+  readonly increment: () => void;
+  readonly children?: TemplateValue;
+}
+
+function CounterFrame({ count, increment, children }: CounterFrameProps) {
   return html\`
     <div class="counter-card">
       <h1>Count \${count}</h1>
       <button @click=\${increment} type="button" aria-tap="Increment counter">Increment</button>
+      \${children}
       <img>Preview</img>
     </div>
+  \`;
+}
+
+export function Counter(count: number, increment: () => void) {
+  return compose(CounterFrame, { count, increment })\`
+  <p>Template-native functional composition</p>
   \`;
 }
 `,

--- a/examples/quick-start.ts
+++ b/examples/quick-start.ts
@@ -1,5 +1,6 @@
 import {
   adoptStyles,
+  compose,
   foundationStyles,
   layerOrderStyles,
   render,
@@ -18,18 +19,15 @@ adoptStyles(
   organismStyles,
 );
 
-render(AppShell({
+render(compose(AppShell, {
   header: q.h1({ children: 'Gluon' }),
   navigation: q.a({ href: '#welcome', children: 'Welcome' }),
-  children: Card({
+})`
+  ${compose(Card, {
     title: 'Native interface layers',
-    children: q.p({
-      id: 'welcome',
-      children: 'Quarks compose into Atoms, Molecules, and Organisms.',
-    }),
     actions: Button({
       label: 'Continue',
       onClick: () => console.log('Continue'),
     }),
-  }),
-}), document.body);
+  })`<p id="welcome">Quarks compose into Atoms, Molecules, and Organisms.</p>`}
+`, document.body);

--- a/examples/shop/FEATURES.md
+++ b/examples/shop/FEATURES.md
@@ -4,6 +4,7 @@
 | --- | --- | --- | --- |
 | Application runtime and plugin context | Isolated shop mount and Router plugin | `tests/shop-example.spec.ts` | Integrated |
 | HTML templates and attribute spreading | Every page and reusable control | Core renderer suite + shop browser test | Integrated |
+| Core `compose()` template-native functional composition | Wordmark, desktop/mobile navigation, product cards, category discovery, bag actions, and home call-to-action use typed `RouterLink` props with native HTML bodies | Core type/browser + compiler/Vite + language-server + SSR + `tests/shop-example.spec.ts` + retained DX comparison | Integrated into existing customer flows |
 | Core `render()` single-node insertion and single-pass binding instantiation | Dynamic product, bag, delivery, and order templates throughout the existing customer journey | Direct-vs-fragment and parser-reordered traversal regressions + retained rendering comparison + shop performance budgets | Integrated renderer optimization |
 | Standalone reactivity | Bag, configuration, search, and navigation UI state | `tests/shop-example.spec.ts` | Integrated |
 | Router histories and links | Home, catalog, product deep links, active navigation | Router suite + shop browser test | Integrated |

--- a/examples/shop/README.md
+++ b/examples/shop/README.md
@@ -7,6 +7,12 @@ repository [working agreement](../../AGENTS.md).
 
 ## Current slice
 
+Customer-facing links with nested or text content use the public
+`compose(RouterLink, props)\`body\`` path. It passes the body as typed children
+to the same RouterLink function; direct functional calls remain supported.
+Compiler, SSR, and shop tests verify that this adds no host or renderer
+boundary.
+
 The current slice uses the public Core, Reactivity, Router, and Store APIs to provide:
 
 - home, catalog, and deep-linkable product routes

--- a/examples/shop/src/components.ts
+++ b/examples/shop/src/components.ts
@@ -2,6 +2,7 @@ import {
   Teleport,
   Transition,
   TransitionGroup,
+  compose,
   html,
   nothing,
   repeat,
@@ -33,14 +34,13 @@ const dialogFocusScopes = new Map<ShopDialog, FocusScope>();
 export function SiteHeader(store: ShopStore): TemplateValue {
   return html`
     <header class="site-header">
-      ${RouterLink({
+      ${compose(RouterLink, {
         to: '/',
-        children: 'GLUON GOODS',
         attributes: { class: 'wordmark', 'aria-label': 'GLUON GOODS home' },
-      })}
+      })`GLUON GOODS`}
       <nav class="desktop-nav" aria-label="Primary navigation">
-        ${RouterLink({ to: '/shop', children: 'Shop' })}
-        ${RouterLink({ to: '/shop?sort=new', children: 'New' })}
+        ${compose(RouterLink, { to: '/shop' })`Shop`}
+        ${compose(RouterLink, { to: '/shop?sort=new' })`New`}
         <a href="#journal">Journal</a>
       </nav>
       <div class="header-actions">
@@ -86,27 +86,25 @@ export function ProductRail(items: readonly Product[] = products): TemplateValue
 }
 
 export function ProductCard(product: Product): TemplateValue {
-  return RouterLink({
+  return compose(RouterLink, {
     to: `/products/${product.slug}`,
     attributes: { class: 'product-card', 'aria-label': `${product.name}, ${formatPrice(product.price)}` },
-    children: html`
+  })`
       <span class="product-media"><img src=${product.image} alt=${product.alt}></span>
       <span class="product-copy">
         <span><strong>${product.name}</strong><small>${formatPrice(product.price)}</small></span>
         <span class="product-arrow">${ArrowIcon()}</span>
       </span>
-    `,
-  });
+  `;
 }
 
 export function CategoryLinks(): TemplateValue {
   return html`
     <nav class="category-links" aria-label="Shop by category">
-      ${repeat(categories, (category) => category, (category) => RouterLink({
+      ${repeat(categories, (category) => category, (category) => compose(RouterLink, {
         to: `/shop?category=${encodeURIComponent(category)}`,
         attributes: { class: 'category-link' },
-        children: html`<span>${category}</span>${ArrowIcon()}`,
-      }))}
+      })`<span>${category}</span>${ArrowIcon()}`)}
     </nav>
   `;
 }
@@ -138,11 +136,10 @@ function BagDrawer(store: ShopStore): TemplateValue {
         ${store.bag.length === 0 ? html`
           <div class="empty-bag">
             <p>Your bag is ready for something useful.</p>
-            ${RouterLink({
+            ${compose(RouterLink, {
               to: '/shop',
-              children: 'Shop all objects',
               attributes: { class: 'inline-link' },
-            })}
+            })`Shop all objects`}
           </div>
         ` : html`
           <div class="bag-lines">
@@ -179,7 +176,7 @@ function BagDrawer(store: ShopStore): TemplateValue {
           <footer class="bag-summary">
             <div><span>Subtotal</span><strong>${formatPrice(store.bagTotal)}</strong></div>
             <p>Shipping calculated at checkout.</p>
-            ${RouterLink({ to: '/checkout', children: 'Checkout', attributes: { class: 'primary-button' } })}
+            ${compose(RouterLink, { to: '/checkout', attributes: { class: 'primary-button' } })`Checkout`}
           </footer>
         `}
       </aside>
@@ -192,9 +189,9 @@ export function SiteFooter(): TemplateValue {
     <footer class="site-footer" id="journal">
       <strong>GLUON GOODS</strong>
       <nav aria-label="Footer navigation">
-        ${RouterLink({ to: '/shipping', children: 'Shipping' })}
-        ${RouterLink({ to: '/returns', children: 'Returns' })}
-        ${RouterLink({ to: '/#materials', children: 'Materials' })}
+        ${compose(RouterLink, { to: '/shipping' })`Shipping`}
+        ${compose(RouterLink, { to: '/returns' })`Returns`}
+        ${compose(RouterLink, { to: '/#materials' })`Materials`}
         <a href="mailto:hello@example.com">Contact</a>
       </nav>
     </footer>
@@ -255,8 +252,8 @@ function MobileMenu(store: ShopStore): TemplateValue {
             const returnTarget = document.querySelector<HTMLElement>('.mobile-menu-button');
             if (returnTarget) focusOpenedDialog('search', returnTarget);
           }}><span>Search</span>${SearchIcon()}</button>
-          ${RouterLink({ to: '/shop', children: html`<span>Shop</span>${ArrowIcon()}` })}
-          ${RouterLink({ to: '/shop?sort=new', children: html`<span>New</span>${ArrowIcon()}` })}
+          ${compose(RouterLink, { to: '/shop' })`<span>Shop</span>${ArrowIcon()}`}
+          ${compose(RouterLink, { to: '/shop?sort=new' })`<span>New</span>${ArrowIcon()}`}
           <a href="#journal" @click=${close}><span>Journal</span>${ArrowIcon()}</a>
         </nav>
         <div class="menu-categories">${CategoryLinks()}</div>

--- a/examples/shop/src/pages.ts
+++ b/examples/shop/src/pages.ts
@@ -1,4 +1,4 @@
-import { html, repeat, type TemplateValue } from '@gluonjs/core';
+import { compose, html, repeat, type TemplateValue } from '@gluonjs/core';
 import { RouterLink, useRoute, useRouter } from '@gluonjs/router';
 import {
   categories,
@@ -27,11 +27,10 @@ export function HomePage(_store: ShopStore): TemplateValue {
       <div class="hero-copy">
         <h1>Objects that work the way you do.</h1>
         <p>Modular essentials, made for changing spaces.</p>
-        ${RouterLink({
+        ${compose(RouterLink, {
           to: '/shop',
           attributes: { class: 'primary-button' },
-          children: html`<span>Shop the collection</span>${ArrowIcon()}`,
-        })}
+        })`<span>Shop the collection</span>${ArrowIcon()}`}
       </div>
       <div class="hero-media">
         <img src=${heroImage} alt="Orbit Lamp and cobalt Stack Tray on a sunlit workspace">

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@cyclonedx/cdxgen": "12.7.1",
         "@jridgewell/trace-mapping": "^0.3.31",
         "@types/node": "^22.10.0",
+        "@types/react": "19.2.17",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitest/browser-playwright": "^4.0.18",
         "@vitest/coverage-v8": "^4.1.10",
@@ -29,12 +30,14 @@
         "lit-html": "3.3.3",
         "markdown-it": "^14.3.0",
         "playwright": "^1.58.2",
+        "react": "19.2.7",
         "typedoc": "^0.28.20",
         "typedoc-plugin-markdown": "^4.12.0",
         "typescript": "^5.7.0",
         "vite": "^8.1.4",
         "vitest": "^4.0.18",
-        "vue": "3.5.39"
+        "vue": "3.5.39",
+        "vue-tsc": "3.3.7"
       },
       "engines": {
         "node": "^22.12.0 || ^24.0.0"
@@ -1273,6 +1276,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -1522,6 +1535,35 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
@@ -1582,6 +1624,22 @@
       "dependencies": {
         "@vue/compiler-dom": "3.5.39",
         "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
+      "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@vue/reactivity": {
@@ -1672,6 +1730,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -3396,6 +3461,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
@@ -3646,6 +3718,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -3828,6 +3907,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/read-package-json-fast": {
@@ -4611,6 +4700,13 @@
         }
       }
     },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
@@ -4631,6 +4727,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.7.tgz",
+      "integrity": "sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.7"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/walk-up-path": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "check:vscode-client": "node --check editors/vscode/extension.cjs",
     "check:language-server-cli": "node scripts/validate-language-server-cli.mjs",
     "check:diagnostics": "node scripts/validate-diagnostic-catalog.mjs",
+    "check:template-composition": "npm run build:compiler && node scripts/validate-template-composition.mjs",
     "check:quality-budgets": "node scripts/validate-quality-budgets.mjs",
     "test:property-fuzz": "npm run build:vue-analyzer && vitest run --config vitest.quality.config.ts",
     "check:security": "node scripts/validate-security-evidence.mjs",
@@ -164,12 +165,13 @@
     "release:verify-registry": "node scripts/verify-registry-release.mjs",
     "check:release-contract": "node scripts/validate-release-contract.mjs",
     "check:release-artifacts": "node scripts/build-release-artifacts.mjs --check-state",
-    "check": "npm run typecheck && npm run check:shop-boundaries && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run build && npm run check:quality-budgets && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:diagnostics && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-contract && npm run check:release-artifacts"
+    "check": "npm run typecheck && npm run check:shop-boundaries && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run build && npm run check:quality-budgets && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:diagnostics && npm run check:template-composition && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-contract && npm run check:release-artifacts"
   },
   "devDependencies": {
     "@cyclonedx/cdxgen": "12.7.1",
     "@jridgewell/trace-mapping": "^0.3.31",
     "@types/node": "^22.10.0",
+    "@types/react": "19.2.17",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.1.10",
@@ -181,11 +183,13 @@
     "lit-html": "3.3.3",
     "markdown-it": "^14.3.0",
     "playwright": "^1.58.2",
+    "react": "19.2.7",
     "typedoc": "^0.28.20",
     "typedoc-plugin-markdown": "^4.12.0",
     "typescript": "^5.7.0",
     "vite": "^8.1.4",
     "vitest": "^4.0.18",
-    "vue": "3.5.39"
+    "vue": "3.5.39",
+    "vue-tsc": "3.3.7"
   }
 }

--- a/packages/compiler/CHANGELOG.md
+++ b/packages/compiler/CHANGELOG.md
@@ -6,3 +6,5 @@
   high-resolution source maps, and development HMR transforms.
 - Added the public versioned diagnostic catalog, compact production codes, and
   stable reference URLs under `@gluonjs/compiler/diagnostics`.
+- Recognize aliased `compose()` tagged bodies as original-source HTML template
+  boundaries without rewriting production output.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -4,6 +4,8 @@
 foundation. It records `html` and `css` tagged-template boundaries and
 interpolation locations, produces high-resolution source maps, and supplies the
 development wrappers consumed by `@gluonjs/vite`.
+Aliased `compose(Component, props)\`body\`` calls are recorded as template
+boundaries with the same source-location and inline-style behavior as `html`.
 
 The compiler does not turn templates into a private renderer format. Runtime
 templates continue to use the public `html` and `css` APIs. Production

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -11,7 +11,7 @@ export {
   type GluonDiagnosticSource,
 } from './diagnostics.js';
 
-export type GluonTemplateTag = 'html' | 'css';
+export type GluonTemplateTag = 'html' | 'css' | 'compose';
 
 export interface SourceLocation {
   readonly offset: number;
@@ -84,6 +84,7 @@ export function transformGluonModule(
   );
   const transforms = collectImportedTransforms(sourceFile);
   const htmlTags = collectImportedNames(sourceFile, '@gluonjs/core', 'html');
+  const composeTags = collectImportedNames(sourceFile, '@gluonjs/core', 'compose');
   const magic = new MagicString(code);
   const templates: GluonTemplateLocation[] = [];
   const diagnostics: GluonCompilerDiagnostic[] = [];
@@ -92,12 +93,16 @@ export function transformGluonModule(
   let changed = false;
 
   const visit = (node: ts.Node): void => {
-    if (ts.isTaggedTemplateExpression(node) && ts.isIdentifier(node.tag)) {
-      const kind = transforms.get(node.tag.text);
-      if (kind === 'style' || htmlTags.has(node.tag.text)) {
-        const tag: GluonTemplateTag = kind === 'style' ? 'css' : 'html';
+    if (ts.isTaggedTemplateExpression(node)) {
+      const identifierTag = ts.isIdentifier(node.tag) ? node.tag : undefined;
+      const compositionTag = ts.isCallExpression(node.tag)
+        && ts.isIdentifier(node.tag.expression)
+        && composeTags.has(node.tag.expression.text);
+      const kind = identifierTag ? transforms.get(identifierTag.text) : undefined;
+      if (kind === 'style' || (identifierTag && htmlTags.has(identifierTag.text)) || compositionTag) {
+        const tag: GluonTemplateTag = kind === 'style' ? 'css' : compositionTag ? 'compose' : 'html';
         templates.push(templateLocation(sourceFile, node, tag));
-        if (tag === 'html') {
+        if (tag !== 'css') {
           const templateText = node.template.getText(sourceFile);
           const styleOffset = templateText.search(/<style(?:\s|>)/i);
           if (styleOffset >= 0) {

--- a/packages/create-gluon/CHANGELOG.md
+++ b/packages/create-gluon/CHANGELOG.md
@@ -7,3 +7,5 @@
 - Validate paths, npm package names, non-empty targets, conflicting flags, and
   SSR compatibility before generation.
 - Add the lockstep `gluon-template-check` command to every maintained starter.
+- Generate Router links with the public `compose()` tagged-body path while
+  preserving the same starter routes and rendered anchors.

--- a/packages/create-gluon/README.md
+++ b/packages/create-gluon/README.md
@@ -14,6 +14,9 @@ Router and Store; explicitly combining `--ssr` with `--no-router` or
 `--no-store` fails before files are written.
 
 Every selection includes TypeScript, Vite, typecheck, template-check, test, and build scripts.
+Router starters author link children with the public
+`compose(RouterLink, props)\`body\`` path, so generated projects demonstrate
+typed nested composition without an additional file format.
 `npm run check:templates` runs the same diagnostics exposed by the Gluon editor service.
 `--ui` uses the separately consumable public `@gluonjs/atoms` package. `--testing` adds
 the official browser fixture utilities and a Playwright-backed Vitest test.

--- a/packages/create-gluon/src/template.ts
+++ b/packages/create-gluon/src/template.ts
@@ -125,7 +125,7 @@ function indexHtml(name: string): string {
 
 function appSource(features: GluonFeatures): string {
   const imports = [
-    "import { createApp, html, type GluonApp } from '@gluonjs/core';",
+    "import { compose, createApp, html, type GluonApp } from '@gluonjs/core';",
     features.ui ? "import { Button } from '@gluonjs/atoms';" : '',
     features.router
       ? "import { RouterLink, RouterView, createRouterPlugin, type Router } from '@gluonjs/router';"
@@ -150,8 +150,8 @@ function appSource(features: GluonFeatures): string {
     : '';
   const navigation = features.router
     ? `      <nav aria-label="Primary">
-        \${RouterLink({ to: '/', children: 'Home' })}
-        \${RouterLink({ to: '/about', children: 'About' })}
+        \${compose(RouterLink, { to: '/' })\`Home\`}
+        \${compose(RouterLink, { to: '/about' })\`About\`}
       </nav>`
     : '';
   const content = features.router

--- a/packages/language-server/CHANGELOG.md
+++ b/packages/language-server/CHANGELOG.md
@@ -5,3 +5,5 @@
 - Add shared project diagnostics for Gluon HTML, SVG, and CSS templates.
 - Add completion, hover, definition, rename, and semantic token services.
 - Add the stdio LSP server and `gluon-template-check` CI command.
+- Analyze native HTML and expose editor features inside aliased `compose()`
+  template bodies at their original TypeScript locations.

--- a/packages/language-server/README.md
+++ b/packages/language-server/README.md
@@ -1,7 +1,8 @@
 # `@gluonjs/language-server`
 
-The Gluon language server analyzes imported `html`, `svg`, and `css` tagged
-templates without evaluating application code. The public service and the
+The Gluon language server analyzes imported `html`, `svg`, `css`, and aliased
+`compose(Component, props)` tagged templates without evaluating application
+code. The public service and the
 `gluon-template-check` CI command share the same two-pass project analyzer.
 
 Diagnostics cover unknown Custom Elements, declared Custom Element properties

--- a/packages/language-server/src/index.ts
+++ b/packages/language-server/src/index.ts
@@ -93,7 +93,7 @@ export function declarationsFromCustomElementsManifest(
 export interface Hover { readonly contents: string; readonly range?: Range }
 export interface WorkspaceEdit { readonly changes: Readonly<Record<string, readonly TextEdit[]>> }
 
-interface TemplateSpan { readonly tag: 'css' | 'html' | 'svg'; readonly start: number; readonly end: number }
+interface TemplateSpan { readonly tag: 'compose' | 'css' | 'html' | 'svg'; readonly start: number; readonly end: number }
 interface OpenDocument { readonly uri: string; readonly text: string; readonly analysis: DocumentAnalysis }
 
 const nativeTags = new Set('a article aside button code div footer form h1 h2 h3 h4 h5 h6 header img input label li main nav ol option p section select small span strong textarea ul'.split(' '));
@@ -323,13 +323,17 @@ function collectTemplates(source: ts.SourceFile): TemplateSpan[] {
     if (!bindings || !ts.isNamedImports(bindings)) continue;
     for (const element of bindings.elements) {
       const imported = element.propertyName?.text ?? element.name.text;
-      if (imported === 'html' || imported === 'svg' || imported === 'css') aliases.set(element.name.text, imported);
+      if (imported === 'html' || imported === 'svg' || imported === 'css' || imported === 'compose') aliases.set(element.name.text, imported);
     }
   }
   const templates: TemplateSpan[] = [];
   const visit = (node: ts.Node): void => {
-    if (ts.isTaggedTemplateExpression(node) && ts.isIdentifier(node.tag)) {
-      const tag = aliases.get(node.tag.text);
+    if (ts.isTaggedTemplateExpression(node)) {
+      const tag = ts.isIdentifier(node.tag)
+        ? aliases.get(node.tag.text)
+        : ts.isCallExpression(node.tag) && ts.isIdentifier(node.tag.expression)
+          ? aliases.get(node.tag.expression.text)
+          : undefined;
       if (tag) templates.push({ tag, start: node.template.getStart(source), end: node.template.end });
     }
     ts.forEachChild(node, visit);

--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -7,3 +7,5 @@
   template source maps and diagnostics.
 - Added compatible Custom Element, functional component, Store, and
   constructable stylesheet HMR without full page reloads.
+- Preserve `compose()` template locations and the existing compatible
+  functional-component HMR identity through the compiler integration.

--- a/scripts/validate-dx-scorecard.mjs
+++ b/scripts/validate-dx-scorecard.mjs
@@ -61,6 +61,18 @@ for (const name of evidenceNames) {
     assert(evidence.limitations.some((value) => value.includes('No task result, win, tie, loss')), `${name} must prohibit unsupported comparison claims`);
     continue;
   }
+  if (evidence.status === 'implementation-slice-only') {
+    assert(evidence.specification === 'benchmarks/dx/specification-v1.json', `${name} must link the accepted specification`);
+    assert(evidence.trackingIssue === 111, `${name} must identify issue #111`);
+    assert(evidence.applicableTask === 'T3-local-layers', `${name} must identify the applicable parent task`);
+    assert(evidence.frameworks.length === 4, `${name} must retain current Gluon, compose Gluon, React, and Vue fixtures`);
+    assertSet(evidence.frameworks.map(({ id }) => id), ['gluon-current', 'gluon-compose', 'react', 'vue'], `${name} slice frameworks`);
+    assert(evidence.frameworks.find(({ id }) => id === 'gluon-compose').callSiteChildrenProperties === 0, `${name} must retain the children-plumbing result`);
+    assert(evidence.limitations.some((value) => value.includes('not a completed benchmark run')), `${name} must not imply a completed run`);
+    assert(evidence.limitations.some((value) => value.includes('No human usability pass')), `${name} must report the missing human pass`);
+    assert(evidence.limitations.some((value) => value.includes('win, tie, loss')), `${name} must prohibit unsupported comparison claims`);
+    continue;
+  }
   assert(validateRun(evidence), `${name} does not match the completed-run schema:\n${ajv.errorsText(validateRun.errors, { separator: '\n' })}`);
   assertSet(evidence.frameworks.map(({ id }) => id), ['gluon', 'react', 'vue'], `${name} framework runs`);
   const expectedPairs = specification.tasks.flatMap(({ id }) =>

--- a/scripts/validate-template-composition.mjs
+++ b/scripts/validate-template-composition.mjs
@@ -1,0 +1,127 @@
+import { execFileSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import ts from 'typescript';
+import { parse } from '@vue/compiler-sfc';
+import { transformGluonModule } from '../packages/compiler/dist/index.js';
+
+const root = resolve(import.meta.dirname, '..');
+const fixtureRoot = resolve(root, 'benchmarks/dx/template-composition');
+const fixtures = {
+  'gluon-current': 'gluon-current.ts',
+  'gluon-compose': 'gluon-compose.ts',
+  react: 'react.tsx',
+  vue: 'vue.vue',
+};
+
+const expected = JSON.parse(await readFile(resolve(fixtureRoot, 'evidence.json'), 'utf8'));
+const actual = {};
+for (const [name, file] of Object.entries(fixtures)) {
+  const source = await readFile(resolve(fixtureRoot, file), 'utf8');
+  if (!source.includes('Checkout') || !source.includes('Delivery') || !source.includes('Confirm order') || !source.includes('Email')) {
+    throw new Error(`TEMPLATE_COMPOSITION_FIXTURE_PARITY: ${file} is missing a retained observable.`);
+  }
+  actual[name] = Object.freeze({
+    nonEmptyLines: source.split('\n').filter((line) => line.trim()).length,
+    tokens: tokenCount(source, file),
+    maximumIndentation: Math.max(...source.split('\n').filter((line) => line.trim()).map((line) => line.length - line.trimStart().length)),
+    explicitChildrenProperties: [...source.matchAll(/\bchildren\s*:/g)].length,
+    callSiteChildrenProperties: file.endsWith('.vue') ? 0 : callSiteChildrenCount(source, file),
+  });
+}
+
+if (JSON.stringify(actual) !== JSON.stringify(expected.metrics)) {
+  throw new Error(`TEMPLATE_COMPOSITION_EVIDENCE_DRIFT\nExpected ${JSON.stringify(expected.metrics, null, 2)}\nActual ${JSON.stringify(actual, null, 2)}`);
+}
+
+execFileSync(process.execPath, [resolve(root, 'node_modules/typescript/bin/tsc'), '-p', resolve(fixtureRoot, 'tsconfig.json')], { stdio: 'inherit' });
+execFileSync(process.execPath, [resolve(root, 'node_modules/vue-tsc/bin/vue-tsc.js'), '--noEmit', '-p', resolve(fixtureRoot, 'tsconfig.vue.json')], { stdio: 'inherit' });
+
+const vueSource = await readFile(resolve(fixtureRoot, 'vue.vue'), 'utf8');
+const parsed = parse(vueSource, { filename: 'vue.vue' });
+if (parsed.errors.length > 0) throw new Error(`TEMPLATE_COMPOSITION_VUE_PARSE: ${parsed.errors.join('\n')}`);
+
+const composeSource = await readFile(resolve(fixtureRoot, 'gluon-compose.ts'), 'utf8');
+const transformed = transformGluonModule(composeSource, resolve(fixtureRoot, 'gluon-compose.ts'));
+if (!transformed.templates.some((template) => template.tag === 'compose')) throw new Error('TEMPLATE_COMPOSITION_COMPILER_BOUNDARY_MISSING');
+if (transformed.code !== composeSource || transformed.map.sourcesContent?.[0] !== composeSource) throw new Error('TEMPLATE_COMPOSITION_SOURCE_MAP_CONTRACT');
+
+validateTypeScriptEditorContract(composeSource);
+
+console.log(`Validated template composition evidence: ${Object.keys(fixtures).join(', ')}.`);
+
+function tokenCount(source, file) {
+  if (file.endsWith('.vue')) return source.match(/[A-Za-z_$][\w$]*|\d+(?:\.\d+)?|[^\s\w]/g)?.length ?? 0;
+  const scanner = ts.createScanner(ts.ScriptTarget.Latest, false, file.endsWith('.tsx') ? ts.LanguageVariant.JSX : ts.LanguageVariant.Standard, source);
+  let count = 0;
+  while (scanner.scan() !== ts.SyntaxKind.EndOfFileToken) {
+    if (scanner.getToken() !== ts.SyntaxKind.WhitespaceTrivia && scanner.getToken() !== ts.SyntaxKind.NewLineTrivia) count += 1;
+  }
+  return count;
+}
+
+function callSiteChildrenCount(source, file) {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS);
+  let count = 0;
+  const visit = (node) => {
+    if (ts.isPropertyAssignment(node) && node.name.getText(sourceFile) === 'children') count += 1;
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return count;
+}
+
+function validateTypeScriptEditorContract(composeSource) {
+  const configFile = ts.readConfigFile(resolve(fixtureRoot, 'tsconfig.json'), ts.sys.readFile);
+  if (configFile.error) throw new Error(ts.flattenDiagnosticMessageText(configFile.error.messageText, '\n'));
+  const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, fixtureRoot);
+  const composeFile = resolve(fixtureRoot, 'gluon-compose.ts');
+  const completionFile = resolve(fixtureRoot, '__composition-completion.ts');
+  const completionSource = `import { compose, html, type TemplateValue } from '@gluonjs/core';
+interface PanelProps { title: string; onSave: (event: Event) => void; children: TemplateValue }
+const Panel = (props: PanelProps) => html\`<section>\${props.children}</section>\`;
+compose(Panel, {  })\`body\`;`;
+  const files = new Map(parsed.fileNames.map((file) => [file, ts.sys.readFile(file) ?? '']));
+  files.set(composeFile, composeSource);
+  files.set(completionFile, completionSource);
+  const service = ts.createLanguageService({
+    getCompilationSettings: () => parsed.options,
+    getScriptFileNames: () => [...files.keys()],
+    getScriptVersion: () => '0',
+    getScriptSnapshot: (file) => {
+      const text = files.get(file) ?? ts.sys.readFile(file);
+      return text === undefined ? undefined : ts.ScriptSnapshot.fromString(text);
+    },
+    getCurrentDirectory: () => root,
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    fileExists: ts.sys.fileExists,
+    readFile: ts.sys.readFile,
+    readDirectory: ts.sys.readDirectory,
+  });
+  if (service.getSyntacticDiagnostics(composeFile).length || service.getSemanticDiagnostics(composeFile).length) {
+    throw new Error('TEMPLATE_COMPOSITION_TYPESCRIPT_DIAGNOSTICS');
+  }
+  const shellPosition = composeSource.indexOf('compose(Shell') + 'compose('.length + 1;
+  if (!service.getQuickInfoAtPosition(composeFile, shellPosition)) throw new Error('TEMPLATE_COMPOSITION_HOVER_MISSING');
+  if (!service.getDefinitionAtPosition(composeFile, shellPosition)?.some((entry) => entry.fileName === composeFile)) throw new Error('TEMPLATE_COMPOSITION_DEFINITION_MISSING');
+  if ((service.findRenameLocations(composeFile, shellPosition, false, false, true)?.length ?? 0) < 2) throw new Error('TEMPLATE_COMPOSITION_RENAME_MISSING');
+  const completionPosition = completionSource.indexOf('{  }') + 2;
+  const completions = service.getCompletionsAtPosition(completionFile, completionPosition, {});
+  if (!completions?.entries.some((entry) => entry.name === 'title') || !completions.entries.some((entry) => entry.name === 'onSave')) {
+    throw new Error('TEMPLATE_COMPOSITION_COMPLETION_MISSING');
+  }
+  const bodyStart = composeSource.indexOf(')`') + 2;
+  const bodyEnd = composeSource.lastIndexOf('`;');
+  const formatting = service.getFormattingEditsForDocument(composeFile, {
+    indentSize: 2,
+    tabSize: 2,
+    convertTabsToSpaces: true,
+    newLineCharacter: '\n',
+    indentStyle: ts.IndentStyle.Smart,
+  });
+  if (formatting.some((edit) => edit.span.start < bodyEnd
+    && edit.span.start + edit.span.length > bodyStart
+    && (!/^\s*$/.test(edit.newText) || !/^\s*$/.test(composeSource.slice(edit.span.start, edit.span.start + edit.span.length))))) {
+    throw new Error('TEMPLATE_COMPOSITION_FORMATTING_BOUNDARY');
+  }
+}

--- a/src/component.ts
+++ b/src/component.ts
@@ -1,4 +1,4 @@
-import { nothing, type TemplateResult, type TemplateValue } from './runtime.js';
+import { html, nothing, type TemplateResult, type TemplateValue } from './runtime.js';
 
 export type ComponentLayer = 'atom' | 'molecule' | 'organism';
 
@@ -11,6 +11,30 @@ export interface Component<Props = Record<string, never>> {
 export type ScopedSlot<Props = Record<string, never>> = (
   props: Readonly<Props>,
 ) => TemplateValue;
+
+/** Props supplied before the template body becomes the component's children. */
+export type CompositionProps<Props> = Omit<Props, 'children'>;
+
+/** A native tagged-template boundary that evaluates to the component result. */
+export interface ComponentTemplateTag<Result extends TemplateValue = TemplateValue> {
+  (strings: TemplateStringsArray, ...values: TemplateValue[]): Result;
+}
+
+/**
+ * Binds typed functional-component props to an `html` template body.
+ *
+ * The body is passed as `children` in one ordinary function call. No component
+ * instance, host node, lifecycle, context, event system, or renderer is added.
+ */
+export function compose<Props extends { readonly children?: TemplateValue }, Result extends TemplateValue>(
+  component: (props: Readonly<Props>) => Result,
+  props: CompositionProps<Props>,
+): ComponentTemplateTag<Result> {
+  return (strings, ...values) => component({
+    ...props,
+    children: html(strings, ...values),
+  } as unknown as Readonly<Props>);
+}
 
 export function renderScopedSlot<Props>(
   slot: ScopedSlot<Props> | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,12 +100,15 @@ export {
 } from './application.js';
 
 export {
+  compose,
   defineAtom,
   defineMolecule,
   defineOrganism,
   renderScopedSlot,
   type Component,
+  type ComponentTemplateTag,
   type ComponentLayer,
+  type CompositionProps,
   type ScopedSlot,
 } from './component.js';
 

--- a/tests-node/compiler-vite.spec.ts
+++ b/tests-node/compiler-vite.spec.ts
@@ -106,6 +106,22 @@ describe('@gluonjs/compiler', () => {
     expect(transformed.code).not.toContain('import.meta.hot');
     expect(transformed.map.sourcesContent).toEqual([source]);
   });
+
+  it('records compose template bodies and preserves their original source mappings', () => {
+    const id = '/app/checkout.ts';
+    const source = [
+      "import { compose as nest, html } from '@gluonjs/core';",
+      "const Panel = (props: { children: unknown }) => html`<section>${props.children as never}</section>`;",
+      'export const Checkout = () => nest(Panel, {})`',
+      '  <button>Pay</button>',
+      '`;',
+    ].join('\n');
+    const transformed = transformGluonModule(source, id, { development: true });
+    expect(transformed.templates.map((template) => template.tag)).toEqual(['html', 'compose']);
+    expect(transformed.templates[1]?.start.line).toBe(3);
+    expect(transformed.code).toContain('nest(Panel, {})`');
+    expect(transformed.map.sourcesContent).toEqual([source]);
+  });
 });
 
 describe('@gluonjs/vite real server contract', () => {
@@ -230,7 +246,7 @@ async function createFixture(version: string, increment: number, color: string):
 
 function componentSource(version: string, increment: number, color: string): string {
   return [
-    "import { css, defineElement, GluonElement, html } from '@gluonjs/core';",
+    "import { compose, css, defineElement, GluonElement, html, type TemplateValue } from '@gluonjs/core';",
     "import { defineStore, type Store } from '@gluonjs/store';",
     'export const counterDefinition = defineStore({',
     "  id: 'vite-counter',",
@@ -239,7 +255,8 @@ function componentSource(version: string, increment: number, color: string): str
     '});',
     `const counterStyles = css\`button { color: ${color}; }\`;`,
     'type CounterStore = Store<\'vite-counter\', { count: number }, Record<never, never>, { increment(): void }>; ',
-    `export function Status(store: CounterStore) { return html\`<output>Function ${version}: \${store.count}</output>\`; }`,
+    'function StatusPanel(props: { children: TemplateValue }) { return html`<output>${props.children}</output>`; }',
+    `export function Status(store: CounterStore) { return compose(StatusPanel, {})\`Function ${version}: \${store.count}\`; }`,
     'export class HmrCounter extends GluonElement {',
     '  static override readonly properties = { store: { attribute: false } };',
     '  static override readonly styles = counterStyles;',

--- a/tests-node/core.types.ts
+++ b/tests-node/core.types.ts
@@ -7,6 +7,7 @@ import {
   TransitionGroup,
   createApp,
   createInjectionKey,
+  compose,
   directive,
   defineAsyncComponent,
   dynamicComponent,
@@ -42,6 +43,32 @@ interface Row {
   readonly id: string;
   readonly label: string;
 }
+
+interface PanelProps {
+  readonly title: string;
+  readonly onClose: (event: MouseEvent) => void;
+  readonly actions?: TemplateValue;
+  readonly children: TemplateValue;
+}
+
+function Panel(props: PanelProps): TemplateValue {
+  return html`<section><h2>${props.title}</h2>${props.children}</section>`;
+}
+
+compose(Panel, {
+  title: 'Checkout',
+  onClose: (event) => event.preventDefault(),
+  actions: html`<button>Save</button>`,
+})`<p>Delivery</p>`;
+Panel({ title: 'Direct', onClose: () => undefined, children: 'Still callable' });
+// @ts-expect-error required title remains required at the author call
+compose(Panel, { onClose: () => undefined })`missing title`;
+// @ts-expect-error callback types remain checked at the author call
+compose(Panel, { title: 'Invalid', onClose: (value: string) => value })`bad callback`;
+// @ts-expect-error unknown props remain checked at the author call
+compose(Panel, { title: 'Invalid', onClose: () => undefined, unknown: true })`bad prop`;
+// @ts-expect-error only components with TemplateValue children accept a template body
+compose((props: { readonly label: string }) => html`<p>${props.label}</p>`, { label: 'No children' })`invalid content`;
 
 const rows: readonly Row[] = [{ id: 'first', label: 'First' }];
 const keyed: RepeatResult = repeat(

--- a/tests-node/language-server.spec.ts
+++ b/tests-node/language-server.spec.ts
@@ -60,6 +60,18 @@ describe('Gluon template analysis', () => {
     expect(result.diagnostics.map((entry) => entry.code)).toContain('GLUON_TEMPLATE_CUSTOM_ELEMENT_UNKNOWN');
   });
 
+  test('analyzes native markup at original locations inside compose template bodies', () => {
+    const source = `import { compose, html, type TemplateValue } from '@gluonjs/core';
+      const Panel = (props: { children: TemplateValue }) => html\`<section>\${props.children}</section>\`;
+      compose(Panel, {})\`<button aria-labl="Pay">Pay</button><img>invalid</img>\`;`;
+    const result = analyzeGluonDocument('file:///compose.ts', source);
+    expect(result.diagnostics.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      'GLUON_TEMPLATE_ARIA_UNKNOWN',
+      'GLUON_TEMPLATE_VOID_CHILDREN',
+    ]));
+    expect(result.diagnostics.every((entry) => entry.range.start.line === 2)).toBe(true);
+  });
+
   test('accepts public Custom Elements Manifest metadata', () => {
     const declarations = declarationsFromCustomElementsManifest('file:///custom-elements.json', {
       modules: [{ declarations: [{
@@ -116,6 +128,18 @@ describe('Gluon language service', () => {
     expect(service.complete('file:///native.ts', { line: 0, character: 47 }).some((entry) => entry.label === 'button')).toBe(true);
     expect(service.definition('file:///native.ts', { line: 0, character: 49 })).toEqual([]);
     expect(service.rename('file:///native.ts', { line: 0, character: 49 }, 'new-button')).toBeUndefined();
+  });
+
+  test('provides template-body editor features inside compose calls', () => {
+    const service = new GluonLanguageService();
+    const source = `import { compose, html, type TemplateValue } from '@gluonjs/core';
+const Panel = (props: { children: TemplateValue }) => html\`<section>\${props.children}</section>\`;
+compose(Panel, {})\`<button type="button">Pay</button>\`;`;
+    service.open('file:///compose.ts', source);
+    const button = positionFor(source, source.lastIndexOf('button') + 2);
+    expect(service.hover('file:///compose.ts', button)?.contents).toContain('Native HTML');
+    expect(service.complete('file:///compose.ts', button).some((entry) => entry.label === 'button')).toBe(true);
+    expect(service.semanticTokens('file:///compose.ts').length).toBeGreaterThan(0);
   });
 });
 

--- a/tests-node/ssr.spec.ts
+++ b/tests-node/ssr.spec.ts
@@ -10,6 +10,7 @@ import {
   Transition,
   createApp,
   createInjectionKey,
+  compose,
   css,
   defineElement,
   directive,
@@ -40,6 +41,21 @@ import { generateStaticSite } from '@gluonjs/ssr/static';
 import { renderShopRequest } from '../examples/shop/src/server.js';
 
 describe('@gluonjs/ssr DOM-independent serialization', () => {
+  it('serializes composed functional templates through the unchanged public template contract', async () => {
+    const Panel = (props: { readonly title: string; readonly children: import('@gluonjs/core').TemplateValue }) => html`
+      <section><h2>${props.title}</h2>${props.children}</section>
+    `;
+    const result = compose(Panel, { title: 'Checkout' })`<p>Delivery</p>`;
+    const rendered = withoutHydrationMarkers(await renderToString(result));
+    expect(rendered).toContain('<section><h2>Checkout</h2><p>Delivery</p></section>');
+    const ordered: string[] = [];
+    for await (const chunk of renderToChunks(result)) ordered.push(chunk);
+    expect(withoutHydrationMarkers(ordered.join(''))).toBe(rendered);
+    const progressive = [];
+    for await (const chunk of renderProgressively(result)) progressive.push(chunk);
+    expect(withoutHydrationMarkers(progressive[0]!.html)).toBe(rendered);
+  });
+
   it('loads the public Core and renderer without browser DOM globals', () => {
     expect(globalThis).not.toHaveProperty('document');
     expect(globalThis).not.toHaveProperty('HTMLElement');

--- a/tests/components-and-utilities.spec.ts
+++ b/tests/components-and-utilities.spec.ts
@@ -1,14 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   adoptStyles,
+  Suspense,
   createStyleSheet,
   css,
+  compose,
   defineAtom,
+  elementRef,
   html,
   installGluonStyles,
   mergeProps,
+  model,
+  repeat,
   render,
 } from '../src/index.js';
+import { ref } from '@gluonjs/reactivity';
 import { Button, Icon } from '@gluonjs/atoms';
 import { Card, FormField } from '@gluonjs/molecules';
 import { AppShell } from '@gluonjs/organisms';
@@ -102,6 +108,50 @@ describe('component variants and utilities', () => {
     expect(root.querySelector('.gluon-app-shell-navigation')).toBeNull();
     expect(root.querySelector('.gluon-app-shell-footer')).toBeNull();
     expect(unnamed.displayName).toBe('AnonymousComponent');
+  });
+
+  it('composes typed functional components with an HTML template body and no host boundary', () => {
+    const root = document.createElement('div');
+    const direct = AppShell({
+      header: 'GLUON GOODS',
+      children: Card({ title: 'Checkout', children: html`<button>Pay</button>` }),
+    });
+    const composed = compose(AppShell, { header: 'GLUON GOODS' })`${compose(Card, { title: 'Checkout' })`<button>Pay</button>`}`;
+
+    render(html`<section id="direct">${direct}</section><section id="composed">${composed}</section>`, root);
+
+    expect(root.querySelector('#composed')?.textContent).toBe(root.querySelector('#direct')?.textContent);
+    expect(root.querySelector('#composed')?.querySelectorAll('.gluon-app-shell')).toHaveLength(1);
+    expect(root.querySelector('#composed')?.querySelectorAll('.gluon-card')).toHaveLength(1);
+  });
+
+  it('keeps named/scoped content, callbacks, spreads, models, refs, conditions, keys, and async bodies on public contracts', async () => {
+    const input = ref('Ada');
+    const inputRef = elementRef<HTMLInputElement>();
+    const save = vi.fn();
+    const Panel = (props: {
+      readonly actions: import('../src/index.js').TemplateValue;
+      readonly row: import('../src/index.js').ScopedSlot<{ label: string }>;
+      readonly children: import('../src/index.js').TemplateValue;
+    }) => html`<section>${props.children}${props.row({ label: 'Scoped' })}${props.actions}</section>`;
+    const view = compose(Panel, {
+      actions: html`<button @click=${save}>Save</button>`,
+      row: ({ label }) => html`<strong>${label}</strong>`,
+    })`
+      <input ...=${{ ...model(input), ref: inputRef }}>
+      ${true ? html`<span>Conditional</span>` : null}
+      ${repeat([{ id: 'one', label: 'Keyed' }], (item) => item.id, (item) => html`<i>${item.label}</i>`)}
+      ${Suspense({ source: Promise.resolve('Async'), fallback: 'Loading', children: (value) => html`<em>${value}</em>` })}
+    `;
+    const root = document.createElement('div');
+    render(html`${view}`, root);
+    expect(inputRef.value?.value).toBe('Ada');
+    expect(root.textContent).toContain('Conditional');
+    expect(root.textContent).toContain('Keyed');
+    expect(root.textContent).toContain('ScopedSave');
+    root.querySelector<HTMLButtonElement>('button')?.click();
+    expect(save).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(root.querySelector('em')?.textContent).toBe('Async'));
   });
 
   it('validates quark names and caches fragment templates', () => {

--- a/tests/devtools.spec.ts
+++ b/tests/devtools.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { GluonElement, defineElement, html } from '../src/index.js';
+import { GluonElement, compose, defineElement, html, render, type TemplateValue } from '../src/index.js';
 import { nextTick, ref } from '@gluonjs/reactivity';
 import {
   GLUON_DEVTOOLS_GLOBAL,
@@ -12,6 +12,27 @@ const cleanups: Array<() => void> = [];
 afterEach(() => { for (const cleanup of cleanups.splice(0).reverse()) cleanup(); });
 
 describe('Gluon Devtools browser bridge', () => {
+  test('observes the same component tree for direct and composed functional output', async () => {
+    class ComposeLeaf extends GluonElement {
+      protected override render() { return html`<span>Leaf</span>`; }
+    }
+    if (!customElements.get('devtools-compose-leaf')) defineElement('devtools-compose-leaf', ComposeLeaf);
+    const Panel = (props: { readonly children: TemplateValue }) => html`<section>${props.children}</section>`;
+    const direct = document.createElement('div');
+    const composed = document.createElement('div');
+    document.body.append(direct, composed);
+    cleanups.push(() => { direct.remove(); composed.remove(); });
+    render(html`${Panel({ children: html`<devtools-compose-leaf></devtools-compose-leaf>` })}`, direct);
+    render(html`${compose(Panel, {})`<devtools-compose-leaf></devtools-compose-leaf>`}`, composed);
+    await nextTick();
+    const bridge = createDevtoolsBridge({ enabled: true });
+    cleanups.push(() => bridge.dispose());
+    bridge.registerApplication({ id: 'direct', app: { mounted: true }, root: direct });
+    bridge.registerApplication({ id: 'composed', app: { mounted: true }, root: composed });
+    const trees = bridge.snapshot().applications.map((application) => application.components.map((component) => component.name));
+    expect(trees).toEqual([['devtools-compose-leaf'], ['devtools-compose-leaf']]);
+  });
+
   test('is inert by default and never exposes a production global', () => {
     const globalObject: Record<string, unknown> = {};
     const bridge = createDevtoolsBridge({ exposeGlobal: true, globalObject });

--- a/tests/hydration.spec.ts
+++ b/tests/hydration.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  compose,
   createApp,
   createInjectionKey,
   defineElement,
@@ -26,6 +27,20 @@ import { hydrateShop } from '../examples/shop/src/hydrate.js';
 import type { ProductConfiguratorElement } from '../examples/shop/src/product-configurator.js';
 
 describe('SSR hydration', () => {
+  it('retains the server DOM produced by a composed functional template', async () => {
+    const Panel = (props: { readonly title: string; readonly children: import('@gluonjs/core').TemplateValue }) => html`
+      <section><h2>${props.title}</h2>${props.children}</section>
+    `;
+    const value = html`${compose(Panel, { title: 'Checkout' })`<button>Pay</button>`}`;
+    const prepared = await prepareForHydration(value);
+    const root = document.createElement('div');
+    root.innerHTML = prepared.html;
+    const section = root.querySelector('section');
+    const result = await hydrateTemplate(value, root);
+    expect(result.retained).toBe(true);
+    expect(root.querySelector('section')).toBe(section);
+  });
+
   it('retains matching nodes while activating refs, events, context, and reactive updates', async () => {
     const label = ref('Server');
     const key = createInjectionKey<string>('hydration-context');

--- a/tests/test-utils.spec.ts
+++ b/tests/test-utils.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   GluonElement,
+  compose,
   createInjectionKey,
   defineElement,
   html,
@@ -31,6 +32,15 @@ afterEach(async () => {
 });
 
 describe('@gluonjs/test-utils component fixtures', () => {
+  it('mounts a composed template body through the same public component fixture', () => {
+    const Panel = (props: Readonly<{ title: string; children: import('@gluonjs/core').TemplateValue }>) => html`
+      <section><h2>${props.title}</h2>${props.children}</section>
+    `;
+    const fixture = renderFixture(() => html`${compose(Panel, { title: 'Checkout' })`<p>Delivery</p>`}`);
+    expect(fixture.get('h2').textContent).toBe('Checkout');
+    expect(fixture.get('p').textContent).toBe('Delivery');
+  });
+
   it('mounts typed functional props and updates through the public scheduler', async () => {
     const onSave = vi.fn();
     const fixture = mountComponent(


### PR DESCRIPTION
Closes #111

## Outcome

- adds the public `compose(Component, props)\`body\`` Core API; it passes one ordinary `html` result as `children` to one ordinary function call
- accepts RFC 0004 after comparing current calls with tagged bodies, interpolated component tags, and proprietary component blocks on the same checkout/dialog fixture
- recognizes aliased `compose()` template bodies in Compiler/Vite source maps and the Language Server while retaining TypeScript completion, hover, definition, rename, formatting, and diagnostics at original locations
- proves direct-call parity across CSR, SSR, ordered/progressive streaming, hydration, static GLUON GOODS generation, Devtools, test utilities, and compatible HMR
- adopts the API in real GLUON GOODS RouterLink flows, create-gluon router starters, the Playground, and quick start; updates API examples, architecture, docs, changelogs, roadmap, and quality gates
- adds a canonical #107 `implementation-slice-only` evidence record and retained Gluon/React/Vue syntax fixtures

## Evidence boundary

The retained comparison reports 28 lines / 202 tokens / two call-site `children:` properties for current Gluon and 28 lines / 213 tokens / zero call-site `children:` properties for `compose()`. It does not claim general readability or DX superiority.

No human usability pass was run for #111 (zero participants). The canonical record explicitly remains a partial T3 syntax slice, not a completed 21-result #107 benchmark run; the shared validator reports 0 completed runs.

## Verification

- `npm run check` — pass on rebased commit `83aef9e`; includes full typecheck, all coverage suites, Playground, property/fuzz, production build, shop/security/UI budgets, public API contracts, language/editor/diagnostic gates, 20/20 clean-installed starters, Vue evidence gates, DX contract, 510/510 curated API pages, and release artifacts
- `npm run check:template-composition` — pass; Gluon/React TypeScript, vue-tsc/SFC parse, parity/metrics, Compiler source maps, TypeScript completion/hover/definition/rename/formatting
- production GLUON GOODS: 5 static routes, 3 dynamic fallbacks, 158109 entry bytes, 45726 gzip bytes

## Visual scope

No CSS, image, or rendered control contract changes. GLUON GOODS uses the new source authoring path for existing RouterLink output; the complete customer-flow browser suite passes.
