### PR TITLE
Protect immutable release tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Machine-validated single-operator release-tag governance that lets only the
+  named operator create `v*` tags while no-bypass rules make existing release
+  tags immutable against update and deletion.
 - A machine-validated, owner-controlled npm bootstrap contract that produces
   minimal non-runtime archives for all 17 package records, restricts any
   registry-created temporary `latest` tag to a reviewed bootstrap placeholder,

--- a/docs-site/content/0.0.0/guides/releasing/index.md
+++ b/docs-site/content/0.0.0/guides/releasing/index.md
@@ -39,6 +39,12 @@ tag that permanently publishes package versions under the staging dist-tag
 without another person's approval. Interactive-2FA promotion to `latest`
 remains a separate later step and does not reverse that publication.
 
+Two active tag rulesets cover exactly `refs/tags/v*`. Only `marcmalerei` may
+bypass the creation restriction, so the sole operator can cut a release. The
+separate update and deletion restrictions have no bypass actor; an existing
+release tag therefore cannot be rewritten or deleted, including by a repository
+administrator.
+
 Strict validation requires a machine-readable, reviewed release-cut record for
 all named branded browser/device and assistive-technology combinations.
 Placeholders, engine substitutions, and undocumented failures do not satisfy

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -275,6 +275,14 @@ publishes package versions under the staging dist-tag without another person's
 approval; later `latest` promotion does not make that initial publication
 reversible.
 
+Release-tag protection separates creation from later mutation. One active
+repository ruleset covers exactly `refs/tags/v*`, restricts creation, and gives
+only the `marcmalerei` user an `always` bypass. A second active ruleset covers
+the same pattern and blocks update and deletion without any bypass actor. The
+sole operator can therefore cut a release without a second person, but neither
+that operator nor an administrator can rewrite or delete an existing release
+tag.
+
 The package-record bootstrap is a distinct, owner-controlled operation. It
 publishes the minimal `0.0.0-bootstrap.1` placeholder under the
 `gluon-bootstrap` dist-tag with interactive 2FA and no provenance claim. npm

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -96,8 +96,11 @@ all of the following outside the source tree:
    and permits only the `v*` tag pattern. The project accepts that the operator
    who creates a release tag can publish immutable package versions under the
    staging dist-tag without another person's approval.
-7. An active GitHub tag ruleset covers `refs/tags/v*` and restricts tag
-   creation, update, and deletion.
+7. Two active GitHub tag rulesets cover exactly `refs/tags/v*`. The creation
+   rule gives only the `marcmalerei` user an `always` bypass so the sole
+   operator can cut a release. The update and deletion rules have no bypass
+   actor, making an existing release tag immutable for every user, including
+   repository administrators.
 8. GitHub immutable releases are enabled.
 9. The release-cut branded browser/device and assistive-technology protocols in
    [`browser-device-evidence.md`](browser-device-evidence.md) and

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -52,6 +52,15 @@
     "longLivedNpmSecretsAllowed": false,
     "singleOperatorImmutableStagingRiskAccepted": true
   },
+  "githubReleaseTagProtection": {
+    "model": "operator-created-immutable-tags",
+    "operator": "marcmalerei",
+    "includePatterns": ["refs/tags/v*"],
+    "creationBypassActorType": "User",
+    "creationBypassMode": "always",
+    "updateBypassAllowed": false,
+    "deletionBypassAllowed": false
+  },
   "spdxSchema": {
     "path": "release/spdx-2.3.schema.json",
     "source": "https://raw.githubusercontent.com/spdx/spdx-spec/44ab76293754df4af5af700fd4abd5453b866c86/schemas/spdx-schema.json",

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -16,6 +16,7 @@
     "bootstrap",
     "npmOwnerRecovery",
     "githubReleaseEnvironment",
+    "githubReleaseTagProtection",
     "spdxSchema",
     "artifacts",
     "publication",
@@ -129,6 +130,33 @@
         },
         "longLivedNpmSecretsAllowed": { "const": false },
         "singleOperatorImmutableStagingRiskAccepted": { "const": true }
+      }
+    },
+    "githubReleaseTagProtection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "model",
+        "operator",
+        "includePatterns",
+        "creationBypassActorType",
+        "creationBypassMode",
+        "updateBypassAllowed",
+        "deletionBypassAllowed"
+      ],
+      "properties": {
+        "model": { "const": "operator-created-immutable-tags" },
+        "operator": { "const": "marcmalerei" },
+        "includePatterns": {
+          "type": "array",
+          "minItems": 1,
+          "prefixItems": [{ "const": "refs/tags/v*" }],
+          "items": false
+        },
+        "creationBypassActorType": { "const": "User" },
+        "creationBypassMode": { "const": "always" },
+        "updateBypassAllowed": { "const": false },
+        "deletionBypassAllowed": { "const": false }
       }
     },
     "spdxSchema": {

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -103,6 +103,7 @@ const result = {
   bootstrap: releaseContract.bootstrap,
   npmOwnerRecovery: releaseContract.npmOwnerRecovery,
   githubReleaseEnvironment: releaseContract.githubReleaseEnvironment,
+  githubReleaseTagProtection: releaseContract.githubReleaseTagProtection,
   publicationState: packageContract.registry.publicationState,
   scopeControl: packageContract.registry.scopeControl,
   externalPrerequisites: releaseContract.externalPrerequisites,
@@ -160,6 +161,21 @@ function validateReleaseContract() {
     return Array.isArray(expected) ? JSON.stringify(actual) !== JSON.stringify(expected) : actual !== expected;
   })) {
     throw new Error('GitHub release publication must use the accepted no-reviewer single-operator npm environment policy.');
+  }
+  const expectedGithubReleaseTagProtection = {
+    model: 'operator-created-immutable-tags',
+    operator: 'marcmalerei',
+    includePatterns: ['refs/tags/v*'],
+    creationBypassActorType: 'User',
+    creationBypassMode: 'always',
+    updateBypassAllowed: false,
+    deletionBypassAllowed: false,
+  };
+  if (Object.entries(expectedGithubReleaseTagProtection).some(([field, expected]) => {
+    const actual = releaseContract.githubReleaseTagProtection?.[field];
+    return Array.isArray(expected) ? JSON.stringify(actual) !== JSON.stringify(expected) : actual !== expected;
+  })) {
+    throw new Error('GitHub release tags must be operator-created and immutable without update or deletion bypass.');
   }
   if (!prereleaseVersion(releaseContract.bootstrap?.version)
     || releaseContract.bootstrap.version === releaseContract.targetVersion
@@ -416,6 +432,10 @@ function validateWorkflow() {
     'environment.can_admins_bypass !== false',
     'deploymentPolicies.branch_policies.length !== 1',
     "deploymentPolicies.branch_policies[0].name !== 'v*'",
+    "ruleTypes.has('creation')",
+    "ruleTypes.has('update')",
+    "ruleTypes.has('deletion')",
+    'bypassActors.length === 0',
   ]) if (!hostingScript.includes(required)) {
     throw new Error(`Release hosting verification is missing single-operator environment control ${required}.`);
   }

