### PR TITLE
Record Gluon 1.1.0 publication

### DIFF
--- a/docs-site/content/1.1.0/guides/releasing/index.md
+++ b/docs-site/content/1.1.0/guides/releasing/index.md
@@ -1,10 +1,10 @@
 # Release readiness
 
 The `1.1.0` documentation describes the completed lockstep release. All 17
-official manifests and npm packages are at `1.1.0`. Release run `29426558738`
-attempt 2 published every package under `latest` with SLSA provenance, passed
-clean-room installation and public-type verification, and published immutable
-GitHub release `v1.1.0` on 2026-07-15. The `v1.0.9` GitHub release remains a
+official manifests and npm packages are at `1.1.0`. Release run `29496068214`
+published every package under `latest` with SLSA provenance, passed clean-room
+installation and public-type verification, and published immutable GitHub
+release `v1.1.0` on 2026-07-16. The `v1.0.9` GitHub release remains a
 draft after its public-type verification failure. The `@gluonjs` scope,
 package records, and trusted-publisher bindings are verified in the package
 contract.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,12 +7,12 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.1.0` candidate. Every official
-manifest is public and lockstep at `1.1.0`. Registry preflight on 2026-07-16
-confirmed that all 17 contracted npm packages expose `1.0.10` as `latest` with
-SLSA provenance and that `1.1.0` is absent. Immutable GitHub release `v1.0.10`
-remains the current finalized release; the `v1.0.9` GitHub release remains a
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for the completed `1.1.0` release. Every official
+manifest is public and lockstep at `1.1.0`. Release run `29496068214` published
+all 17 contracted npm packages under `latest` with SLSA provenance, passed
+clean-room installation and public-type verification, and published immutable
+GitHub release `v1.1.0` on 2026-07-16. The `v1.0.9` GitHub release remains a
 draft after its public-type verification failure. This is enforced locally by:
 
 ```sh

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security threat model
 
-This threat model applies to the prepared `1.1.0` release line. Its
+This threat model applies to the released `1.1.0` release line. Its
 machine-readable source is
 [`quality/security-threat-model.json`](../quality/security-threat-model.json),
 and `npm run check:security` rejects missing threat areas or evidence paths.

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-07-15",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-07-16 confirmed that all 17 contracted npm package records expose 1.0.10 as latest with SLSA provenance and that version 1.1.0 is absent. The prepared 1.1.0 candidate advances the current verified capability set."
+    "publicationState": "released",
+    "observation": "Release run 29496068214 completed on 2026-07-16. All 17 contracted npm packages expose 1.1.0 as latest with SLSA provenance; clean-room installation and public-type verification passed, and GitHub release v1.1.0 is published and immutable."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary\n\n- record successful Release run 29496068214\n- mark the 17-package lockstep train as published\n- correct the versioned release guide to the actual 1.1.0 run and publication date\n- mark the 1.1.0 threat model as released\n\n## Live verification\n\n- all 17 npm packages expose 1.1.0 as latest\n- all 17 npm versions expose integrity and attestation endpoints\n- GitHub release v1.1.0 is immutable, non-draft, and published\n- npm run check:release-contract\n- npm run check:security\n- npm run check:docs\n\nRefs #209