### PR TITLE
Automate trusted latest publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,6 @@ on:
         description: Existing lockstep version to validate without publication
         required: true
         type: string
-      phase:
-        description: Validate a candidate or finalize an owner-promoted draft
-        required: true
-        default: validate
-        type: choice
-        options:
-          - validate
-          - finalize
 
 concurrency:
   group: release-${{ github.ref }}-${{ inputs.version }}
@@ -28,7 +20,6 @@ permissions:
 
 jobs:
   candidate:
-    if: ${{ github.event_name == 'push' || inputs.phase != 'finalize' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -125,8 +116,23 @@ jobs:
           else
             gh release create "$GITHUB_REF_NAME" "${assets[@]}" --verify-tag --draft --title "Gluon $GITHUB_REF_NAME" --notes-file .tmp/release/RELEASE_NOTES.md
           fi
-      - name: Publish reviewed archives under the recoverable staging dist-tag
+      - name: Publish reviewed archives directly to latest through trusted publishing
         run: npm run release:publish -- --version "$RELEASE_VERSION"
+      - name: Verify latest registry train from a clean directory
+        run: npm run release:verify-registry -- --version "$RELEASE_VERSION" --directory .tmp/release --output .tmp/release/registry-verification.json
+      - run: npm run release:finalize-assets
+      - name: Attest registry verification
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: |
+            .tmp/release/registry-verification.json
+            .tmp/release/SHA256SUMS
+      - name: Attach verification and publish the immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" .tmp/release/registry-verification.json .tmp/release/SHA256SUMS --clobber
+          gh release edit "$GITHUB_REF_NAME" --draft=false --latest
 
   reproducibility:
     needs: candidate
@@ -167,7 +173,6 @@ jobs:
           include-hidden-files: true
 
   browser-engines:
-    if: ${{ github.event_name == 'push' || inputs.phase != 'finalize' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -186,7 +191,6 @@ jobs:
           GLUON_BROWSER: ${{ matrix.browser }}
 
   node-runtime:
-    if: ${{ github.event_name == 'push' || inputs.phase != 'finalize' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -203,7 +207,6 @@ jobs:
       - run: npm run test:ssr
 
   performance-evidence:
-    if: ${{ github.event_name == 'push' || inputs.phase != 'finalize' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -223,55 +226,3 @@ jobs:
           retention-days: 30
           if-no-files-found: error
           include-hidden-files: true
-
-  finalize:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.phase == 'finalize' }}
-    runs-on: ubuntu-latest
-    environment: npm
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
-    env:
-      GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
-      GLUON_RELEASE_ENVIRONMENT: npm
-      RELEASE_VERSION: ${{ inputs.version }}
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 24.x
-          package-manager-cache: false
-      - run: npm install --global npm@11.18.0
-      - run: npm ci --ignore-scripts
-      - name: Require the exact release tag and draft
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          test "$GITHUB_REF_TYPE" = tag
-          test "$GITHUB_REF_NAME" = "v$RELEASE_VERSION"
-          test "$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft)" = true
-      - run: node scripts/verify-release-hosting.mjs
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - name: Download reviewed draft assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release download "$GITHUB_REF_NAME" --dir .tmp/release-assets
-      - name: Verify latest registry train from a clean directory
-        run: npm run release:verify-registry -- --version "$RELEASE_VERSION" --directory .tmp/release-assets --output .tmp/release-assets/registry-verification.json
-      - run: npm run release:finalize-assets -- --directory .tmp/release-assets
-      - name: Attest registry verification
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
-        with:
-          subject-path: |
-            .tmp/release-assets/registry-verification.json
-            .tmp/release-assets/SHA256SUMS
-      - name: Attach verification and publish the immutable release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "$GITHUB_REF_NAME" .tmp/release-assets/registry-verification.json .tmp/release-assets/SHA256SUMS --clobber
-          gh release edit "$GITHUB_REF_NAME" --draft=false --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Changed future lockstep releases to publish all 17 packages directly under
+  `latest` through npm Trusted Publishing. The protected workflow now performs
+  publication, complete registry and clean-install verification, and GitHub
+  release finalization in one recoverable job, without long-lived npm tokens,
+  dist-tag mutation, or 17 interactive 2FA approvals.
 - Added opt-in standard and legacy TypeScript authoring decorators through
   `@gluonjs/core/decorators`: `@customElement()`, `@property()`, and `@state()`.
   The official Vite plugin transpiles them, preserves compatible Custom Element

--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -1,7 +1,7 @@
 # ADR 0002: Package, release, and supply-chain governance
 
 - **Status:** Accepted
-- **Decision date:** 2026-07-10
+- **Decision date:** 2026-07-10; amended 2026-07-14
 - **Tracking issue:** [#17](https://github.com/marcmalerei/gluon/issues/17)
 - **Roadmap tracker:** [#42](https://github.com/marcmalerei/gluon/issues/42)
 - **Depends on:** [RFC 0001](../rfcs/0001-gluon-1.0-product-scope.md), [RFC 0002](../rfcs/0002-unified-component-model.md), [ADR 0001](0001-browser-runtime-and-style-transport.md)
@@ -246,10 +246,11 @@ moving a dist-tag may limit discovery but does not rewrite history.
 7. enters the tag-restricted single-operator GitHub release environment without
    independent human approval
 8. publishes through npm trusted publishing with public access and provenance
-   under a release-specific staging dist-tag
-9. requires interactive-2FA owner promotion of the complete train to `latest`
-10. verifies registry installation, exports, types, provenance, and dist-tags
+   directly under `latest`
+9. verifies registry installation, exports, types, provenance, and dist-tags
    from an empty consumer project
+10. publishes the immutable GitHub release only after the complete registry
+    train passes verification
 
 The first public release additionally verifies the npm organization, package
 names, existing owner-controlled package records, public repository state,
@@ -270,11 +271,13 @@ GitHub release publication uses the same single-operator governance choice. The
 `npm` environment has no required reviewers, independent human approval,
 self-review rule, or wait timer. It permits only `v*` tags, disallows
 administrator bypass and long-lived npm secrets, and relies on the complete
-automated release gates plus interactive-2FA `latest` promotion. The project
-accepts that the sole operator can create a release tag that permanently
-publishes package versions under the staging dist-tag without another person's
-approval; later `latest` promotion does not make that initial publication
-reversible.
+automated release gates. The project accepts that the sole operator can create
+a release tag that permanently publishes package versions directly under
+`latest` without another person's approval. npm does not provide an atomic
+multi-package publish operation, so a failed train may temporarily leave only
+part of the 17-package train at the new `latest` version. The same protected job
+is safely repeatable for matching immutable versions and keeps the GitHub
+release in draft state until the complete train passes clean-room verification.
 
 Release-tag protection separates creation from later mutation. One active
 repository ruleset covers exactly `refs/tags/v*`, restricts creation, and gives
@@ -324,11 +327,11 @@ Public release jobs use GitHub-hosted runners, minimal job permissions, and
 `id-token: write` only where OIDC or attestations require it. npm trusted
 publishing is the only authorized publication identity; repository or
 organization secrets must not contain a long-lived npm publication token.
-Trusted publishing authorizes publication but not dist-tag mutation, so the
-reviewed release train is first published under a non-`latest` tag and an
-authorized owner performs the final `latest` promotion with interactive 2FA.
+The reviewed release train is published directly under `latest`, so the
+workflow needs neither a dist-tag mutation nor 17 interactive 2FA approvals.
 The immutable GitHub release remains a draft until the complete registry train
-passes clean-room verification.
+passes integrity, provenance, dist-tag, clean-install, and public-type
+verification.
 
 Each package and the aggregate release receive:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -154,8 +154,10 @@ all of the following outside the source tree:
    it has no required reviewers, independent human approval, self-review rule,
    or wait timer; disallows administrator bypass and long-lived npm secrets;
    and permits only the `v*` tag pattern. The project accepts that the operator
-   who creates a release tag can publish immutable package versions under the
-   staging dist-tag without another person's approval.
+   who creates a release tag can publish immutable package versions directly
+   to `latest` without another person's approval. Because npm has no atomic
+   multi-package publish operation, a failed train may temporarily leave only
+   part of the 17-package train on the new `latest` version.
 7. Two active GitHub tag rulesets cover exactly `refs/tags/v*`. The creation
    rule gives only the `marcmalerei` user an `always` bypass so the sole
    operator can cut a release. The update and deletion rules have no bypass
@@ -343,15 +345,17 @@ long-lived npm token variables. All release-workflow actions are pinned to
 commit SHAs. It attests archives, SBOMs, checksums, the immutable compatibility
 manifest, and other evidence, then creates or updates a draft GitHub release.
 
-The protected publish and finalize jobs use `actions/setup-node` only to select
-Node; they do not provide its `registry-url` input because that input writes
+The protected publication job uses `actions/setup-node` only to select
+Node; it does not provide its `registry-url` input because that input writes
 token-backed npm configuration and exports a placeholder `NODE_AUTH_TOKEN` even
 when OIDC is intended. Publisher and registry-verification commands pass the
 registry from `release/release-contract.json` explicitly. Contract validation
-rejects either protected job if setup-node registry authentication returns.
-The hosting-verification step alone receives GitHub's ephemeral workflow token
-as `GH_TOKEN` for its live public environment, deployment-policy, public
-ruleset, operator, and Quality Gates queries. GitHub's immutable-releases
+rejects the protected job if setup-node registry authentication returns.
+Only the workflow steps that verify or update GitHub state receive GitHub's
+ephemeral workflow token as `GH_TOKEN`; npm publication receives no npm token.
+The hosting verifier uses that token for its live public environment,
+deployment-policy, public ruleset, operator, and Quality Gates queries.
+GitHub's immutable-releases
 endpoint requires repository Administration read access, and GitHub omits
 ruleset `bypass_actors` from non-administration responses. An Actions
 `GITHUB_TOKEN` cannot receive that access, so the sole operator records both
@@ -361,25 +365,20 @@ secret, and contract validation rejects either missing preflight evidence or a
 verifier without the ephemeral token.
 
 The workflow publishes every reviewed archive through npm trusted publishing
-with provenance under `gluon-staging-v<version-with-dashes>`, never directly to
-`latest`. Before the first publish it proves that all 17 npm package records
-already exist. After each publish it compares registry integrity and provenance
-with `release-evidence.json`. A rerun skips an already-existing version only
-when those facts match; a mismatch stops the train.
+with provenance directly under `latest`. Before the first publish it proves
+that all 17 npm package records already exist. After each publish it compares
+registry integrity and provenance with `release-evidence.json`. A rerun skips
+an already-existing version only when those facts match; a mismatch stops the
+train. No long-lived npm token, `npm dist-tag` mutation, or per-package 2FA
+approval is part of a supported release.
 
-After all 17 staging publications succeed, an authorized npm owner reviews the
-draft evidence and promotes every exact package version to `latest` with
-interactive 2FA using `npm dist-tag add <name>@<version> latest`. OIDC trusted
-publishing does not authorize dist-tag changes. The owner may remove the
-temporary staging tags after finalization with `npm dist-tag rm`.
-
-Finally, dispatch the `Release` workflow from the exact `v<version>` tag with
-`phase=finalize` and the matching version. The protected finalizer downloads
-the draft assets, requires every `latest` tag to point to the reviewed version,
-compares registry integrity and provenance, performs a clean-directory install
-and public-type check, attaches the registry verification and final checksum
-manifest, and only then publishes the immutable GitHub release. A partial
-manual promotion makes finalization fail without publishing the GitHub release.
+After all 17 direct publications succeed, the same protected job requires every
+`latest` tag to point to the reviewed version, compares registry integrity and
+provenance, performs a clean-directory install and public-type check, attaches
+the registry verification and final checksum manifest, and only then publishes
+the immutable GitHub release. A partial npm publication leaves the GitHub
+release as a draft. Rerunning the failed job verifies and skips matching
+immutable versions before continuing with the unpublished packages.
 
 A second fresh runner runs the complete root `npm run build` for the same source
 commit and compares every canonical unpacked package-file digest with the
@@ -387,8 +386,9 @@ candidate job. Release-contract validation rejects a workflow that replaces
 this aggregate build with an incomplete manually maintained package list. The
 publication job cannot start unless this reproducibility job passes.
 
-A failed publication is never retried by rebuilding the same version. Preserve the run
-and draft-release evidence and rerun the failed jobs with the same artifacts.
-Matching immutable registry versions are verified and skipped; unpublished
-packages continue. If any existing registry version has different integrity or
-lacks provenance, stop and follow the new-version policy in ADR 0002.
+A failed publication is never retried by rebuilding the same version. Preserve
+the run and draft-release evidence and rerun the failed job with the same
+artifacts. Matching immutable registry versions are verified and skipped;
+unpublished packages continue. If any existing registry version has different
+integrity or lacks provenance, stop and follow the new-version policy in ADR
+0002.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -334,9 +334,9 @@ The first #41 release-engineering slice adds a machine-readable release
 contract, lockstep candidate validation, reproducible package-content digests,
 aggregate and per-package SPDX 2.3 and CycloneDX 1.7 SBOM generation, checksums,
 schema-pinned SPDX validation, immutable compatibility evidence, SHA-pinned
-workflow actions, OIDC artifact attestation, recoverable staged-tag npm trusted
-publication, interactive-2FA `latest` promotion, and clean-room registry
-verification. It deliberately leaves publication blocked while the repository
+workflow actions, OIDC artifact attestation, direct `latest` npm trusted
+publication without long-lived tokens, and clean-room registry verification.
+It deliberately leaves publication blocked while the repository
 is private, npm scope control is unverified, and package records and protected
 release settings are absent.
 

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -50,7 +50,7 @@
     "deploymentBranchPatterns": [],
     "deploymentTagPatterns": ["v*"],
     "longLivedNpmSecretsAllowed": false,
-    "singleOperatorImmutableStagingRiskAccepted": true
+    "singleOperatorPartialLatestRiskAccepted": true
   },
   "githubReleaseTagProtection": {
     "model": "operator-created-immutable-tags",
@@ -90,8 +90,7 @@
     "access": "public",
     "provenance": true,
     "distTag": "latest",
-    "stagingDistTagPrefix": "gluon-staging-v",
-    "promotion": "interactive-2fa",
+    "promotion": "direct-trusted-publishing",
     "identity": "npm-trusted-publishing",
     "longLivedTokenAllowed": false
   },

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -110,7 +110,7 @@
         "deploymentBranchPatterns",
         "deploymentTagPatterns",
         "longLivedNpmSecretsAllowed",
-        "singleOperatorImmutableStagingRiskAccepted"
+        "singleOperatorPartialLatestRiskAccepted"
       ],
       "properties": {
         "name": { "const": "npm" },
@@ -130,7 +130,7 @@
           "items": false
         },
         "longLivedNpmSecretsAllowed": { "const": false },
-        "singleOperatorImmutableStagingRiskAccepted": { "const": true }
+        "singleOperatorPartialLatestRiskAccepted": { "const": true }
       }
     },
     "githubReleaseTagProtection": {
@@ -226,14 +226,13 @@
     "publication": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["registry", "access", "provenance", "distTag", "stagingDistTagPrefix", "promotion", "identity", "longLivedTokenAllowed"],
+      "required": ["registry", "access", "provenance", "distTag", "promotion", "identity", "longLivedTokenAllowed"],
       "properties": {
         "registry": { "const": "https://registry.npmjs.org" },
         "access": { "const": "public" },
         "provenance": { "const": true },
         "distTag": { "const": "latest" },
-        "stagingDistTagPrefix": { "const": "gluon-staging-v" },
-        "promotion": { "const": "interactive-2fa" },
+        "promotion": { "const": "direct-trusted-publishing" },
         "identity": { "const": "npm-trusted-publishing" },
         "longLivedTokenAllowed": { "const": false }
       }

--- a/scripts/publish-release.mjs
+++ b/scripts/publish-release.mjs
@@ -30,7 +30,7 @@ if (evidence.version !== version || evidence.tag !== `v${version}` || evidence.b
 }
 
 await verifyChecksums();
-const stagingTag = `${releaseContract.publication.stagingDistTagPrefix}${version.replaceAll('.', '-')}`;
+const distTag = releaseContract.publication.distTag;
 if (!dryRun) {
   for (const entry of evidence.packages) await requireExistingPackage(entry.name);
 }
@@ -48,7 +48,7 @@ for (const entry of evidence.packages) {
     resolve(directory, 'packages', entry.filename),
     '--access', 'public',
     '--provenance',
-    '--tag', stagingTag,
+    '--tag', distTag,
     '--registry', registry,
   ];
   if (dryRun) args.push('--dry-run');
@@ -59,9 +59,10 @@ if (!dryRun) {
   for (const entry of evidence.packages) {
     const metadata = await waitForRegistry(entry.name, version);
     verifyPublishedMetadata(entry, metadata);
+    const latest = await waitForDistTag(entry.name, distTag, version);
+    if (latest !== version) throw new Error(`${entry.name} ${distTag} tag is ${latest}; expected ${version}.`);
   }
-  console.log(`staging publication verified: ${evidence.packages.length} packages at ${version} under ${stagingTag}`);
-  console.log('An authorized npm owner must now promote every package to latest with interactive 2FA before release finalization.');
+  console.log(`direct publication verified: ${evidence.packages.length} packages at ${version} under ${distTag}`);
 }
 
 async function requireExistingPackage(name) {
@@ -96,6 +97,25 @@ async function waitForRegistry(name, packageVersion) {
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 2_000));
   }
   throw new Error(`${name}@${packageVersion} was not visible on the public registry after publication.`);
+}
+
+async function waitForDistTag(name, tag, expectedVersion) {
+  let observed = null;
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    observed = await registryDistTag(name, tag);
+    if (observed === expectedVersion) return observed;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 2_000));
+  }
+  return observed;
+}
+
+async function registryDistTag(name, tag) {
+  const { stdout } = await execFile('npm', ['view', name, `dist-tags.${tag}`, '--registry', registry], {
+    cwd: root,
+    encoding: 'utf8',
+    maxBuffer: 5 * 1024 * 1024,
+  });
+  return stdout.trim();
 }
 
 function verifyPublishedMetadata(entry, metadata) {

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -133,9 +133,9 @@ function validateReleaseContract() {
   if (releaseContract.publication?.identity !== 'npm-trusted-publishing' || releaseContract.publication?.longLivedTokenAllowed !== false) {
     throw new Error('Release publication must use npm trusted publishing without long-lived tokens.');
   }
-  if (releaseContract.publication?.stagingDistTagPrefix !== 'gluon-staging-v'
-    || releaseContract.publication?.promotion !== 'interactive-2fa') {
-    throw new Error('Release publication must stage under a non-latest dist-tag and require interactive 2FA promotion.');
+  if (releaseContract.publication?.distTag !== 'latest'
+    || releaseContract.publication?.promotion !== 'direct-trusted-publishing') {
+    throw new Error('Release publication must publish directly to latest through npm trusted publishing.');
   }
   const expectedNpmOwnerRecovery = {
     model: 'single-owner',
@@ -162,7 +162,7 @@ function validateReleaseContract() {
     deploymentBranchPatterns: [],
     deploymentTagPatterns: ['v*'],
     longLivedNpmSecretsAllowed: false,
-    singleOperatorImmutableStagingRiskAccepted: true,
+    singleOperatorPartialLatestRiskAccepted: true,
   };
   if (Object.entries(expectedGithubReleaseEnvironment).some(([field, expected]) => {
     const actual = releaseContract.githubReleaseEnvironment?.[field];
@@ -524,27 +524,34 @@ function validateWorkflow() {
     'id-token: write',
     'actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3',
     'release:publish',
-    'inputs.phase == \'finalize\'',
+    'release:verify-registry',
+    'release:finalize-assets',
     'gh release create',
     '--draft',
     'gh release edit',
   ]) if (!workflow.includes(required)) throw new Error(`Release workflow is missing ${required}.`);
+  if (workflow.includes('inputs.phase') || /^  finalize:/m.test(workflow)) {
+    throw new Error('Release workflow must publish, verify, and finalize the release in one trusted-publishing job.');
+  }
   const reproducibilityJob = workflow.match(/\n  reproducibility:\n([\s\S]*?)\n  browser-engines:\n/)?.[1];
   if (!/^\s*-\s+run:\s+npm run build\s*$/m.test(reproducibilityJob ?? '')) {
     throw new Error('Release reproducibility must use the complete root build before rebuilding artifacts.');
   }
   const publishJob = workflow.match(/\n  publish:\n([\s\S]*?)\n  reproducibility:\n/)?.[1];
-  const finalizeJob = workflow.match(/\n  finalize:\n([\s\S]*?)$/)?.[1];
-  for (const [name, job] of [['publish', publishJob], ['finalize', finalizeJob]]) {
-    if (!job || /registry-url:/.test(job)) {
-      throw new Error(`Release ${name} must not ask setup-node to create token-backed registry authentication.`);
-    }
-    if (!/- run: node scripts\/verify-release-hosting\.mjs\n\s+env:\n\s+GH_TOKEN: \$\{\{ github\.token \}\}/.test(job)) {
-      throw new Error(`Release ${name} must expose the ephemeral GitHub token only to hosting verification.`);
-    }
+  if (!publishJob || /registry-url:/.test(publishJob)) {
+    throw new Error('Release publish must not ask setup-node to create token-backed registry authentication.');
   }
-  for (const required of ["'publish'", "'--provenance'", "'--access', 'public'", "'--tag', stagingTag", "'--registry', registry", 'releaseContract.publication.registry', 'requireExistingPackage']) {
+  if (!/- run: node scripts\/verify-release-hosting\.mjs\n\s+env:\n\s+GH_TOKEN: \$\{\{ github\.token \}\}/.test(publishJob)) {
+    throw new Error('Release publish must expose the ephemeral GitHub token to hosting verification.');
+  }
+  if (!/gh release create[\s\S]*release:publish[\s\S]*release:verify-registry[\s\S]*release:finalize-assets[\s\S]*gh release edit/.test(publishJob)) {
+    throw new Error('Release publish must create a draft before direct publication, then verify the registry before finalizing the GitHub release.');
+  }
+  for (const required of ["'publish'", "'--provenance'", "'--access', 'public'", "'--tag', distTag", "'--registry', registry", 'releaseContract.publication.registry', 'releaseContract.publication.distTag', 'requireExistingPackage', 'waitForDistTag']) {
     if (!publishScript.includes(required)) throw new Error(`Release publisher is missing ${required}.`);
+  }
+  if (publishScript.includes('stagingDistTagPrefix') || publishScript.includes("'dist-tag'")) {
+    throw new Error('Release publisher must publish directly to latest without a staging or dist-tag mutation phase.');
   }
   for (const required of ["'--registry', registry", 'releaseContract.publication.registry']) {
     if (!registryVerificationScript.includes(required)) throw new Error(`Registry verifier is missing ${required}.`);


### PR DESCRIPTION
## What changed

- publish all 17 lockstep packages directly to `latest` through npm Trusted Publishing/OIDC
- run registry, provenance, dist-tag, clean-install, and public-type verification in the same protected job
- keep the GitHub release as a draft until the complete package train passes verification
- make partial package-train retries idempotent by verifying and skipping matching immutable versions
- update the executable contract, schema, validator, ADR, release runbook, roadmap, and changelog

## Why

The previous staging flow required 17 interactive `npm dist-tag` operations with 2FA. Trusted Publishing can publish packages but cannot perform dist-tag mutations. Publishing directly under `latest` removes both long-lived npm credentials and the per-package 2FA promotion phase.

The accepted tradeoff is that npm does not offer atomic multi-package publication. A failed train can temporarily leave only part of the packages on the new `latest` version. The workflow records this risk, remains safely repeatable for matching immutable versions, and does not publish the GitHub release until the full train passes clean-room verification.

## Validation

- `npm run check`
- `npm run check:release-contract`
- `npm run check:security`
- release workflow YAML parse
- `publish-release.mjs --dry-run` against all 17 immutable v1.0.6 release archives using `--tag latest`

Closes #154