### PR TITLE
Stabilize create-gluon invalid-tag rejection coverage

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -160,6 +160,12 @@ transforms, and language-service declaration discovery. The filesystem writer
 stages same-directory temporary files and restores already-applied targets if a
 commit step fails.
 
+Invalid-input cases start one operation only after its rejection assertion is
+installed. The reserved `annotation-xml` regression verifies the exact
+`INVALID_CUSTOM_ELEMENT_NAME` diagnostic and no-write result separately;
+`test:create-gluon:coverage` must finish without an unhandled-rejection record
+after all assertions pass.
+
 The optional `--components-only` validator argument is a development shortcut
 for the five generated projects. The blocking repository command uses no
 shortcut and therefore runs both matrices.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,6 @@
 # Release operations
 
-Gluon uses one lockstep release for the 16 packages in
+Gluon uses one lockstep release for the 17 packages in
 [`package-contract.json`](../package-contract.json). The executable release
 contract is [`release/release-contract.json`](../release/release-contract.json),
 and `.github/workflows/release.yml` is the only supported publication path.
@@ -132,12 +132,12 @@ GitHub release.
 
 The workflow publishes every reviewed archive through npm trusted publishing
 with provenance under `gluon-staging-v<version-with-dashes>`, never directly to
-`latest`. Before the first publish it proves that all 16 npm package records
+`latest`. Before the first publish it proves that all 17 npm package records
 already exist. After each publish it compares registry integrity and provenance
 with `release-evidence.json`. A rerun skips an already-existing version only
 when those facts match; a mismatch stops the train.
 
-After all 16 staging publications succeed, an authorized npm owner reviews the
+After all 17 staging publications succeed, an authorized npm owner reviews the
 draft evidence and promotes every exact package version to `latest` with
 interactive 2FA using `npm dist-tag add <name>@<version> latest`. OIDC trusted
 publishing does not authorize dist-tag changes. The owner may remove the

--- a/packages/create-gluon/CHANGELOG.md
+++ b/packages/create-gluon/CHANGELOG.md
@@ -24,3 +24,6 @@
   browser tests.
 - Verify every component kind through packed clean installs, type and template
   checks, Chromium, client/SSR builds, and package dry runs.
+- Own every invalid-input rejection at assertion creation time so reserved
+  Custom Element names retain their exact diagnostic without an asynchronous
+  unhandled-Promise escape under coverage.

--- a/tests-node/create-gluon.spec.ts
+++ b/tests-node/create-gluon.spec.ts
@@ -376,19 +376,37 @@ describe('create-gluon add-component planning and writes', () => {
     const cwd = await mkdtemp(join(tmpdir(), 'create-gluon-component-safety-'));
     const project = await scaffoldProject({ directory: 'app', cwd });
     const invalid = [
-      addComponent({ root: project.directory, kind: 'atom', name: 'bad-name' }),
-      addComponent({ root: project.directory, kind: 'atom', name: 'ValidName', path: '../outside' }),
-      addComponent({ root: project.directory, kind: 'atom', name: 'ValidName', path: join(cwd, 'absolute') }),
-      addComponent({ root: project.directory, kind: 'element', name: 'ValidName', tagName: 'Invalid' }),
-      addComponent({ root: project.directory, kind: 'element', name: 'ValidName', tagName: 'annotation-xml' }),
+      () => addComponent({ root: project.directory, kind: 'atom', name: 'bad-name' }),
+      () => addComponent({ root: project.directory, kind: 'atom', name: 'ValidName', path: '../outside' }),
+      () => addComponent({ root: project.directory, kind: 'atom', name: 'ValidName', path: join(cwd, 'absolute') }),
+      () => addComponent({ root: project.directory, kind: 'element', name: 'ValidName', tagName: 'Invalid' }),
     ];
-    for (const promise of invalid) await expect(promise).rejects.toBeInstanceOf(AddComponentError);
+    for (const rejectInvalidInput of invalid) {
+      await expect(rejectInvalidInput()).rejects.toBeInstanceOf(AddComponentError);
+    }
     const outside = join(cwd, 'outside');
     await mkdir(outside);
     await symlink(outside, join(project.directory, 'src/components'));
     await expect(addComponent({ root: project.directory, kind: 'atom', name: 'SafeAction' }))
       .rejects.toMatchObject({ code: 'SYMLINK_ESCAPE' });
     await expect(readFile(join(outside, 'safe-action.ts'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('owns reserved custom-element tag rejection before it can escape the assertion', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'create-gluon-component-reserved-tag-'));
+    const project = await scaffoldProject({ directory: 'app', cwd });
+
+    await expect(addComponent({
+      root: project.directory,
+      kind: 'element',
+      name: 'ValidName',
+      tagName: 'annotation-xml',
+    })).rejects.toMatchObject({
+      code: 'INVALID_CUSTOM_ELEMENT_NAME',
+      message: 'INVALID_CUSTOM_ELEMENT_NAME: "annotation-xml" is not a valid autonomous Custom Element name.',
+    });
+    await expect(readFile(join(project.directory, 'src/components/valid-name.ts')))
+      .rejects.toMatchObject({ code: 'ENOENT' });
   });
 
   test('fails invalid manifests before creating component paths', async () => {


### PR DESCRIPTION
Closes #125.

## Root cause

The safety test constructed five rejecting `addComponent()` promises before attaching rejection assertions. The loop then attached `.rejects` handlers sequentially. Under create-gluon coverage timing, the later reserved-tag operation could reject before its handler was installed, so all assertions passed but Vitest reported a delayed unhandled `AddComponentError` for `annotation-xml`.

The public generator diagnostic was correct; Promise ownership in the test was not.

## Changes

- start each invalid operation only when its rejection assertion is installed
- give `annotation-xml` a focused regression for the exact `INVALID_CUSTOM_ELEMENT_NAME` diagnostic and no-write result
- document the immediate rejection-ownership requirement in the quality gate and create-gluon changelog
- correct the audited release runbook package count from 16 to the current 17 lockstep packages

No public API or generator runtime behavior changes. The branch is rebased on #128 merge `ee476686`; its React T4 timing regression remains unchanged from `main`.

## Verification

- pre-fix reproduction: the second of 20 fresh coverage attempts exited 1 after 20 passing assertions with `PromiseRejectionHandledWarning` and the escaped `annotation-xml` error
- focused reserved-tag regression: PASS
- `npm run test:create-gluon`: PASS, 21/21
- 20 fresh `test:create-gluon:coverage` processes: PASS, 21/21 each, no unhandled rejection
- `TMPDIR=/Volumes/ssd/gluon-issue125-tmp npm run check`: PASS
  - browser coverage: 238/238, including the merged #128 regression
  - create-gluon coverage: 21/21 with no unhandled rejection
  - fixture matrix: 20/20 applications and 5/5 component kinds
  - release artifacts: 17 packages and 36 schema-valid SBOMs
- `git diff --check origin/main...HEAD`: PASS
- raw branch diff: exactly four #125 files; no #128 test diff
