### PR TITLE
Record Gluon 1.0.10 publication

### DIFF
--- a/docs-site/content/1.0.10/guides/releasing/index.md
+++ b/docs-site/content/1.0.10/guides/releasing/index.md
@@ -1,10 +1,10 @@
 # Release readiness
 
-The `1.0.10` documentation describes the prepared lockstep release candidate.
-All 17 official manifests are at `1.0.10`. Registry preflight on 2026-07-15
-confirmed that `1.0.10` is absent while all contracted npm packages expose
-`1.0.9` under `latest` with SLSA provenance. Immutable GitHub release `v1.0.8`
-remains the current finalized release; the `v1.0.9` GitHub release remains a
+The `1.0.10` documentation describes the completed lockstep release. All 17
+official manifests and npm packages are at `1.0.10`. Release run `29426558738`
+attempt 2 published every package under `latest` with SLSA provenance, passed
+clean-room installation and public-type verification, and published immutable
+GitHub release `v1.0.10` on 2026-07-15. The `v1.0.9` GitHub release remains a
 draft after its public-type verification failure. The `@gluonjs` scope,
 package records, and trusted-publisher bindings are verified in the package
 contract.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,13 +7,14 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.0.10` candidate. Every official
-manifest is public and lockstep at `1.0.10`. Registry preflight on 2026-07-15
-confirmed that all 17 contracted npm packages expose `1.0.9` as `latest` with
-SLSA provenance and that `1.0.10` is absent. Immutable GitHub release `v1.0.8`
-remains the current finalized release; the `v1.0.9` GitHub release remains a
-draft after its public-type verification failure. This is enforced locally by:
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for the completed `1.0.10` release. Every official
+manifest is public and lockstep at `1.0.10`. Release run `29426558738` attempt 2
+published all 17 contracted npm packages under `latest` with SLSA provenance,
+passed clean-room installation and public-type verification, and published
+immutable GitHub release `v1.0.10` on 2026-07-15. The `v1.0.9` GitHub release
+remains a draft after its public-type verification failure. This is enforced
+locally by:
 
 ```sh
 npm run check:release-contract

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security threat model
 
-This threat model applies to the prepared `1.0.10` release line. Its
+This threat model applies to the released `1.0.10` release line. Its
 machine-readable source is
 [`quality/security-threat-model.json`](../quality/security-threat-model.json),
 and `npm run check:security` rejects missing threat areas or evidence paths.

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-07-15",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-07-15 confirmed that all 17 contracted npm package records expose 1.0.9 as latest with SLSA provenance and that version 1.0.10 is absent. Release run 29422302132 preserved a GitHub draft after the published Core declaration bundle failed clean-room type verification; 1.0.10 supersedes the immutable 1.0.9 npm packages."
+    "publicationState": "released",
+    "observation": "Release run 29426558738 attempt 2 completed on 2026-07-15. All 17 contracted npm packages expose 1.0.10 as latest with SLSA provenance; clean-room installation and public-type verification passed, and GitHub release v1.0.10 is published and immutable."
   },
   "packages": [
     {


### PR DESCRIPTION
Closes #184

## Summary
- mark the 1.0.10 package train as released
- record Release run 29426558738 attempt 2 and immutable GitHub release completion
- update maintained and versioned release/security documentation

## Verification
- `npm run check:security`
- `npm run check:docs`
- `npm run check:release-contract`
- `npm run check:release-artifacts`
- all 17 npm packages independently verified at `latest = 1.0.10` with SLSA provenance