### PR TITLE
Handle npm bootstrap registry convergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 ### Added
 
 - A machine-validated, owner-controlled npm bootstrap contract that produces
-  minimal non-runtime archives for all 17 package records, keeps the bootstrap
-  version off `latest`, rejects long-lived publication tokens, and makes the
-  later trusted publisher verify the exact bootstrap version.
+  minimal non-runtime archives for all 17 package records, restricts any
+  registry-created temporary `latest` tag to a reviewed bootstrap placeholder,
+  records the exact superseded first package attempt, waits for registry
+  convergence, rejects long-lived publication tokens, and makes the later
+  trusted publisher verify the exact bootstrap version.
 - GLUON GOODS production dogfooding for official Button, Icon, Input, Label,
   and FormField components plus app-local brand presets, a repeated delivery
   Molecule, a real checkout Organism, target-owned CSR/SSR/hydration/static

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -198,8 +198,10 @@ Gluon follows Semantic Versioning:
   require a patch release.
 - A released version is immutable and is never rebuilt or republished. A defect
   is fixed in a new version.
-- `latest` points only to stable releases, `next` to release candidates or other
-  planned prereleases, and `canary` to explicitly unsupported commit previews.
+- After the first supported release, `latest` points only to stable releases,
+  `next` to release candidates or other planned prereleases, and `canary` to
+  explicitly unsupported commit previews. Before that release, npm may retain
+  only the exact reviewed bootstrap placeholders described below on `latest`.
 - The latest major and its latest minor receive regular fixes. The latest minor
   of the immediately preceding major receives critical security fixes. Older
   lines are unsupported unless a release notice explicitly extends support.
@@ -254,12 +256,19 @@ authentication. Existing package records are mandatory because npm does not
 allow trusted publishers to bootstrap brand-new package names.
 
 The package-record bootstrap is a distinct, owner-controlled operation. It
-publishes the minimal `0.0.0-bootstrap.0` placeholder under the
-`gluon-bootstrap` dist-tag with interactive 2FA, no `latest`, and no provenance
-claim. Each archive contains only its manifest, bootstrap notice, and MIT
-license; it exports no implementation. The executable release contract,
-artifact builder, and bootstrap publisher verify that boundary and make partial
-publication recoverable without replacing an immutable matching version.
+publishes the minimal `0.0.0-bootstrap.1` placeholder under the
+`gluon-bootstrap` dist-tag with interactive 2FA and no provenance claim. npm
+materialized `latest` while creating the first package record even though the
+publish used a non-`latest` tag, and rejected removal of that initial tag. Until
+the first supported release replaces it, `latest` may therefore be absent or
+point only to the current reviewed bootstrap or an exact contracted predecessor.
+The failed initial contract attempt created only
+`@gluonjs/reactivity@0.0.0-bootstrap.0`; its exact integrity and SHA-1 are
+retained as a superseded record. Each bootstrap archive contains only its
+manifest, bootstrap notice, and MIT license; it exports no implementation. The
+executable release contract, artifact builder, and bootstrap publisher verify
+that boundary and make partial publication recoverable without replacing an
+immutable matching version.
 
 ## Supply-chain evidence
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -114,12 +114,23 @@ Do not change `package-contract.json` from `blocked`/`unverified` to
 
 npm package settings expose trusted-publisher configuration only after the
 package record exists. The one-time bootstrap therefore publishes a minimal
-`0.0.0-bootstrap.0` placeholder for every package under the
+`0.0.0-bootstrap.1` placeholder for every package under the
 `gluon-bootstrap` dist-tag. These placeholders contain only `package.json`,
 `README.md`, and `LICENSE`: they expose no runtime, executable, types, exports,
 dependencies, or supported API. They do not use provenance, because this is an
