### PR TITLE
Add verified npm package bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- A machine-validated, owner-controlled npm bootstrap contract that produces
+  minimal non-runtime archives for all 17 package records, keeps the bootstrap
+  version off `latest`, rejects long-lived publication tokens, and makes the
+  later trusted publisher verify the exact bootstrap version.
 - GLUON GOODS production dogfooding for official Button, Icon, Input, Label,
   and FormField components plus app-local brand presets, a repeated delivery
   Molecule, a real checkout Organism, target-owned CSR/SSR/hydration/static

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -253,6 +253,14 @@ trusted-publisher bindings, recovery owners, and account multi-factor
 authentication. Existing package records are mandatory because npm does not
 allow trusted publishers to bootstrap brand-new package names.
 
+The package-record bootstrap is a distinct, owner-controlled operation. It
+publishes the minimal `0.0.0-bootstrap.0` placeholder under the
+`gluon-bootstrap` dist-tag with interactive 2FA, no `latest`, and no provenance
+claim. Each archive contains only its manifest, bootstrap notice, and MIT
+license; it exports no implementation. The executable release contract,
+artifact builder, and bootstrap publisher verify that boundary and make partial
+publication recoverable without replacing an immutable matching version.
+
 ## Supply-chain evidence
 
 Public release jobs use GitHub-hosted runners, minimal job permissions, and

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,10 +7,12 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-Publication remains blocked while the repository is private and npm scope
-control is unverified. In that state every package stays `private: true`, uses
-the documentation version `0.0.0`, and keeps release work under `Unreleased`.
-This is enforced by:
+Publication remains blocked while the machine-readable package contract records
+`publicationState: blocked` and `scopeControl: unverified`. In that state every
+package stays `private: true`, uses the documentation version `0.0.0`, and keeps
+release work under `Unreleased`. External setup work does not make the source
+tree releasable until every owner-controlled prerequisite has been verified and
+the reviewed release-cut PR changes those fields together. This is enforced by:
 
 ```sh
 npm run check:release-contract
@@ -107,6 +109,61 @@ that commit, strict validation permits only those two evidence files to change.
 
 Do not change `package-contract.json` from `blocked`/`unverified` to
 `ready`/`verified` until those facts have been checked by an owner.
+
+## Owner-controlled package-record bootstrap
+
+npm package settings expose trusted-publisher configuration only after the
+package record exists. The one-time bootstrap therefore publishes a minimal
+`0.0.0-bootstrap.0` placeholder for every package under the
+`gluon-bootstrap` dist-tag. These placeholders contain only `package.json`,
+`README.md`, and `LICENSE`: they expose no runtime, executable, types, exports,
+dependencies, or supported API. They do not use provenance, because this is an
+interactive owner publication rather than the protected release workflow, and
+they must never receive `latest`.
+
+Prepare and inspect the deterministic allowlisted archives from clean `main`:
+
+```sh
+npm ci --ignore-scripts
+npm run check:release-bootstrap
+npm run release:bootstrap:artifacts
+cat .tmp/npm-bootstrap/bootstrap-evidence.json
+cat .tmp/npm-bootstrap/SHA256SUMS
+for archive in .tmp/npm-bootstrap/packages/*.tgz; do
+  tar -tzf "$archive"
+done
+npm run release:bootstrap:publish -- --dry-run
+```
+
+The builder records the exact source commit, archive integrity, SHA-1, SHA-256,
+and file allowlist for all 17 packages. Review every name and archive before the
+irreversible step. The publisher rejects `NPM_TOKEN` and `NODE_AUTH_TOKEN`, an
+artifact set that is not byte-identical to an independent rebuild, a dirty or
+non-`main` checkout, a source commit that is not the exact current
+`origin/main`, a user who is not an npm organization owner, a conflicting
+existing package record, any unexpected `latest`, and a rerun whose registry
+integrity differs from the reviewed archive.
+
+The npm owner then runs this command in an interactive terminal and completes
+the registry's 2FA challenges without copying credentials or one-time codes
+into logs, issues, or chat:
+
+```sh
+npm run release:bootstrap:publish -- --confirm-owner-controlled-bootstrap
+```
+
+A matching partial run is recoverable: already-published immutable bootstrap
+versions are verified and skipped, while missing records continue. After all
+records exist, confirm that each package maps only `gluon-bootstrap` to
+`0.0.0-bootstrap.0` and has no `latest` tag.
+
+For each package, configure npm Trusted Publishing from its package settings
+with GitHub Actions, repository owner `marcmalerei`, repository `gluon`,
+workflow filename `release.yml`, environment `npm`, and the `npm publish`
+allowed action required by this repository's workflow. npm does not validate
+these coordinates when they are saved, so review them exactly. Configure and
+verify all 17 bindings before restricting traditional token publishing; no
+long-lived publication token may be added to GitHub.
 
 ## Release-candidate commit
 

--- a/package.json
+++ b/package.json
@@ -159,15 +159,18 @@
     "check:shop-performance": "npm run build:core && npm run build:compiler && npm run build:vite && npm run benchmark:shop-flow",
     "check:budgets": "npm run build:shop && npm run check:quality-budgets",
     "check:docs": "npm run typecheck:docs && npm run build:docs && node scripts/validate-docs.mjs",
+    "release:bootstrap:artifacts": "node scripts/build-npm-bootstrap-artifacts.mjs",
+    "release:bootstrap:publish": "node scripts/publish-npm-bootstrap.mjs --directory .tmp/npm-bootstrap",
     "release:validate": "node scripts/validate-release-contract.mjs",
     "release:artifacts": "node scripts/build-release-artifacts.mjs",
     "release:compare-artifacts": "node scripts/compare-release-artifacts.mjs",
     "release:finalize-assets": "node scripts/finalize-release-assets.mjs",
     "release:publish": "node scripts/publish-release.mjs --directory .tmp/release",
     "release:verify-registry": "node scripts/verify-registry-release.mjs",
+    "check:release-bootstrap": "node scripts/build-npm-bootstrap-artifacts.mjs --check",
     "check:release-contract": "node scripts/validate-release-contract.mjs",
     "check:release-artifacts": "node scripts/build-release-artifacts.mjs --check-state",
-    "check": "npm run typecheck && npm run check:shop-boundaries && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run build && npm run check:quality-budgets && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:diagnostics && npm run check:template-composition && npm run check:stateful-control-comparison && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-contract && npm run check:release-artifacts"
+    "check": "npm run typecheck && npm run check:shop-boundaries && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run build && npm run check:quality-budgets && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:diagnostics && npm run check:template-composition && npm run check:stateful-control-comparison && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-bootstrap && npm run check:release-contract && npm run check:release-artifacts"
   },
   "devDependencies": {
     "@cyclonedx/cdxgen": "12.7.1",

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -8,6 +8,19 @@
   "artifactDirectory": ".tmp/release",
   "manualEvidencePath": "release/evidence/{version}.json",
   "compatibilityManifestPath": "release/compatibility/{version}.json",
+  "bootstrap": {
+    "version": "0.0.0-bootstrap.0",
+    "artifactDirectory": ".tmp/npm-bootstrap",
+    "distTag": "gluon-bootstrap",
+    "access": "public",
+    "identity": "owner-interactive-2fa",
+    "latestAllowed": false,
+    "packageFiles": [
+      "package.json",
+      "README.md",
+      "LICENSE"
+    ]
+  },
   "spdxSchema": {
     "path": "release/spdx-2.3.schema.json",
     "source": "https://raw.githubusercontent.com/spdx/spdx-spec/44ab76293754df4af5af700fd4abd5453b866c86/schemas/spdx-schema.json",

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -13,6 +13,7 @@
     "artifactDirectory",
     "manualEvidencePath",
     "compatibilityManifestPath",
+    "bootstrap",
     "spdxSchema",
     "artifacts",
     "publication",
@@ -28,6 +29,28 @@
     "artifactDirectory": { "const": ".tmp/release" },
     "manualEvidencePath": { "const": "release/evidence/{version}.json" },
     "compatibilityManifestPath": { "const": "release/compatibility/{version}.json" },
+    "bootstrap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "artifactDirectory", "distTag", "access", "identity", "latestAllowed", "packageFiles"],
+      "properties": {
+        "version": { "const": "0.0.0-bootstrap.0" },
+        "artifactDirectory": { "const": ".tmp/npm-bootstrap" },
+        "distTag": { "const": "gluon-bootstrap" },
+        "access": { "const": "public" },
+        "identity": { "const": "owner-interactive-2fa" },
+        "latestAllowed": { "const": false },
+        "packageFiles": {
+          "type": "array",
+          "prefixItems": [
+            { "const": "package.json" },
+            { "const": "README.md" },
+            { "const": "LICENSE" }
+          ],
+          "items": false
+        }
+      }
+    },
     "spdxSchema": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/build-npm-bootstrap-artifacts.mjs
+++ b/scripts/build-npm-bootstrap-artifacts.mjs
@@ -1,0 +1,174 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { basename, resolve } from 'node:path';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+const execFile = promisify(execFileCallback);
+const root = resolve(import.meta.dirname, '..');
+const packageContract = await readJson('package-contract.json');
+const releaseContract = await readJson('release/release-contract.json');
+const bootstrap = releaseContract.bootstrap;
+const check = process.argv.includes('--check');
+const requestedOutput = option('--output');
+const allowed = new Set(['--check', '--output', requestedOutput]);
+
+if (process.argv.slice(2).some((argument) => argument !== undefined && !allowed.has(argument))) {
+  throw new Error('Usage: node scripts/build-npm-bootstrap-artifacts.mjs [--output <directory>] [--check]');
+}
+
+const output = resolve(root, requestedOutput ?? (check ? '.tmp/npm-bootstrap-check' : bootstrap.artifactDirectory));
+const sourceOutput = resolve(output, 'sources');
+const packageOutput = resolve(output, 'packages');
+const expectedFiles = [...bootstrap.packageFiles].sort();
+const rootManifest = await readJson('package.json');
+const sourceCommit = (await run('git', ['rev-parse', 'HEAD'])).trim();
+
+await rm(output, { recursive: true, force: true });
+await mkdir(sourceOutput, { recursive: true });
+await mkdir(packageOutput, { recursive: true });
+
+const packages = [];
+for (const entry of packageContract.packages) {
+  const safeName = fileSafe(entry.name);
+  const directory = resolve(sourceOutput, safeName);
+  await mkdir(directory, { recursive: true });
+
+  const manifest = bootstrapManifest(entry, rootManifest);
+  await writeJson(resolve(directory, 'package.json'), manifest);
+  await writeFile(resolve(directory, 'README.md'), bootstrapReadme(entry.name), 'utf8');
+  await copyFile(resolve(root, 'LICENSE'), resolve(directory, 'LICENSE'));
+
+  const [packed] = JSON.parse(await run('npm', [
+    'pack',
+    '--json',
+    '--ignore-scripts',
+    '--pack-destination', packageOutput,
+  ], { cwd: directory }));
+  if (!packed?.filename || !Array.isArray(packed.files)) {
+    throw new Error(`npm pack returned invalid bootstrap output for ${entry.name}.`);
+  }
+  const actualFiles = packed.files.map(({ path }) => path).sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+    throw new Error(`${entry.name} bootstrap archive contains ${actualFiles.join(', ')}; expected ${expectedFiles.join(', ')}.`);
+  }
+
+  const archive = resolve(packageOutput, packed.filename);
+  const packedManifest = JSON.parse(await run('tar', ['-xOf', archive, 'package/package.json']));
+  validatePackedManifest(entry.name, packedManifest);
+  packages.push({
+    name: entry.name,
+    version: bootstrap.version,
+    filename: packed.filename,
+    integrity: packed.integrity,
+    shasum: packed.shasum,
+    sha256: sha256(await readFile(archive)),
+    files: actualFiles,
+  });
+}
+
+const evidence = {
+  schemaVersion: 1,
+  releaseGroup: releaseContract.releaseGroup,
+  sourceCommit,
+  version: bootstrap.version,
+  distTag: bootstrap.distTag,
+  access: bootstrap.access,
+  identity: bootstrap.identity,
+  latestAllowed: bootstrap.latestAllowed,
+  packages,
+};
+await writeJson(resolve(output, 'bootstrap-evidence.json'), evidence);
+
+const checksumLines = [];
+for (const path of await allFiles(output)) {
+  if (basename(path) === 'SHA256SUMS' || path.includes(`${resolve(output, 'sources')}/`)) continue;
+  checksumLines.push(`${sha256(await readFile(path))}  ${path.slice(output.length + 1)}`);
+}
+await writeFile(resolve(output, 'SHA256SUMS'), `${checksumLines.sort().join('\n')}\n`, 'utf8');
+
+if (check) await rm(output, { recursive: true, force: true });
+console.log(`${check ? 'validated' : 'built'} ${packages.length} minimal npm bootstrap archives at ${check ? bootstrap.artifactDirectory : output}`);
+
+function bootstrapManifest(entry, rootPackage) {
+  const repository = {
+    type: 'git',
+    url: rootPackage.repository.url,
+    ...(entry.directory === '.' ? {} : { directory: entry.directory }),
+  };
+  return {
+    name: entry.name,
+    version: bootstrap.version,
+    description: `Bootstrap package record for ${entry.name}; contains no supported Gluon implementation.`,
+    private: false,
+    license: 'MIT',
+    repository,
+    homepage: rootPackage.homepage,
+    bugs: rootPackage.bugs,
+    files: ['README.md', 'LICENSE'],
+    publishConfig: {
+      access: bootstrap.access,
+      tag: bootstrap.distTag,
+    },
+  };
+}
+
+function bootstrapReadme(name) {
+  return `# ${name}\n\nThis package version only establishes the npm package record required by Gluon's trusted-publishing release workflow.\n\nIt contains no runtime, build integration, executable, or supported public API. Do not install this bootstrap version. The first supported release is planned as \`1.0.0\`.\n\nThe bootstrap version is published only under the \`${bootstrap.distTag}\` dist-tag and must never be assigned \`latest\`. Reviewed source and release evidence live at https://github.com/marcmalerei/gluon.\n`;
+}
+
+function validatePackedManifest(name, manifest) {
+  if (manifest.name !== name || manifest.version !== bootstrap.version || manifest.private !== false) {
+    throw new Error(`${name} bootstrap manifest does not preserve its exact public name, version, and private=false boundary.`);
+  }
+  if (manifest.publishConfig?.access !== bootstrap.access || manifest.publishConfig?.tag !== bootstrap.distTag) {
+    throw new Error(`${name} bootstrap manifest does not preserve the contracted access and dist-tag.`);
+  }
+  for (const forbidden of ['main', 'module', 'types', 'exports', 'bin', 'scripts', 'dependencies', 'peerDependencies', 'optionalDependencies']) {
+    if (forbidden in manifest) throw new Error(`${name} bootstrap manifest must not expose ${forbidden}.`);
+  }
+  if (manifest.publishConfig?.provenance !== undefined) {
+    throw new Error(`${name} bootstrap manifest must not claim automated provenance.`);
+  }
+}
+
+function fileSafe(name) {
+  return name.replace(/^@/, '').replaceAll('/', '-');
+}
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index < 0 ? undefined : process.argv[index + 1];
+}
+
+function sha256(value) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+async function allFiles(directory) {
+  const result = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) result.push(...await allFiles(path));
+    else if (entry.isFile()) result.push(path);
+  }
+  return result.sort();
+}
+
+async function run(command, args, options = {}) {
+  const { stdout } = await execFile(command, args, {
+    cwd: options.cwd ?? root,
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(resolve(root, path), 'utf8'));
+}
+
+async function writeJson(path, value) {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}

--- a/scripts/publish-npm-bootstrap.mjs
+++ b/scripts/publish-npm-bootstrap.mjs
@@ -1,0 +1,179 @@
+import { execFile as execFileCallback, execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFile, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import process from 'node:process';
+
+const execFile = promisify(execFileCallback);
+const root = resolve(import.meta.dirname, '..');
+const releaseContract = await readJson('release/release-contract.json');
+const packageContract = await readJson('package-contract.json');
+const bootstrap = releaseContract.bootstrap;
+const directory = resolve(root, option('--directory') ?? bootstrap.artifactDirectory);
+const dryRun = process.argv.includes('--dry-run');
+const confirmed = process.argv.includes('--confirm-owner-controlled-bootstrap');
+const allowed = new Set([
+  '--directory',
+  option('--directory'),
+  '--dry-run',
+  '--confirm-owner-controlled-bootstrap',
+]);
+
+if (process.argv.slice(2).some((argument) => argument !== undefined && !allowed.has(argument))) {
+  throw new Error('Usage: node scripts/publish-npm-bootstrap.mjs [--directory <directory>] [--dry-run] [--confirm-owner-controlled-bootstrap]');
+}
+if (process.env.NPM_TOKEN || process.env.NODE_AUTH_TOKEN) {
+  throw new Error('Long-lived npm publication tokens are prohibited for the owner-controlled bootstrap.');
+}
+if (!dryRun && !confirmed) {
+  throw new Error('Bootstrap publication is immutable; pass --confirm-owner-controlled-bootstrap after reviewing every archive.');
+}
+
+const evidence = JSON.parse(await readFile(resolve(directory, 'bootstrap-evidence.json'), 'utf8'));
+validateEvidence(evidence);
+await verifyChecksums();
+await reproduceArtifacts(evidence);
+
+if (!dryRun) {
+  await requireCleanMain(evidence.sourceCommit);
+  await requireNpmOwner();
+}
+
+const registryState = new Map();
+if (!dryRun) {
+  for (const entry of evidence.packages) {
+    const packument = await registryPackument(entry.name);
+    if (packument && !packument.versions?.[bootstrap.version]) {
+      throw new Error(`${entry.name} already exists without the reviewed ${bootstrap.version} bootstrap record; stop before publishing.`);
+    }
+    if (packument) verifyBootstrapMetadata(entry, packument);
+    registryState.set(entry.name, packument);
+  }
+}
+
+for (const entry of evidence.packages) {
+  if (!dryRun && registryState.get(entry.name)) {
+    console.log(`verified existing ${entry.name}@${bootstrap.version}; immutable matching bootstrap skipped`);
+    continue;
+  }
+  const args = [
+    'publish',
+    resolve(directory, 'packages', entry.filename),
+    '--access', bootstrap.access,
+    '--tag', bootstrap.distTag,
+    '--ignore-scripts',
+  ];
+  if (dryRun) args.push('--dry-run');
+  execFileSync('npm', args, { cwd: root, stdio: 'inherit' });
+  console.log(`${dryRun ? 'validated' : 'published'} ${entry.name}@${bootstrap.version}`);
+  if (!dryRun) verifyBootstrapMetadata(entry, await waitForRegistry(entry.name));
+}
+
+console.log(`${dryRun ? 'bootstrap dry-run valid' : 'bootstrap publication verified'}: ${evidence.packages.length} packages at ${bootstrap.version} under ${bootstrap.distTag}; latest ${dryRun ? 'forbidden by contract' : 'absent'}`);
+
+function validateEvidence(evidenceValue) {
+  const expectedNames = packageContract.packages.map(({ name }) => name);
+  const actualNames = evidenceValue.packages?.map(({ name }) => name) ?? [];
+  if (evidenceValue.version !== bootstrap.version
+    || evidenceValue.distTag !== bootstrap.distTag
+    || evidenceValue.identity !== bootstrap.identity
+    || evidenceValue.latestAllowed !== false
+    || JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
+    throw new Error('Bootstrap evidence does not match the reviewed release and package contracts.');
+  }
+}
+
+async function requireCleanMain(sourceCommit) {
+  const branch = (await run('git', ['branch', '--show-current'])).trim();
+  const head = (await run('git', ['rev-parse', 'HEAD'])).trim();
+  const upstream = (await run('git', ['rev-parse', 'origin/main'])).trim();
+  const dirty = (await run('git', ['status', '--porcelain'])).trim();
+  if (branch !== 'main' || head !== sourceCommit || head !== upstream || dirty) {
+    throw new Error('Bootstrap publication requires clean main at the exact reviewed origin/main commit used to build the artifacts.');
+  }
+}
+
+async function reproduceArtifacts(reviewedEvidence) {
+  const reproduced = resolve(root, '.tmp/npm-bootstrap-reproduced');
+  try {
+    await run('node', ['scripts/build-npm-bootstrap-artifacts.mjs', '--output', reproduced]);
+    const reproducedEvidence = JSON.parse(await readFile(resolve(reproduced, 'bootstrap-evidence.json'), 'utf8'));
+    const reviewedChecksums = await readFile(resolve(directory, 'SHA256SUMS'), 'utf8');
+    const reproducedChecksums = await readFile(resolve(reproduced, 'SHA256SUMS'), 'utf8');
+    if (JSON.stringify(reproducedEvidence) !== JSON.stringify(reviewedEvidence)
+      || reproducedChecksums !== reviewedChecksums) {
+      throw new Error('Bootstrap artifacts do not match an independent rebuild from the reviewed source commit.');
+    }
+  } finally {
+    await rm(reproduced, { recursive: true, force: true });
+  }
+}
+
+async function requireNpmOwner() {
+  const user = (await run('npm', ['whoami'])).trim();
+  const scope = packageContract.registry.scope.replace(/^@/, '');
+  const members = JSON.parse(await run('npm', ['org', 'ls', scope, '--json']));
+  if (members[user] !== 'owner') {
+    throw new Error(`${user} is not an owner of npm organization ${scope}.`);
+  }
+}
+
+async function registryPackument(name) {
+  const url = `${releaseContract.publication.registry}/${encodeURIComponent(name)}`;
+  const response = await fetch(url, { headers: { accept: 'application/json' } });
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`npm registry returned HTTP ${response.status} for ${name}.`);
+  return response.json();
+}
+
+async function waitForRegistry(name) {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const packument = await registryPackument(name);
+    if (packument?.versions?.[bootstrap.version]) return packument;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 2_000));
+  }
+  throw new Error(`${name}@${bootstrap.version} was not visible on npm after publication.`);
+}
+
+function verifyBootstrapMetadata(entry, packument) {
+  const metadata = packument.versions?.[bootstrap.version];
+  if (!metadata) throw new Error(`${entry.name} is missing ${bootstrap.version}.`);
+  if (metadata.dist?.integrity !== entry.integrity) {
+    throw new Error(`${entry.name}@${bootstrap.version} registry integrity does not match the reviewed archive.`);
+  }
+  if (packument['dist-tags']?.[bootstrap.distTag] !== bootstrap.version) {
+    throw new Error(`${entry.name} does not map ${bootstrap.distTag} to ${bootstrap.version}.`);
+  }
+  if (bootstrap.latestAllowed === false && packument['dist-tags']?.latest) {
+    throw new Error(`${entry.name} unexpectedly has latest=${packument['dist-tags'].latest} during bootstrap.`);
+  }
+}
+
+async function verifyChecksums() {
+  const manifest = await readFile(resolve(directory, 'SHA256SUMS'), 'utf8');
+  for (const line of manifest.trim().split('\n')) {
+    const match = /^([a-f0-9]{64})  (.+)$/.exec(line);
+    if (!match) throw new Error(`Invalid checksum line: ${line}`);
+    const actual = createHash('sha256').update(await readFile(resolve(directory, match[2]))).digest('hex');
+    if (actual !== match[1]) throw new Error(`Checksum mismatch for ${match[2]}.`);
+  }
+}
+
+function option(name) {
+  const index = process.argv.indexOf(name);
+  return index < 0 ? undefined : process.argv[index + 1];
+}
+
+async function run(command, args) {
+  const { stdout } = await execFile(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(resolve(root, path), 'utf8'));
+}

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -63,13 +63,13 @@ if (!dryRun) {
 }
 
 async function requireExistingPackage(name) {
-  try {
-    await execFile('npm', ['view', name, 'name', '--json'], { cwd: root, encoding: 'utf8', maxBuffer: 1024 * 1024 });
-  } catch (error) {
-    if (npmNotFound(error)) {
-      throw new Error(`${name} has no existing npm package record. Trusted publishing cannot bootstrap a new package; complete the owner-controlled bootstrap before running this workflow.`);
-    }
-    throw error;
+  const bootstrapVersion = releaseContract.bootstrap.version;
+  const metadata = await registryMetadata(name, bootstrapVersion);
+  if (!metadata) {
+    throw new Error(`${name} has no reviewed ${bootstrapVersion} npm bootstrap record. Trusted publishing cannot bootstrap a new package; complete the owner-controlled bootstrap before running this workflow.`);
+  }
+  if (metadata.name !== name || metadata.version !== bootstrapVersion) {
+    throw new Error(`${name} npm bootstrap metadata does not match ${name}@${bootstrapVersion}.`);
   }
 }
 

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -22,11 +22,14 @@ const spdxSchemaDigest = createHash('sha256')
   .update(await readFile(resolve(root, releaseContract.spdxSchema.path)))
   .digest('hex');
 const packageContract = await readJson('package-contract.json');
+const rootManifest = await readJson('package.json');
 const versions = await readJson('docs-site/versions.json');
 const lockfile = await readJson('package-lock.json');
 const rootChangelog = await readFile(resolve(root, 'CHANGELOG.md'), 'utf8');
 const workflow = await readFile(resolve(root, '.github/workflows/release.yml'), 'utf8');
 const publishScript = await readFile(resolve(root, 'scripts/publish-release.mjs'), 'utf8');
+const bootstrapBuildScript = await readFile(resolve(root, 'scripts/build-npm-bootstrap-artifacts.mjs'), 'utf8');
+const bootstrapPublishScript = await readFile(resolve(root, 'scripts/publish-npm-bootstrap.mjs'), 'utf8');
 const hostingScript = await readFile(resolve(root, 'scripts/verify-release-hosting.mjs'), 'utf8');
 const officialNames = new Set(packageContract.packages.map((entry) => entry.name));
 const manualEvidenceSchema = await readJson('release/manual-evidence.schema.json');
@@ -97,6 +100,7 @@ const result = {
   version: currentVersion,
   candidate: candidateVersion ?? null,
   packagesPrivate,
+  bootstrap: releaseContract.bootstrap,
   publicationState: packageContract.registry.publicationState,
   scopeControl: packageContract.registry.scopeControl,
   externalPrerequisites: releaseContract.externalPrerequisites,
@@ -121,6 +125,16 @@ function validateReleaseContract() {
   if (releaseContract.publication?.stagingDistTagPrefix !== 'gluon-staging-v'
     || releaseContract.publication?.promotion !== 'interactive-2fa') {
     throw new Error('Release publication must stage under a non-latest dist-tag and require interactive 2FA promotion.');
+  }
+  if (!prereleaseVersion(releaseContract.bootstrap?.version)
+    || releaseContract.bootstrap.version === releaseContract.targetVersion
+    || releaseContract.bootstrap.distTag === releaseContract.publication.distTag
+    || releaseContract.bootstrap.latestAllowed !== false
+    || releaseContract.bootstrap.identity !== 'owner-interactive-2fa') {
+    throw new Error('npm bootstrap must use a distinct prerelease, a non-latest dist-tag, and owner-controlled interactive 2FA.');
+  }
+  if (JSON.stringify(releaseContract.bootstrap.packageFiles) !== JSON.stringify(['package.json', 'README.md', 'LICENSE'])) {
+    throw new Error('npm bootstrap archives must contain only package.json, README.md, and LICENSE.');
   }
   if (!releaseContract.spdxSchema.source.includes(`/${releaseContract.spdxSchema.sourceCommit}/`)) {
     throw new Error('SPDX schema source URL must pin the declared source commit.');
@@ -315,6 +329,29 @@ function validateWorkflow() {
   for (const required of ["'publish'", "'--provenance'", "'--access', 'public'", "'--tag', stagingTag", 'requireExistingPackage']) {
     if (!publishScript.includes(required)) throw new Error(`Release publisher is missing ${required}.`);
   }
+  if (!publishScript.includes('releaseContract.bootstrap.version')) {
+    throw new Error('Release publisher must verify the exact contracted bootstrap package record.');
+  }
+  for (const [name, command] of Object.entries({
+    'release:bootstrap:artifacts': 'node scripts/build-npm-bootstrap-artifacts.mjs',
+    'release:bootstrap:publish': 'node scripts/publish-npm-bootstrap.mjs --directory .tmp/npm-bootstrap',
+    'check:release-bootstrap': 'node scripts/build-npm-bootstrap-artifacts.mjs --check',
+  })) {
+    if (rootManifest.scripts?.[name] !== command) throw new Error(`package.json must define ${name} as ${command}.`);
+  }
+  for (const required of ['bootstrap.packageFiles', 'publishConfig', "'README.md'", "'LICENSE'"]) {
+    if (!bootstrapBuildScript.includes(required)) throw new Error(`npm bootstrap builder is missing ${required}.`);
+  }
+  for (const required of [
+    'confirm-owner-controlled-bootstrap',
+    'NPM_TOKEN',
+    'NODE_AUTH_TOKEN',
+    "'--tag', bootstrap.distTag",
+    'bootstrap.latestAllowed === false',
+    'requireCleanMain',
+    'requireNpmOwner',
+    'reproduceArtifacts',
+  ]) if (!bootstrapPublishScript.includes(required)) throw new Error(`npm bootstrap publisher is missing ${required}.`);
   for (const match of workflow.matchAll(/uses:\s+[^\s@]+@([^\s#]+)/g)) {
     if (!/^[a-f0-9]{40}$/.test(match[1])) {
       throw new Error(`Release workflow action ref ${match[1]} is not an immutable commit SHA.`);
@@ -330,6 +367,10 @@ function validateWorkflow() {
 
 function stableVersion(value) {
   return /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(value);
+}
+
+function prereleaseVersion(value) {
+  return /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(value ?? '');
 }
 
 function escapeRegExp(value) {


### PR DESCRIPTION
## Summary

- define the one-time `0.0.0-bootstrap.0` / `gluon-bootstrap` package-record contract for all 17 packages
- generate reproducible three-file placeholder archives and enforce a byte-identical independent rebuild
- add an owner-only interactive publisher that rejects long-lived tokens, dirty/non-main sources, conflicting registry state, unexpected `latest`, and integrity drift
- require the protected release publisher to verify the exact bootstrap version
- document the bootstrap and Trusted Publishing setup in the release runbook and governance ADR

This delivers the npm package-record bootstrap slice of #41. The epic remains open for package publication, Trusted Publisher bindings, recovery ownership, GitHub environment/tag protection, release-cut evidence, and the 1.0.0 release.

## Verification

- `npm ci --ignore-scripts`
- `npm run build`
- `npm run check`
- `npm run release:bootstrap:artifacts`
- `npm run release:bootstrap:publish -- --dry-run`
- two consecutive bootstrap artifact builds produced the same `SHA256SUMS`
- negative gates verified for token environment variables, missing confirmation, and non-main publication