### PR TITLE
Adopt single-operator release governance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,10 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- GitHub release governance now explicitly uses a no-reviewer single-operator
+  `npm` environment, with the immutable staging-publication risk accepted and
+  machine-validated `v*`-only deployments, disabled administrator bypass, and
+  no long-lived npm secrets.
 - npm release governance now explicitly accepts `marcmalerei` as the single
   organization owner without requiring a second owner, while retaining
   `auth-and-writes` 2FA, linked-GitHub, separately stored recovery-code, and

--- a/docs-site/content/0.0.0/guides/releasing/index.md
+++ b/docs-site/content/0.0.0/guides/releasing/index.md
@@ -22,14 +22,22 @@ SHA-256.
 Publication remains blocked until an owner verifies public repository
 visibility, npm scope control, the accepted single-owner recovery and
 multi-factor-authentication controls, existing owner-controlled package
-records, trusted-publisher bindings, the protected `npm` environment and tag
-rules, immutable GitHub releases, and the manual release-cut browser/device and
+records, trusted-publisher bindings, the single-operator `npm` environment and
+tag rules, immutable GitHub releases, and the manual release-cut browser/device and
 assistive-technology evidence. `marcmalerei` is the sole required npm owner; a
 second owner is not required. The owner must use `auth-and-writes` 2FA, keep the
 npm account linked to GitHub, and retain current recovery codes outside the
 second-factor device. Loss of the sole owner account can stop package
 administration and require npm Support account recovery. Repository validation
 does not prove that the recovery codes are stored.
+
+The `npm` environment uses the accepted single-operator model. It has no
+required reviewers, independent human approval, self-review rule, or wait
+timer; permits only the `v*` tag pattern; and disallows administrator bypass and
+long-lived npm secrets. This accepts that the sole operator can create a release
+tag that permanently publishes package versions under the staging dist-tag
+without another person's approval. Interactive-2FA promotion to `latest`
+remains a separate later step and does not reverse that publication.
 
 Strict validation requires a machine-readable, reviewed release-cut record for
 all named branded browser/device and assistive-technology combinations.

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -242,7 +242,8 @@ moving a dist-tag may limit discovery but does not rewrite history.
 5. creates one protected `vX.Y.Z` tag for the reviewed source commit
 6. creates one immutable GitHub release containing packages, checksums,
    compatibility evidence, SBOMs, and attestations
-7. obtains required approval through a protected GitHub release environment
+7. enters the tag-restricted single-operator GitHub release environment without
+   independent human approval
 8. publishes through npm trusted publishing with public access and provenance
    under a release-specific staging dist-tag
 9. requires interactive-2FA owner promotion of the complete train to `latest`
@@ -263,6 +264,16 @@ administration dependency: loss of the sole owner account can stop organization
 and package administration and require npm Support account recovery. The
 release contract states these required controls but does not treat repository
 configuration as proof that recovery codes are stored.
+
+GitHub release publication uses the same single-operator governance choice. The
+`npm` environment has no required reviewers, independent human approval,
+self-review rule, or wait timer. It permits only `v*` tags, disallows
+administrator bypass and long-lived npm secrets, and relies on the complete
+automated release gates plus interactive-2FA `latest` promotion. The project
+accepts that the sole operator can create a release tag that permanently
+publishes package versions under the staging dist-tag without another person's
+approval; later `latest` promotion does not make that initial publication
+reversible.
 
 The package-record bootstrap is a distinct, owner-controlled operation. It
 publishes the minimal `0.0.0-bootstrap.1` placeholder under the

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -90,8 +90,12 @@ all of the following outside the source tree:
    require npm Support account recovery.
 5. Every package has a trusted-publisher binding to this repository and the
    `Release` workflow. No long-lived npm publication token is configured.