-interactive owner publication rather than the protected release workflow, and
-they must never receive `latest`.
+interactive owner publication rather than the protected release workflow.
+
+The first live bootstrap attempt created
+`@gluonjs/reactivity@0.0.0-bootstrap.0` with the reviewed archive integrity, but
+npm also materialized `latest` for that new package record and returned HTTP
+400 when the owner tried to remove it. The public packument was unavailable for
+several minutes after the successful publish response even though npm already
+reported the package as public and owner-controlled. Because published versions
+are immutable, the corrected bootstrap is `0.0.0-bootstrap.1`; the release
+contract retains the exact integrity and SHA-1 of the superseded Reactivity
+record. Until the first supported release replaces the temporary state,
+`latest` may be absent or point only to the reviewed current bootstrap or that
+exact contracted predecessor. Any other value blocks the bootstrap.
 
 Prepare and inspect the deterministic allowlisted archives from clean `main`:
 
@@ -142,7 +153,9 @@ artifact set that is not byte-identical to an independent rebuild, a dirty or
 non-`main` checkout, a source commit that is not the exact current
 `origin/main`, a user who is not an npm organization owner, a conflicting
 existing package record, any unexpected `latest`, and a rerun whose registry
-integrity differs from the reviewed archive.
+integrity differs from the reviewed archive. Registry visibility is allowed up
+to ten minutes after a successful publish before the operation stops; this wait
+does not weaken the exact integrity and dist-tag checks.
 
 The npm owner then runs this command in an interactive terminal and completes
 the registry's 2FA challenges without copying credentials or one-time codes
@@ -154,8 +167,11 @@ npm run release:bootstrap:publish -- --confirm-owner-controlled-bootstrap
 
 A matching partial run is recoverable: already-published immutable bootstrap
 versions are verified and skipped, while missing records continue. After all