--- a/scripts/verify-release-hosting.mjs
+++ b/scripts/verify-release-hosting.mjs
@@ -9,6 +9,7 @@ const root = resolve(import.meta.dirname, '..');
 const repository = process.env.GITHUB_REPOSITORY;
 const expectedEnvironment = process.env.GLUON_RELEASE_ENVIRONMENT;
 const releaseVersion = process.env.RELEASE_VERSION;
+const releaseContract = JSON.parse(await readFile(resolve(root, 'release/release-contract.json'), 'utf8'));
 
 if (!repository) throw new Error('GITHUB_REPOSITORY is required.');
 if (!releaseVersion) throw new Error('RELEASE_VERSION is required.');
@@ -47,18 +48,41 @@ if (!Array.isArray(deploymentPolicies.branch_policies)
 }
 
 const rulesets = await githubJson(`repos/${repository}/rulesets?includes_parents=true`);
-let protectedReleaseTags = false;
+const releaseTagProtection = releaseContract.githubReleaseTagProtection;
+const operator = await githubJson(`users/${releaseTagProtection.operator}`);
+let operatorCanCreateReleaseTags = false;
+let releaseTagUpdatesAreImmutable = false;
+let releaseTagDeletionsAreImmutable = false;
 for (const summary of rulesets.filter((entry) => entry.target === 'tag' && entry.enforcement === 'active')) {
   const ruleset = await githubJson(`repos/${repository}/rulesets/${summary.id}`);
   const includes = ruleset.conditions?.ref_name?.include ?? [];
+  const excludes = ruleset.conditions?.ref_name?.exclude ?? [];
   const ruleTypes = new Set(ruleset.rules?.map((rule) => rule.type));
-  const coversReleaseTags = includes.includes('~ALL') || includes.some((pattern) => ['refs/tags/v*', 'refs/tags/v*.*.*'].includes(pattern));
-  if (coversReleaseTags && ['creation', 'update', 'deletion'].every((type) => ruleTypes.has(type))) {
-    protectedReleaseTags = true;
-    break;
+  const coversReleaseTags = JSON.stringify(includes) === JSON.stringify(releaseTagProtection.includePatterns)
+    && excludes.length === 0;
+  if (!coversReleaseTags) continue;
+
+  const bypassActors = ruleset.bypass_actors ?? [];
+  const hasExactCreationBypass = bypassActors.length === 1
+    && bypassActors[0].actor_type === releaseTagProtection.creationBypassActorType
+    && bypassActors[0].actor_id === operator.id
+    && bypassActors[0].bypass_mode === releaseTagProtection.creationBypassMode;
+  if (ruleTypes.has('creation') && hasExactCreationBypass) {
+    operatorCanCreateReleaseTags = true;
+  }
+  if (bypassActors.length === 0 && ruleTypes.has('update')) {
+    releaseTagUpdatesAreImmutable = true;
+  }
+  if (bypassActors.length === 0 && ruleTypes.has('deletion')) {
+    releaseTagDeletionsAreImmutable = true;
   }
 }
-if (!protectedReleaseTags) throw new Error('An active ruleset must protect v-prefixed release tags.');
+if (!operatorCanCreateReleaseTags) {
+  throw new Error(`An active ruleset must allow only ${releaseTagProtection.operator} to create v-prefixed release tags.`);
+}
+if (!releaseTagUpdatesAreImmutable || !releaseTagDeletionsAreImmutable) {
+  throw new Error('Active no-bypass rulesets must prevent update and deletion of v-prefixed release tags.');
+}
 
 const manualEvidence = JSON.parse(await readFile(resolve(root, 'release/evidence', `${releaseVersion}.json`), 'utf8'));
 const runId = /\/actions\/runs\/(\d+)$/.exec(manualEvidence.automatedQualityRun.url)?.[1];


### PR DESCRIPTION
## Summary
- contract two active tag rulesets for refs/tags/v*
- permit only the named single operator to bypass tag creation
- require update and deletion protection without bypass actors
- verify the live GitHub ruleset shape before release publication
- document the single-operator immutable-tag model

## Verification
- npm run check:release-contract
- npm run check:docs
- npm run build
- npm run check
- git diff --check

Tracks the release-governance slice of #41; the release epic remains open.