-6. A protected GitHub environment named `npm` has named reviewers, prevents
-   self-review and administrator bypass, and permits only `v*` tags.
+6. A GitHub environment named `npm` uses the accepted single-operator model:
+   it has no required reviewers, independent human approval, self-review rule,
+   or wait timer; disallows administrator bypass and long-lived npm secrets;
+   and permits only the `v*` tag pattern. The project accepts that the operator
+   who creates a release tag can publish immutable package versions under the
+   staging dist-tag without another person's approval.
 7. An active GitHub tag ruleset covers `refs/tags/v*` and restricts tag
    creation, update, and deletion.
 8. GitHub immutable releases are enabled.
@@ -236,15 +240,18 @@ the publisher rejects it.
 
 After the candidate PR is merged and all gates are green, create the exact
 reviewed `v1.0.0` tag. The tag starts the `Release` workflow. Its candidate job
-repeats the full repository check and artifact build. The protected `npm`
-environment must then approve the publication job.
+repeats the full repository check and artifact build. The single-operator `npm`
+environment then admits the publication job without independent approval. It
+permits only `v*` tags and disallows administrator bypass and long-lived npm
+secrets.
 
-The publication job verifies public repository visibility, required environment
-reviewers and tag policy, release-tag mutation rules, immutable GitHub releases,
-and the absence of long-lived npm token variables. All release-workflow actions
-are pinned to commit SHAs. It attests archives, SBOMs, checksums, the immutable
-compatibility manifest, and other evidence, then creates or updates a draft
-GitHub release.
+The publication job verifies public repository visibility, the absence of
+environment reviewers and an uncontracted wait timer, the exact `v*` tag policy,
+disabled administrator bypass, release-tag mutation rules, immutable GitHub
+releases, and the absence of long-lived npm token variables. All
+release-workflow actions are pinned to commit SHAs. It attests archives, SBOMs,
+checksums, the immutable compatibility manifest, and other evidence, then
+creates or updates a draft GitHub release.
 
 The workflow publishes every reviewed archive through npm trusted publishing
 with provenance under `gluon-staging-v<version-with-dashes>`, never directly to

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -39,6 +39,19 @@
     "recoveryCodeStorage": "outside-second-factor-device",
     "npmSupportRecoveryRiskAccepted": true
   },