-records exist, confirm that each package maps only `gluon-bootstrap` to
-`0.0.0-bootstrap.0` and has no `latest` tag.
+records exist, confirm that every package maps `gluon-bootstrap` to
+`0.0.0-bootstrap.1`. Any `latest` tag must resolve only to that reviewed
+bootstrap version or, for Reactivity, its exact contracted
+`0.0.0-bootstrap.0` predecessor. The first supported release replaces this
+temporary `latest` state for the complete package train.
 
 For each package, configure npm Trusted Publishing from its package settings
 with GitHub Actions, repository owner `marcmalerei`, repository `gluon`,

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -9,12 +9,20 @@
   "manualEvidencePath": "release/evidence/{version}.json",
   "compatibilityManifestPath": "release/compatibility/{version}.json",
   "bootstrap": {
-    "version": "0.0.0-bootstrap.0",
+    "version": "0.0.0-bootstrap.1",
     "artifactDirectory": ".tmp/npm-bootstrap",
     "distTag": "gluon-bootstrap",
     "access": "public",
     "identity": "owner-interactive-2fa",
-    "latestAllowed": false,
+    "latestPolicy": "absent-or-reviewed-bootstrap-until-first-supported-release",
+    "supersededRecords": [
+      {
+        "name": "@gluonjs/reactivity",
+        "version": "0.0.0-bootstrap.0",
+        "integrity": "sha512-/WfS45xyarkObJanK4IbQsyznDR60Fte+mvik1mh2SUm29D/ns1tqrQs2b21FYdjAQFyq62z0WDENNBDJ4472w==",
+        "shasum": "9a1ca1af75878ea5aebba3ac6139ac0beee3273b"
+      }
+    ],
     "packageFiles": [
       "package.json",
       "README.md",

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -32,14 +32,31 @@
     "bootstrap": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["version", "artifactDirectory", "distTag", "access", "identity", "latestAllowed", "packageFiles"],
+      "required": ["version", "artifactDirectory", "distTag", "access", "identity", "latestPolicy", "supersededRecords", "packageFiles"],
       "properties": {
-        "version": { "const": "0.0.0-bootstrap.0" },
+        "version": { "const": "0.0.0-bootstrap.1" },
         "artifactDirectory": { "const": ".tmp/npm-bootstrap" },
         "distTag": { "const": "gluon-bootstrap" },
         "access": { "const": "public" },
         "identity": { "const": "owner-interactive-2fa" },
-        "latestAllowed": { "const": false },
+        "latestPolicy": { "const": "absent-or-reviewed-bootstrap-until-first-supported-release" },
+        "supersededRecords": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name", "version", "integrity", "shasum"],
+              "properties": {
+                "name": { "const": "@gluonjs/reactivity" },
+                "version": { "const": "0.0.0-bootstrap.0" },
+                "integrity": { "const": "sha512-/WfS45xyarkObJanK4IbQsyznDR60Fte+mvik1mh2SUm29D/ns1tqrQs2b21FYdjAQFyq62z0WDENNBDJ4472w==" },
+                "shasum": { "const": "9a1ca1af75878ea5aebba3ac6139ac0beee3273b" }
+              }
+            }
+          ],
+          "items": false
+        },
         "packageFiles": {
           "type": "array",
           "prefixItems": [

--- a/scripts/build-npm-bootstrap-artifacts.mjs
+++ b/scripts/build-npm-bootstrap-artifacts.mjs
@@ -76,7 +76,8 @@ const evidence = {
   distTag: bootstrap.distTag,
   access: bootstrap.access,
   identity: bootstrap.identity,
-  latestAllowed: bootstrap.latestAllowed,
+  latestPolicy: bootstrap.latestPolicy,
+  supersededRecords: bootstrap.supersededRecords,
   packages,
 };
 await writeJson(resolve(output, 'bootstrap-evidence.json'), evidence);
@@ -115,7 +116,7 @@ function bootstrapManifest(entry, rootPackage) {
 }
 
 function bootstrapReadme(name) {
-  return `# ${name}\n\nThis package version only establishes the npm package record required by Gluon's trusted-publishing release workflow.\n\nIt contains no runtime, build integration, executable, or supported public API. Do not install this bootstrap version. The first supported release is planned as \`1.0.0\`.\n\nThe bootstrap version is published only under the \`${bootstrap.distTag}\` dist-tag and must never be assigned \`latest\`. Reviewed source and release evidence live at https://github.com/marcmalerei/gluon.\n`;
+  return `# ${name}\n\nThis package version only establishes the npm package record required by Gluon's trusted-publishing release workflow.\n\nIt contains no runtime, build integration, executable, or supported public API. Do not install this bootstrap version. The first supported release is planned as \`1.0.0\`.\n\nThe reviewed bootstrap dist-tag is \`${bootstrap.distTag}\`. For a new package record, npm may also materialize a temporary \`latest\` tag that points to a reviewed bootstrap placeholder until the first supported release replaces it. Reviewed source and release evidence live at https://github.com/marcmalerei/gluon.\n`;
 }
 
 function validatePackedManifest(name, manifest) {

--- a/scripts/publish-npm-bootstrap.mjs
+++ b/scripts/publish-npm-bootstrap.mjs
@@ -44,16 +44,18 @@ const registryState = new Map();
 if (!dryRun) {
   for (const entry of evidence.packages) {
     const packument = await registryPackument(entry.name);
-    if (packument && !packument.versions?.[bootstrap.version]) {
-      throw new Error(`${entry.name} already exists without the reviewed ${bootstrap.version} bootstrap record; stop before publishing.`);
+    if (packument?.versions?.[bootstrap.version]) {
+      verifyBootstrapMetadata(entry, packument);
+      registryState.set(entry.name, true);
+      continue;
     }
-    if (packument) verifyBootstrapMetadata(entry, packument);
-    registryState.set(entry.name, packument);
+    if (packument) verifySupersededPackageRecord(entry.name, packument);
+    registryState.set(entry.name, false);
   }
 }
 
 for (const entry of evidence.packages) {
-  if (!dryRun && registryState.get(entry.name)) {
+  if (!dryRun && registryState.get(entry.name) === true) {
     console.log(`verified existing ${entry.name}@${bootstrap.version}; immutable matching bootstrap skipped`);
     continue;
   }
@@ -70,7 +72,7 @@ for (const entry of evidence.packages) {
   if (!dryRun) verifyBootstrapMetadata(entry, await waitForRegistry(entry.name));
 }
 
-console.log(`${dryRun ? 'bootstrap dry-run valid' : 'bootstrap publication verified'}: ${evidence.packages.length} packages at ${bootstrap.version} under ${bootstrap.distTag}; latest ${dryRun ? 'forbidden by contract' : 'absent'}`);
+console.log(`${dryRun ? 'bootstrap dry-run valid' : 'bootstrap publication verified'}: ${evidence.packages.length} packages at ${bootstrap.version} under ${bootstrap.distTag}; latest is absent or restricted to reviewed bootstrap placeholders until the first supported release`);
 
 function validateEvidence(evidenceValue) {
   const expectedNames = packageContract.packages.map(({ name }) => name);
@@ -78,7 +80,8 @@ function validateEvidence(evidenceValue) {
   if (evidenceValue.version !== bootstrap.version
     || evidenceValue.distTag !== bootstrap.distTag
     || evidenceValue.identity !== bootstrap.identity
-    || evidenceValue.latestAllowed !== false
+    || evidenceValue.latestPolicy !== bootstrap.latestPolicy
+    || JSON.stringify(evidenceValue.supersededRecords) !== JSON.stringify(bootstrap.supersededRecords)
     || JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
     throw new Error('Bootstrap evidence does not match the reviewed release and package contracts.');
   }
@@ -128,12 +131,15 @@ async function registryPackument(name) {
 }
 
 async function waitForRegistry(name) {
-  for (let attempt = 0; attempt < 10; attempt += 1) {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
     const packument = await registryPackument(name);
     if (packument?.versions?.[bootstrap.version]) return packument;
-    await new Promise((resolveDelay) => setTimeout(resolveDelay, 2_000));
+    if (attempt > 0 && attempt % 12 === 0) {
+      console.log(`waiting for npm registry visibility: ${name}@${bootstrap.version} (${attempt * 5}s)`);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 5_000));
   }
-  throw new Error(`${name}@${bootstrap.version} was not visible on npm after publication.`);
+  throw new Error(`${name}@${bootstrap.version} was not visible on npm within 10 minutes after publication.`);
 }
 
 function verifyBootstrapMetadata(entry, packument) {
@@ -145,8 +151,33 @@ function verifyBootstrapMetadata(entry, packument) {
   if (packument['dist-tags']?.[bootstrap.distTag] !== bootstrap.version) {
     throw new Error(`${entry.name} does not map ${bootstrap.distTag} to ${bootstrap.version}.`);
   }
-  if (bootstrap.latestAllowed === false && packument['dist-tags']?.latest) {
-    throw new Error(`${entry.name} unexpectedly has latest=${packument['dist-tags'].latest} during bootstrap.`);
+  const latest = packument['dist-tags']?.latest;
+  const allowedLatest = new Set([
+    bootstrap.version,
+    ...bootstrap.supersededRecords
+      .filter(({ name }) => name === entry.name)
+      .map(({ version }) => version),
+  ]);
+  if (latest && !allowedLatest.has(latest)) {
+    throw new Error(`${entry.name} unexpectedly has latest=${latest}; only reviewed bootstrap placeholders are permitted before the first supported release.`);
+  }
+}
+
+function verifySupersededPackageRecord(name, packument) {
+  const reviewed = bootstrap.supersededRecords.filter((entry) => entry.name === name);
+  const versions = Object.keys(packument.versions ?? {});
+  if (reviewed.length === 0 || versions.some((version) => !reviewed.some((entry) => entry.version === version))) {
+    throw new Error(`${name} already exists without the reviewed ${bootstrap.version} bootstrap record and is not an exact contracted predecessor; stop before publishing.`);
+  }
+  for (const entry of reviewed) {
+    const metadata = packument.versions?.[entry.version];
+    if (metadata?.dist?.integrity !== entry.integrity || metadata.dist?.shasum !== entry.shasum) {
+      throw new Error(`${name}@${entry.version} does not match the contracted superseded bootstrap record.`);
+    }
+  }
+  const latest = packument['dist-tags']?.latest;
+  if (latest && !reviewed.some((entry) => entry.version === latest)) {
+    throw new Error(`${name} has unreviewed latest=${latest} before ${bootstrap.version} publication.`);
   }
 }
 

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -129,9 +129,15 @@ function validateReleaseContract() {
   if (!prereleaseVersion(releaseContract.bootstrap?.version)
     || releaseContract.bootstrap.version === releaseContract.targetVersion
     || releaseContract.bootstrap.distTag === releaseContract.publication.distTag
-    || releaseContract.bootstrap.latestAllowed !== false
+    || releaseContract.bootstrap.latestPolicy !== 'absent-or-reviewed-bootstrap-until-first-supported-release'
     || releaseContract.bootstrap.identity !== 'owner-interactive-2fa') {
-    throw new Error('npm bootstrap must use a distinct prerelease, a non-latest dist-tag, and owner-controlled interactive 2FA.');
+    throw new Error('npm bootstrap must use a distinct prerelease, a non-latest reviewed dist-tag, the temporary bootstrap latest policy, and owner-controlled interactive 2FA.');
+  }
+  if (!releaseContract.bootstrap.supersededRecords.every((entry) => packageContract.packages.some(({ name }) => name === entry.name)
+    && entry.version !== releaseContract.bootstrap.version
+    && entry.integrity.startsWith('sha512-')
+    && /^[a-f0-9]{40}$/.test(entry.shasum))) {
+    throw new Error('Superseded npm bootstrap records must identify an official package, a distinct version, and exact registry digests.');
   }
   if (JSON.stringify(releaseContract.bootstrap.packageFiles) !== JSON.stringify(['package.json', 'README.md', 'LICENSE'])) {
     throw new Error('npm bootstrap archives must contain only package.json, README.md, and LICENSE.');
@@ -347,7 +353,8 @@ function validateWorkflow() {
     'NPM_TOKEN',
     'NODE_AUTH_TOKEN',
     "'--tag', bootstrap.distTag",
-    'bootstrap.latestAllowed === false',
+    'bootstrap.supersededRecords',
+    'waiting for npm registry visibility',
     'requireCleanMain',
     'requireNpmOwner',
     'reproduceArtifacts',


### PR DESCRIPTION
## What changed

- advance the reviewed package-record bootstrap to `0.0.0-bootstrap.1`
- retain the exact integrity and SHA-1 of the superseded `@gluonjs/reactivity@0.0.0-bootstrap.0` record
- allow `latest` only when absent or when it points to a reviewed current or contracted superseded bootstrap placeholder before the first supported release
- wait up to ten minutes for npm packument visibility after a successful publish
- update bootstrap archive notices, validation, release documentation, ADR 0002, and the changelog

## Root cause and impact

The first owner-controlled publish returned HTTP 200 and npm reported `@gluonjs/reactivity` as public and writable, but its public packument remained 404 for several minutes. npm also materialized `latest=0.0.0-bootstrap.0` while creating the record despite the non-`latest` publish tag, and returned HTTP 400 for both authenticated removal attempts. No other package was published. The immutable first archive matches the contracted predecessor digests exactly.

This change makes the partial run recoverable without replacing or misrepresenting an immutable registry version. The remaining 16 names are still unpublished until this PR is reviewed and merged.

## Verification

- `node --check` for all three changed scripts
- `npm run check:release-contract`
- `npm run check:release-bootstrap`
- two bootstrap builds with identical `SHA256SUMS` digest
- `npm run release:bootstrap:publish -- --dry-run` for all 17 corrected archives
- live registry predecessor integrity and SHA-1 comparison
- `npm run check:docs`
- `npm run check:release-artifacts`
- `npm run build`
- `npm run check`

This is another delivery slice of #41. The epic remains open for the remaining package records, trusted-publisher bindings, recovery owner, protected npm environment, release-tag ruleset, and first supported release evidence.