### PR TITLE
Adopt single-owner npm recovery governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,10 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- npm release governance now explicitly accepts `marcmalerei` as the single
+  organization owner without requiring a second owner, while retaining
+  `auth-and-writes` 2FA, linked-GitHub, separately stored recovery-code, and
+  accepted npm Support recovery-risk requirements as machine-validated gates.
 - SSR style manifests now accept named Core selections and preserve their stable
   IDs and optional hydration scopes in emitted carriers.
 - Empty Core node parts insert a single new node directly while preserving

--- a/docs-site/content/0.0.0/guides/releasing/index.md
+++ b/docs-site/content/0.0.0/guides/releasing/index.md
@@ -3,7 +3,7 @@
 The `0.0.0` documentation describes the private development line. It is not a
 published npm release and does not claim control of the `@gluonjs` scope.
 
-Gluon's release group contains 16 lockstep packages. The repository validates
+Gluon's release group contains 17 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,
 documentation version, license, changelogs, provenance settings, and protected
 workflow with:
@@ -20,10 +20,16 @@ evidence. The official SPDX schema is vendored with a pinned upstream commit and
 SHA-256.
 
 Publication remains blocked until an owner verifies public repository
-visibility, npm scope control, recovery owners and multi-factor authentication,
-existing owner-controlled package records, trusted-publisher bindings, the
-protected `npm` environment and tag rules, immutable GitHub releases, and the
-manual release-cut browser/device and assistive-technology evidence.
+visibility, npm scope control, the accepted single-owner recovery and
+multi-factor-authentication controls, existing owner-controlled package
+records, trusted-publisher bindings, the protected `npm` environment and tag
+rules, immutable GitHub releases, and the manual release-cut browser/device and
+assistive-technology evidence. `marcmalerei` is the sole required npm owner; a
+second owner is not required. The owner must use `auth-and-writes` 2FA, keep the
+npm account linked to GitHub, and retain current recovery codes outside the
+second-factor device. Loss of the sole owner account can stop package
+administration and require npm Support account recovery. Repository validation
+does not prove that the recovery codes are stored.
 
 Strict validation requires a machine-readable, reviewed release-cut record for
 all named branded browser/device and assistive-technology combinations.
@@ -34,7 +40,7 @@ The same release cut freezes an immutable compatibility manifest with exact
 branded browser, engine, OS/device, Node LTS, and CSR/SSR/streaming/hydration/SSG
 evidence. Both evidence files must describe the same tested commit.
 
-Publication uses two recoverable phases. Trusted publishing first places all 16
+Publication uses two recoverable phases. Trusted publishing first places all 17
 reviewed versions under a temporary non-`latest` dist-tag and verifies registry
 integrity and provenance. An npm owner then promotes every package to `latest`
 with interactive 2FA. A protected finalizer verifies the complete train and a

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -251,9 +251,18 @@ moving a dist-tag may limit discovery but does not rewrite history.
 
 The first public release additionally verifies the npm organization, package
 names, existing owner-controlled package records, public repository state,
-trusted-publisher bindings, recovery owners, and account multi-factor
-authentication. Existing package records are mandatory because npm does not
-allow trusted publishers to bootstrap brand-new package names.
+trusted-publisher bindings, and account recovery and multi-factor
+authentication controls. Existing package records are mandatory because npm
+does not allow trusted publishers to bootstrap brand-new package names.
+
+The accepted npm ownership model has one organization owner: `marcmalerei`. A
+second owner is not required. The owner uses `auth-and-writes` 2FA, keeps the
+npm account linked to GitHub, and must retain current recovery codes outside the
+device used as the second factor. This deliberately accepts a single-person
+administration dependency: loss of the sole owner account can stop organization
+and package administration and require npm Support account recovery. The
+release contract states these required controls but does not treat repository
+configuration as proof that recovery codes are stored.
 
 The package-record bootstrap is a distinct, owner-controlled operation. It
 publishes the minimal `0.0.0-bootstrap.1` placeholder under the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -79,8 +79,15 @@ all of the following outside the source tree:
    record. npm trusted publishing cannot create a brand-new package. Any
    bootstrap publication is an owner-controlled, interactive-2FA operation and
    is not performed by this workflow.
-4. npm recovery owners and multi-factor authentication satisfy the accepted
-   governance policy.
+4. npm account recovery and multi-factor authentication satisfy the accepted
+   single-owner governance policy. `marcmalerei` is the sole required npm
+   organization owner; a second owner is explicitly not required. The owner
+   must use `auth-and-writes` 2FA, keep the npm account linked to GitHub, and
+   retain current npm recovery codes outside the device used as the second
+   factor. This contract records the required controls, not evidence that the
+   recovery codes are currently stored. The project accepts that loss of the
+   sole owner account can suspend organization and package administration and
+   require npm Support account recovery.
 5. Every package has a trusted-publisher binding to this repository and the
    `Release` workflow. No long-lived npm publication token is configured.
 6. A protected GitHub environment named `npm` has named reviewers, prevents

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -29,6 +29,16 @@
       "LICENSE"
     ]
   },
