### PR TITLE
Record Gluon 1.0.8 publication state

### DIFF
--- a/docs-site/content/1.0.8/guides/releasing/index.md
+++ b/docs-site/content/1.0.8/guides/releasing/index.md
@@ -1,11 +1,12 @@
 # Release readiness
 
-The `1.0.8` documentation describes the prepared lockstep release candidate.
-All 17 official manifests are at `1.0.8`. Registry preflight on 2026-07-15
-confirmed that `1.0.8` is absent while all contracted npm packages still expose
-`1.0.7` under `latest`; immutable GitHub release `v1.0.7` remains current. The
-`@gluonjs` scope, package records, and trusted-publisher bindings are verified
-in the package contract.
+The `1.0.8` documentation describes one lockstep supported release line. All
+17 contracted npm packages expose immutable version `1.0.8` under `latest`
+with SLSA provenance, and immutable GitHub release `v1.0.8` was published on
+2026-07-15. Release workflow `29403576667` completed candidate,
+reproducibility, Trusted Publishing, clean-install registry verification, and
+release finalization from the canonical tag. The `@gluonjs` scope, package
+records, and trusted-publisher bindings are verified in the package contract.
 
 Gluon's release group contains 17 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,12 +7,14 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.0.8` candidate. Every official
-manifest is public and lockstep at `1.0.8`. Registry preflight on 2026-07-15
-confirmed that all 17 contracted npm packages still expose `1.0.7` as `latest`
-and that `1.0.8` is absent. Immutable GitHub release `v1.0.7` remains the
-current release. This is enforced locally by:
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for `1.0.8`. Every official manifest is public and
+lockstep at `1.0.8`. All 17 contracted npm packages expose `1.0.8` as `latest`
+with SLSA provenance, and immutable GitHub release `v1.0.8` was published on
+2026-07-15. Release workflow `29403576667` completed candidate,
+reproducibility, Trusted Publishing, clean-install registry verification, and
+release finalization from the canonical `v1.0.8` tag. This is enforced locally
+by:
 
 ```sh
 npm run check:release-contract

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-07-15",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-07-15 confirmed that all 17 contracted npm package records still expose 1.0.7 as latest and that version 1.0.8 is absent. Existing trusted-publisher bindings successfully published the complete 1.0.7 train with SLSA provenance."
+    "publicationState": "released",
+    "observation": "All 17 contracted npm package records expose 1.0.8 as latest with SLSA provenance. Release workflow 29403576667 completed reproducibility, Trusted Publishing, clean-install registry verification, and immutable GitHub release v1.0.8 publication on 2026-07-15."
   },
   "packages": [
     {


### PR DESCRIPTION
Closes #169

## What changed

- records the completed v1.0.8 publication state in the package contract
- updates release operations and versioned release documentation with the successful workflow and registry facts

## Verified live state

- Release workflow 29403576667 succeeded
- immutable GitHub release v1.0.8 is published
- all 17 contracted npm packages expose 1.0.8 as latest
- all 17 records expose integrity, shasum, and SLSA provenance metadata

## Checks

- `npm run check:release-contract`
- `npm run check:docs`