### PR TITLE
Record Gluon 1.0.7 as released

### DIFF
--- a/docs-site/content/1.0.7/guides/releasing/index.md
+++ b/docs-site/content/1.0.7/guides/releasing/index.md
@@ -1,11 +1,12 @@
 # Release readiness
 
-The `1.0.7` documentation describes one lockstep supported release line.
-Availability is established only when all 17 contracted npm packages expose
-the immutable `1.0.7` version under `latest` and GitHub release `v1.0.7` is
-published. The protected workflow enforces that boundary. The `@gluonjs`
-scope, package records, and trusted-publisher bindings are verified in the
-package contract.
+The `1.0.7` documentation describes one lockstep supported release line. All
+17 contracted npm packages expose immutable version `1.0.7` under `latest`
+with SLSA provenance, and immutable GitHub release `v1.0.7` was published on
+2026-07-14. Protected recovery workflow `29338710037` established that state
+through candidate, reproducibility, Trusted Publishing, clean-install registry
+verification, and release finalization. The `@gluonjs` scope, package records,
+and trusted-publisher bindings are verified in the package contract.
 
 Gluon's release group contains 17 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,
@@ -103,7 +104,12 @@ machine-verified recovery uses protected execution tag
 release workflow, recovery validation, documentation, and renewed evidence
 paths. Package sources, manifests, READMEs, licenses, and changelogs cannot
 differ. Trusted Publishing still publishes version `1.0.7`, and the GitHub
-release remains attached to canonical tag `v1.0.7`.
+release remains attached to canonical tag `v1.0.7`. Recovery execution tag
+`v1.0.7-recovery.1` retained both required histories at merge commit
+`16355e237134b664ec385e6caeb575093eb20251`; release run `29338710037` then
+passed every gate, published all 17 packages to `latest` with SLSA provenance,
+verified a clean install, and published the immutable canonical GitHub release
+on 2026-07-14.
 
 The maintained [release operations runbook](https://github.com/marcmalerei/gluon/blob/main/docs/releasing.md)
 defines the exact candidate, tag, protected publication, registry verification,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,16 +7,14 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.0.7` candidate. Every official
-manifest is public and lockstep at `1.0.7`. GitHub release `v1.0.6` remains the
-current immutable release, all 17 contracted npm packages expose `1.0.6` as
-`latest`, and the `1.0.7` package versions remain absent. The first `v1.0.7`
-Release run `29335253064` stopped before reproducibility, publication, or draft
-creation because PR #157 had been squash-merged: tested commit `192d647` is not
-an ancestor of immutable tagged commit `6c1d95a`, although tagged and reviewed
-evidence commits have the identical tree `0395fab4`. This is enforced locally
-by:
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for `1.0.7`. Every official manifest is public and
+lockstep at `1.0.7`. All 17 contracted npm packages expose `1.0.7` as `latest`
+with SLSA provenance, and immutable GitHub release `v1.0.7` was published on
+2026-07-14. Recovery workflow `29338710037` completed candidate,
+reproducibility, Trusted Publishing, clean-install registry verification, and
+release finalization from execution tag `v1.0.7-recovery.1` while preserving
+the canonical `v1.0.7` tag. This is enforced locally by:
 
 ```sh
 npm run check:release-contract
@@ -100,7 +98,13 @@ created, and registry verification found no official `1.0.7` package version.
 The exact one-time recovery manifest is `release/recovery/1.0.7.json`. It
 preserves the canonical tag, records the identical canonical and reviewed
 evidence tree, and permits only the recovery workflow, validation,
-documentation, and renewed evidence files to differ.
+documentation, and renewed evidence files to differ. Recovery execution tag
+`v1.0.7-recovery.1` points to merge commit
+`16355e237134b664ec385e6caeb575093eb20251`, which retains both required
+histories. Release run `29338710037` passed every gate, published all 17
+packages directly to `latest` through Trusted Publishing with SLSA provenance,
+verified them from a clean install, and published the immutable canonical
+GitHub release `v1.0.7` on 2026-07-14.
 
 `create-gluon` is part of the same lockstep group even though it has no runtime
 dependency. Its generated UI manifest pins `@gluonjs/core`, `@gluonjs/atoms`,

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-07-14",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "All 17 contracted npm package records expose 1.0.6 as latest, version 1.0.7 is unpublished, and the existing GitHub Actions trusted-publisher bindings previously published the complete 1.0.6 train."
+    "publicationState": "released",
+    "observation": "All 17 contracted npm package records expose 1.0.7 as latest with SLSA provenance. Release workflow 29338710037 completed clean-install registry verification, and immutable GitHub release v1.0.7 was published on 2026-07-14."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary

- move the package contract from `ready` to `released`
- record that all 17 npm packages expose `1.0.7` as `latest` with SLSA provenance
- record successful release workflow `29338710037` and immutable GitHub release `v1.0.7`
- update the maintained and versioned release documentation with the completed recovery outcome

## Live verification

- all 17 contracted npm packages: version `1.0.7`, `latest=1.0.7`, SLSA provenance present
- GitHub release `v1.0.7`: published, non-draft, non-prerelease, immutable
- release workflow https://github.com/marcmalerei/gluon/actions/runs/29338710037: success

## Validation

- `npm run check`
- `npm run check:release-contract`
- `npm run check:release-artifacts`
- `npm run check:docs`

Closes #156