### PR TITLE
Stabilize retained React control render timing

### DIFF
--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -64,6 +64,14 @@ plain-HTML boundary, Vue-host consumption, exact comparator-tag hydration,
 readable-stream/static output, and cleanup. This partial
 evidence has no human pass and makes no general ranking claim.
 
+The stateful-control browser fixture treats React's scheduled `root.render()`
+commit as ready only when a ShadowRoot observer sees the exact accepted
+quantity and computed total. It checks that observable condition immediately
+before and after observer registration and uses the deadline only to fail a
+missing commit. The retained synchronous event assertion remains separate, and
+a focused 25-update React case exercises the event/render boundary in every
+configured Playwright engine.
+
 ## Generated API example gate
 
 `npm run docs:api` generates TypeDoc Markdown for every public package entry

--- a/docs/stateful-form-control-comparison.md
+++ b/docs/stateful-form-control-comparison.md
@@ -26,6 +26,17 @@ server outputs, readable-stream serialization, and static generation. Generator
 and Playground tests retain public
 `defineGluonElement` examples.
 
+React 19's `root.render()` schedules a commit after the autonomous-element
+bridge has synchronously accepted and dispatched a `quantity-change` event. A
+single animation frame is not a React commit signal: retained pull-request runs
+observed the exact quantity-2 event while the ShadowRoot still rendered
+quantity 1 in both Chromium and WebKit. The browser fixture therefore observes
+the ShadowRoot until both the exact quantity and computed total are rendered,
+with an immediate check before and after observer registration. Its timeout is
+only a failure boundary; it is not a settlement delay. A focused React case
+repeats 25 accepted changes while preserving separate event, quantity, and
+computed-total assertions.
+
 The raw record is
 `benchmarks/dx/stateful-form-control/evidence.json`; its parent-contract record
 is `benchmarks/dx/evidence/stateful-form-control-2026-07-12.json`. These records

--- a/tests/dx-stateful-form-control.spec.ts
+++ b/tests/dx-stateful-form-control.spec.ts
@@ -85,6 +85,25 @@ describe.each([
   });
 });
 
+test('the React bridge settles every accepted quantity against its rendered ShadowRoot output', async () => {
+  const control = document.createElement(reactQuantityTag) as TestControl;
+  control.product = product;
+  control.value = 1;
+  document.body.append(control);
+  await settled(control);
+
+  const changes: QuantityChange[] = [];
+  control.addEventListener('quantity-change', (event) => changes.push((event as CustomEvent<QuantityChange>).detail));
+  for (let iteration = 0; iteration < 25; iteration += 1) {
+    const quantity = (iteration % 5) + 1;
+    expect(control.setQuantity(quantity)).toBe(true);
+    expect(changes.at(-1)).toEqual({ productId: product.id, quantity });
+    await settled(control);
+    expect(control.shadowRoot?.querySelector('output')?.textContent).toBe(String(quantity));
+    expect(control.shadowRoot?.querySelector('strong')?.textContent).toBe(`Total €${(quantity * product.price).toFixed(2)}`);
+  }
+});
+
 test('the retained Gluon class and functional comparator tags hydrate their exact server DOM', async () => {
   for (const [tagName, definition] of [
     [gluonClassTag, ClassQuantityControl],
@@ -178,4 +197,34 @@ async function settled(control: TestControl): Promise<void> {
   await control.updateComplete;
   await nextTick();
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  if (!control.isConnected) return;
+  await renderedQuantity(control, control.quantity);
+}
+
+async function renderedQuantity(control: TestControl, quantity: number): Promise<void> {
+  const expectedOutput = String(quantity);
+  const expectedTotal = `Total €${(quantity * control.product.price).toFixed(2)}`;
+  const isReady = (): boolean => control.shadowRoot?.querySelector('output')?.textContent === expectedOutput
+    && control.shadowRoot?.querySelector('strong')?.textContent === expectedTotal;
+  if (isReady()) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const observer = new MutationObserver(() => {
+      if (!isReady()) return;
+      window.clearTimeout(deadline);
+      observer.disconnect();
+      resolve();
+    });
+    const deadline = window.setTimeout(() => {
+      observer.disconnect();
+      reject(new Error(`Timed out waiting for rendered quantity ${expectedOutput} and ${expectedTotal}.`));
+    }, 5_000);
+    observer.observe(control.shadowRoot!, { childList: true, characterData: true, subtree: true });
+
+    if (isReady()) {
+      window.clearTimeout(deadline);
+      observer.disconnect();
+      resolve();
+    }
+  });
 }


### PR DESCRIPTION
Closes #128.

## Root cause

The retained React autonomous-element bridge dispatches an accepted quantity-change event synchronously, then schedules the React 19.2.7 root.render() commit. The previous shared settlement helper waited one animation frame, which is not a React commit signal. PR #124 WebKit and PR #127 Chromium therefore recorded the exact quantity-2 event while the ShadowRoot output still rendered quantity 1.

## Changes

- observe the connected control ShadowRoot until the exact accepted quantity and computed total are both rendered
- check readiness before and after MutationObserver registration so a commit cannot be missed
- use the five-second deadline only as a missing-commit failure boundary, never as a settlement delay
- retain the original exact event and ShadowRoot assertions and add a focused 25-update React event/render regression
- document the React scheduling boundary and deterministic browser-gate contract

No runtime or public API code changed, so no changelog entry is required.

## Verification

- unchanged baseline: Chromium 20/20 fresh processes and WebKit 20/20 fresh processes passed locally; the retained CI failures are the pre-fix reproduction evidence
- fixed Chromium: 20/20 fresh processes, 160/160 focused T4 tests
- fixed WebKit: 20/20 fresh processes, 160/160 focused T4 tests
- full browser matrix: Chromium, Firefox, and WebKit each passed 34 files / 238 core browser tests plus Router 5/5, test-utils 14/14, Devtools 6/6, Playground 2/2
- SSR: 21/21
- stateful-control comparison validator: PASS
- language-server diagnostics: 12/12
- compiler/Vite diagnostics: 8/8
- full production build: PASS, including 575 API examples and 619 documentation pages
- npm run check: PASS, including 20/20 starter applications, 5/5 component kinds, 624 documentation pages, 17 release packages, and 36 schema-valid SBOMs

Pull-request CI remains the final approval gate for this draft.