+  "githubReleaseEnvironment": {
+    "name": "npm",
+    "approvalModel": "single-operator",
+    "requiredReviewers": 0,
+    "independentHumanApprovalRequired": false,
+    "selfReviewPreventionRequired": false,
+    "waitTimerMinutes": 0,
+    "administratorBypassAllowed": false,
+    "deploymentBranchPatterns": [],
+    "deploymentTagPatterns": ["v*"],
+    "longLivedNpmSecretsAllowed": false,
+    "singleOperatorImmutableStagingRiskAccepted": true
+  },
   "spdxSchema": {
     "path": "release/spdx-2.3.schema.json",
     "source": "https://raw.githubusercontent.com/spdx/spdx-spec/44ab76293754df4af5af700fd4abd5453b866c86/schemas/spdx-schema.json",
@@ -69,7 +82,7 @@
     "existing-npm-package-records",
     "npm-single-owner-recovery-and-mfa",
     "verified-npm-trusted-publisher",
-    "protected-npm-environment",
+    "verified-single-operator-npm-environment",
     "protected-release-tags",
     "immutable-github-releases",
     "release-cut-browser-device-evidence",

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -15,6 +15,7 @@
     "compatibilityManifestPath",
     "bootstrap",
     "npmOwnerRecovery",
+    "githubReleaseEnvironment",
     "spdxSchema",
     "artifacts",
     "publication",
@@ -91,6 +92,43 @@
         "recoveryCodesRequired": { "const": true },
         "recoveryCodeStorage": { "const": "outside-second-factor-device" },
         "npmSupportRecoveryRiskAccepted": { "const": true }
+      }
+    },
+    "githubReleaseEnvironment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "approvalModel",
+        "requiredReviewers",
+        "independentHumanApprovalRequired",
+        "selfReviewPreventionRequired",
+        "waitTimerMinutes",
+        "administratorBypassAllowed",
+        "deploymentBranchPatterns",
+        "deploymentTagPatterns",
+        "longLivedNpmSecretsAllowed",
+        "singleOperatorImmutableStagingRiskAccepted"
+      ],
+      "properties": {
+        "name": { "const": "npm" },
+        "approvalModel": { "const": "single-operator" },
+        "requiredReviewers": { "const": 0 },
+        "independentHumanApprovalRequired": { "const": false },
+        "selfReviewPreventionRequired": { "const": false },
+        "waitTimerMinutes": { "const": 0 },
+        "administratorBypassAllowed": { "const": false },
+        "deploymentBranchPatterns": {
+          "type": "array",
+          "maxItems": 0
+        },
+        "deploymentTagPatterns": {
+          "type": "array",
+          "prefixItems": [{ "const": "v*" }],
+          "items": false
+        },
+        "longLivedNpmSecretsAllowed": { "const": false },
+        "singleOperatorImmutableStagingRiskAccepted": { "const": true }
       }
     },
     "spdxSchema": {

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -102,6 +102,7 @@ const result = {
   packagesPrivate,
   bootstrap: releaseContract.bootstrap,
   npmOwnerRecovery: releaseContract.npmOwnerRecovery,
+  githubReleaseEnvironment: releaseContract.githubReleaseEnvironment,
   publicationState: packageContract.registry.publicationState,
   scopeControl: packageContract.registry.scopeControl,
   externalPrerequisites: releaseContract.externalPrerequisites,
@@ -141,6 +142,25 @@ function validateReleaseContract() {
     .some(([field, expected]) => releaseContract.npmOwnerRecovery?.[field] !== expected)) {
     throw new Error('npm owner recovery must use the accepted single-owner, auth-and-writes MFA, linked-GitHub, separately stored recovery-code policy.');
   }
+  const expectedGithubReleaseEnvironment = {
+    name: 'npm',
+    approvalModel: 'single-operator',
+    requiredReviewers: 0,
+    independentHumanApprovalRequired: false,
+    selfReviewPreventionRequired: false,
+    waitTimerMinutes: 0,
+    administratorBypassAllowed: false,
+    deploymentBranchPatterns: [],
+    deploymentTagPatterns: ['v*'],
+    longLivedNpmSecretsAllowed: false,
+    singleOperatorImmutableStagingRiskAccepted: true,
+  };
+  if (Object.entries(expectedGithubReleaseEnvironment).some(([field, expected]) => {
+    const actual = releaseContract.githubReleaseEnvironment?.[field];
+    return Array.isArray(expected) ? JSON.stringify(actual) !== JSON.stringify(expected) : actual !== expected;
+  })) {
+    throw new Error('GitHub release publication must use the accepted no-reviewer single-operator npm environment policy.');
+  }
   if (!prereleaseVersion(releaseContract.bootstrap?.version)
     || releaseContract.bootstrap.version === releaseContract.targetVersion
     || releaseContract.bootstrap.distTag === releaseContract.publication.distTag
@@ -175,6 +195,10 @@ function validateReleaseContract() {
   if (!releaseContract.externalPrerequisites.includes('npm-single-owner-recovery-and-mfa')
     || releaseContract.externalPrerequisites.includes('npm-recovery-owners-and-mfa')) {
     throw new Error('Release contract must record the accepted single-owner npm recovery and MFA prerequisite.');
+  }
+  if (!releaseContract.externalPrerequisites.includes('verified-single-operator-npm-environment')
+    || releaseContract.externalPrerequisites.includes('protected-npm-environment')) {
+    throw new Error('Release contract must record the accepted single-operator GitHub npm environment prerequisite.');
   }
 }
 
@@ -385,6 +409,18 @@ function validateWorkflow() {
   }
   if (!hostingScript.includes('immutable-releases') || !hostingScript.includes("!== 'public'")) {
     throw new Error('Release hosting verification must require public, immutable GitHub releases.');
+  }
+  for (const required of [
+    "rule.type === 'required_reviewers'",
+    "rule.type === 'wait_timer'",
+    'environment.can_admins_bypass !== false',
+    'deploymentPolicies.branch_policies.length !== 1',
+    "deploymentPolicies.branch_policies[0].name !== 'v*'",
+  ]) if (!hostingScript.includes(required)) {
+    throw new Error(`Release hosting verification is missing single-operator environment control ${required}.`);
+  }
+  if (hostingScript.includes('requires named reviewers')) {
+    throw new Error('Release hosting verification must not retain the superseded second-person reviewer requirement.');
   }
   for (const forbidden of ['NPM_TOKEN', 'NODE_AUTH_TOKEN']) {
     if (workflow.includes(forbidden)) throw new Error(`Release workflow must not reference long-lived ${forbidden}.`);

--- a/scripts/verify-release-hosting.mjs
+++ b/scripts/verify-release-hosting.mjs
@@ -25,8 +25,12 @@ if (immutable.enabled !== true) throw new Error('GitHub immutable releases must 
 
 const environment = await githubJson(`repos/${repository}/environments/npm`);
 const reviewerRule = environment.protection_rules?.find((rule) => rule.type === 'required_reviewers');
-if (!reviewerRule || reviewerRule.prevent_self_review !== true || !Array.isArray(reviewerRule.reviewers) || reviewerRule.reviewers.length === 0) {
-  throw new Error('The npm environment requires named reviewers with self-review prevention.');
+if (reviewerRule) {
+  throw new Error('The accepted single-operator npm environment must not require a second-person reviewer.');
+}
+const waitTimerRule = environment.protection_rules?.find((rule) => rule.type === 'wait_timer');
+if (waitTimerRule) {
+  throw new Error('The accepted single-operator npm environment must not imply an uncontracted wait timer.');
 }
 if (environment.can_admins_bypass !== false) {
   throw new Error('The npm environment must disallow administrator bypass.');
@@ -35,8 +39,11 @@ if (environment.deployment_branch_policy?.custom_branch_policies !== true) {
   throw new Error('The npm environment requires a custom release-tag deployment policy.');
 }
 const deploymentPolicies = await githubJson(`repos/${repository}/environments/npm/deployment-branch-policies`);
-if (!deploymentPolicies.branch_policies?.some((policy) => policy.type === 'tag' && ['v*', 'v*.*.*'].includes(policy.name))) {
-  throw new Error('The npm environment must restrict deployments to v-prefixed release tags.');
+if (!Array.isArray(deploymentPolicies.branch_policies)
+  || deploymentPolicies.branch_policies.length !== 1
+  || deploymentPolicies.branch_policies[0].type !== 'tag'
+  || deploymentPolicies.branch_policies[0].name !== 'v*') {
+  throw new Error('The npm environment must permit only the exact v* release-tag pattern.');
 }
 
 const rulesets = await githubJson(`repos/${repository}/rulesets?includes_parents=true`);


### PR DESCRIPTION
## Summary

- replace the second-person GitHub release approval requirement with the explicitly accepted single-operator model
- machine-validate zero required reviewers and wait timer, disabled administrator bypass, exact `v*`-only deployments, and no long-lived npm token variables
- document that a sole operator can create immutable staged npm versions without independent approval

## Verification

- `node --check scripts/validate-release-contract.mjs`
- `node --check scripts/verify-release-hosting.mjs`
- `npm run check:release-contract`
- `npm run check:docs`
- `npm run build`
- `npm run check`

## Shop impact

None. This changes release governance and hosting validation only; it does not change a public framework API or customer-visible shop behavior.

Part of #41.