+  "npmOwnerRecovery": {
+    "model": "single-owner",
+    "owner": "marcmalerei",
+    "secondOwnerRequired": false,
+    "mfaMode": "auth-and-writes",
+    "linkedGitHubAccountRequired": true,
+    "recoveryCodesRequired": true,
+    "recoveryCodeStorage": "outside-second-factor-device",
+    "npmSupportRecoveryRiskAccepted": true
+  },
   "spdxSchema": {
     "path": "release/spdx-2.3.schema.json",
     "source": "https://raw.githubusercontent.com/spdx/spdx-spec/44ab76293754df4af5af700fd4abd5453b866c86/schemas/spdx-schema.json",
@@ -57,7 +67,7 @@
     "public-repository",
     "verified-npm-scope-control",
     "existing-npm-package-records",
-    "npm-recovery-owners-and-mfa",
+    "npm-single-owner-recovery-and-mfa",
     "verified-npm-trusted-publisher",
     "protected-npm-environment",
     "protected-release-tags",

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -14,6 +14,7 @@
     "manualEvidencePath",
     "compatibilityManifestPath",
     "bootstrap",
+    "npmOwnerRecovery",
     "spdxSchema",
     "artifacts",
     "publication",
@@ -66,6 +67,30 @@
           ],
           "items": false
         }
+      }
+    },
+    "npmOwnerRecovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "model",
+        "owner",
+        "secondOwnerRequired",
+        "mfaMode",
+        "linkedGitHubAccountRequired",
+        "recoveryCodesRequired",
+        "recoveryCodeStorage",
+        "npmSupportRecoveryRiskAccepted"
+      ],
+      "properties": {
+        "model": { "const": "single-owner" },
+        "owner": { "const": "marcmalerei" },
+        "secondOwnerRequired": { "const": false },
+        "mfaMode": { "const": "auth-and-writes" },
+        "linkedGitHubAccountRequired": { "const": true },
+        "recoveryCodesRequired": { "const": true },
+        "recoveryCodeStorage": { "const": "outside-second-factor-device" },
+        "npmSupportRecoveryRiskAccepted": { "const": true }
       }
     },
     "spdxSchema": {

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -101,6 +101,7 @@ const result = {
   candidate: candidateVersion ?? null,
   packagesPrivate,
   bootstrap: releaseContract.bootstrap,
+  npmOwnerRecovery: releaseContract.npmOwnerRecovery,
   publicationState: packageContract.registry.publicationState,
   scopeControl: packageContract.registry.scopeControl,
   externalPrerequisites: releaseContract.externalPrerequisites,
@@ -125,6 +126,20 @@ function validateReleaseContract() {
   if (releaseContract.publication?.stagingDistTagPrefix !== 'gluon-staging-v'
     || releaseContract.publication?.promotion !== 'interactive-2fa') {
     throw new Error('Release publication must stage under a non-latest dist-tag and require interactive 2FA promotion.');
+  }
+  const expectedNpmOwnerRecovery = {
+    model: 'single-owner',
+    owner: 'marcmalerei',
+    secondOwnerRequired: false,
+    mfaMode: 'auth-and-writes',
+    linkedGitHubAccountRequired: true,
+    recoveryCodesRequired: true,
+    recoveryCodeStorage: 'outside-second-factor-device',
+    npmSupportRecoveryRiskAccepted: true,
+  };
+  if (Object.entries(expectedNpmOwnerRecovery)
+    .some(([field, expected]) => releaseContract.npmOwnerRecovery?.[field] !== expected)) {
+    throw new Error('npm owner recovery must use the accepted single-owner, auth-and-writes MFA, linked-GitHub, separately stored recovery-code policy.');
   }
   if (!prereleaseVersion(releaseContract.bootstrap?.version)
     || releaseContract.bootstrap.version === releaseContract.targetVersion
@@ -156,6 +171,10 @@ function validateReleaseContract() {
   }
   if (!releaseContract.externalPrerequisites.includes('existing-npm-package-records')) {
     throw new Error('Release contract must record the npm package-existence prerequisite for trusted publishing.');
+  }
+  if (!releaseContract.externalPrerequisites.includes('npm-single-owner-recovery-and-mfa')
+    || releaseContract.externalPrerequisites.includes('npm-recovery-owners-and-mfa')) {
+    throw new Error('Release contract must record the accepted single-owner npm recovery and MFA prerequisite.');
   }
 }
 


### PR DESCRIPTION
## Summary

- accept `marcmalerei` as the sole required npm organization owner
- machine-validate the selected 2FA, linked-GitHub, separately stored recovery-code, and accepted npm Support recovery-risk requirements
- update the release runbook, ADR, generated guide source, and changelog; correct the guide package count to 17

## Verification

- `node --check scripts/validate-release-contract.mjs`
- `npm run check:release-contract`
- `npm run check:docs`
- `npm run build`
- `npm run check`

## Shop impact

None. This changes release governance and its validator, with no public framework API or customer-visible shop behavior.

Part of #41.