### PR TITLE
feat(quarks): define component library manifest contract

### DIFF
--- a/docs-site/api-examples.json
+++ b/docs-site/api-examples.json
@@ -1,6 +1,27 @@
 {
   "version": 1,
   "recipes": {
+    "component-library-manifest": {
+      "module": "@gluonjs/quarks",
+      "code": [
+        "import { validateComponentLibraryManifest, type ComponentLibraryEntry, type ComponentLibraryManifest, type ComponentLibraryManifestValidation } from '@gluonjs/quarks';",
+        "",
+        "const entry = {",
+        "  id: 'product-configurator',",
+        "  module: '@acme/shop-components/product-configurator',",
+        "  exportName: 'ProductConfigurator',",
+        "  layer: 'element',",
+        "  tag: 'acme-product-configurator',",
+        "  styles: ['acme-product-configurator'],",
+        "  dependencies: [],",
+        "  accessibility: 'Uses labelled native choices.',",
+        "} as const satisfies ComponentLibraryEntry;",
+        "const manifest = { schemaVersion: 1, name: '@acme/shop-components', entries: [entry] } as const satisfies ComponentLibraryManifest;",
+        "const result: ComponentLibraryManifestValidation = validateComponentLibraryManifest(manifest);",
+        "if (!result.valid) throw new Error(result.errors.join('\\n'));",
+        "console.log(manifest.entries[0]?.module);"
+      ]
+    },
     "create-gluon-io": {
       "module": "create-gluon",
       "code": [
@@ -3722,6 +3743,10 @@
       "recipe": "quark-headless",
       "description": "Contain Tab focus inside an owned panel, choose its initial target, and restore the connected trigger when the scope closes:"
     },
+    "packages/quarks/src/functions/validateComponentLibraryManifest.md": {
+      "recipe": "component-library-manifest",
+      "description": "Validate a serializable component-library manifest before a consumer resolves any requested public module:"
+    },
     "packages/quarks/src/functions/Field.md": {
       "recipe": "quark-headless",
       "description": "Render a native label around form content and show either helper text or an announced error message:"
@@ -3757,6 +3782,18 @@
     "packages/quarks/src/interfaces/FieldProps.md": {
       "recipe": "quark-headless",
       "description": "Supply required visible label and form content plus optional helper, error, and native label attributes:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryEntry.md": {
+      "recipe": "component-library-manifest",
+      "description": "Describe a requested public component module, its styles, dependencies, accessibility contract, and optional custom-element tag:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryManifest.md": {
+      "recipe": "component-library-manifest",
+      "description": "Publish a versioned, serializable inventory without importing modules or registering elements as a side effect:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryManifestValidation.md": {
+      "recipe": "component-library-manifest",
+      "description": "Inspect all structural manifest errors before handing records to an explicit consumer-owned loader:"
     },
     "packages/quarks/src/interfaces/FocusScope.md": {
       "recipe": "quark-headless",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -542,6 +542,12 @@ itself remains developer tooling.
 
 ## Developer-experience evidence boundary
 
+Optional third-party component libraries use the versioned public manifest
+contract in [`component-library-contract.md`](component-library-contract.md).
+That contract names public module, export, stylesheet, dependency, accessibility,
+and optional custom-element-tag metadata without making imports, registrations,
+or style adoption implicit runtime behavior.
+
 The issue #107 comparison is an evidence system, not a framework runtime or an
 application dependency. Its versioned task contract and completed-run JSON
 schema live under `benchmarks/dx`; they do not enter Core, UI, Router, Store,

--- a/docs/component-library-contract.md
+++ b/docs/component-library-contract.md
@@ -1,0 +1,68 @@
+# Component-library manifest and loader contract
+
+This document specifies the public boundary for an optional Gluon component
+library. It is a contract, not an implementation guide for importing arbitrary
+application code. The canonical customer acceptance surface remains GLUON
+GOODS; a library explorer or Storybook is developer evidence only.
+
+## Manifest
+
+Libraries publish a serializable `ComponentLibraryManifest` from
+`@gluonjs/quarks`. Its version is currently `1`. Every entry has a stable
+library-local `id`, a bare public ESM `module` specifier, named `exportName`,
+layer, exact stylesheet ids, dependency ids, and an accessibility summary.
+An `element` entry additionally supplies one unique custom-element `tag`.
+
+```ts
+import { type ComponentLibraryManifest } from '@gluonjs/quarks';
+
+export const manifest = {
+  schemaVersion: 1,
+  name: '@acme/shop-components',
+  entries: [{
+    id: 'product-configurator',
+    module: '@acme/shop-components/product-configurator',
+    exportName: 'ProductConfigurator',
+    layer: 'element',
+    tag: 'acme-product-configurator',
+    styles: ['acme-product-configurator'],
+    dependencies: ['purchase-action'],
+    accessibility: 'Uses labelled native choices and exposes an add event.',
+    storyId: 'product-configurator--default',
+  }],
+} as const satisfies ComponentLibraryManifest;
+```
+
+Consumers must call `validateComponentLibraryManifest()` before using JSON from
+outside their trusted build. Validation performs no import or registration.
+Manifest ids, element tags, and module/export targets are public compatibility
+surface; a breaking rename requires a major version.
+
+## Loader requirements
+
+A future loader resolves only a consumer-requested entry and its declared
+dependencies. It exposes its load state, cached result, and failure explicitly;
+it must not register an entire library as an import side effect. It may resolve
+only declared bare public module specifiers and named public exports.
+
+For an element it must first check the selected registry: an existing identical
+constructor is a cache hit, while a different constructor for the same tag is a
+reported duplicate-registration error. Functional entries never register a
+custom element.
+
+Styles are constructable sheets owned by an explicit target-scoped owner. A
+loader retains exactly the requested entry styles, returns a disposal handle,
+and releases exactly those references once the consumer tears down. It must not
+use a `<style>` fallback. SSR must retain the selected stylesheet ids in its
+request-local manifest; hydration must validate and hand off the same ordered
+ids without replacing retained DOM.
+
+The loader is intentionally separate from this schema so that package authors,
+bundlers, SSR adapters, and applications retain explicit authority over imports,
+registries, style roots, cache lifetime, error reporting, and disposal.
+
+## Verification boundary
+
+`npm run typecheck:ui` compiles the public manifest API. `npm run
+check:ui-contract` retains the existing official UI inventory; the library and
+loader implementation slices add their own packed-consumer and browser gates.

--- a/packages/quarks/src/component-library.ts
+++ b/packages/quarks/src/component-library.ts
@@ -1,0 +1,75 @@
+/**
+ * Public, serializable contract for optional component-library records.
+ *
+ * A manifest describes what a consumer may request.  It deliberately does not
+ * import modules, register custom elements, or adopt styles: those observable
+ * effects belong to an explicit loader implementation owned by the consumer.
+ */
+export interface ComponentLibraryEntry {
+  /** Stable, library-local request key such as `product-configurator`. */
+  readonly id: string;
+  /** Public ESM specifier that a loader is allowed to resolve. */
+  readonly module: string;
+  /** Named public export provided by `module`. */
+  readonly exportName: string;
+  /** Functional components render through this public layer. */
+  readonly layer: 'quark' | 'atom' | 'molecule' | 'element';
+  /** Required only for an element that may register a custom-element name. */
+  readonly tag?: `${string}-${string}`;
+  /** Stable constructable-stylesheet ids needed by this record. */
+  readonly styles: readonly string[];
+  /** Other manifest entries that must be loaded first. */
+  readonly dependencies: readonly string[];
+  /** Short consumer-visible accessibility contract. */
+  readonly accessibility: string;
+  /** Stable Storybook story id, when a developer story is supplied. */
+  readonly storyId?: string;
+}
+
+export interface ComponentLibraryManifest {
+  readonly schemaVersion: 1;
+  readonly name: string;
+  readonly entries: readonly ComponentLibraryEntry[];
+}
+
+export interface ComponentLibraryManifestValidation {
+  readonly valid: boolean;
+  readonly errors: readonly string[];
+}
+
+/**
+ * Validates untrusted JSON before a loader uses it for module resolution.
+ * The result contains all structural errors and never performs an import.
+ */
+export function validateComponentLibraryManifest(value: unknown): ComponentLibraryManifestValidation {
+  if (!value || typeof value !== 'object') {
+    return { valid: false, errors: ['Manifest must be an object.'] };
+  }
+  const manifest = value as Partial<ComponentLibraryManifest>;
+  const errors: string[] = [];
+  if (manifest.schemaVersion !== 1) errors.push('Manifest schemaVersion must be 1.');
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) errors.push('Manifest name must be a non-empty string.');
+  if (!Array.isArray(manifest.entries)) {
+    errors.push('Manifest entries must be an array.');
+    return { valid: false, errors };
+  }
+  const ids = new Set<string>();
+  const tags = new Set<string>();
+  for (const [index, entry] of manifest.entries.entries()) {
+    const prefix = `Entry ${index}`;
+    if (!entry || typeof entry !== 'object') { errors.push(`${prefix} must be an object.`); continue; }
+    const candidate = entry as Partial<ComponentLibraryEntry>;
+    if (typeof candidate.id !== 'string' || !/^[a-z][a-z0-9-]*$/.test(candidate.id)) errors.push(`${prefix} id must be a kebab-case string.`);
+    else if (ids.has(candidate.id)) errors.push(`${prefix} duplicates id ${candidate.id}.`); else ids.add(candidate.id);
+    if (typeof candidate.module !== 'string' || !/^(?:@[^/]+\/[^/]+|[a-z][a-z0-9-]*)(?:\/[a-zA-Z0-9._-]+)*$/.test(candidate.module)) errors.push(`${prefix} module must be a bare public ESM specifier.`);
+    if (typeof candidate.exportName !== 'string' || !/^[A-Za-z_$][\w$]*$/.test(candidate.exportName)) errors.push(`${prefix} exportName must be an identifier.`);
+    if (!['quark', 'atom', 'molecule', 'element'].includes(candidate.layer ?? '')) errors.push(`${prefix} layer is invalid.`);
+    if (!Array.isArray(candidate.styles) || candidate.styles.some((style) => typeof style !== 'string' || style.length === 0)) errors.push(`${prefix} styles must be non-empty string ids.`);
+    if (!Array.isArray(candidate.dependencies) || candidate.dependencies.some((dependency) => typeof dependency !== 'string' || dependency.length === 0)) errors.push(`${prefix} dependencies must be string ids.`);
+    if (typeof candidate.accessibility !== 'string' || candidate.accessibility.length === 0) errors.push(`${prefix} accessibility must be a non-empty string.`);
+    if (candidate.layer === 'element' && (typeof candidate.tag !== 'string' || !/^[a-z][a-z0-9]*-[a-z0-9-]+$/.test(candidate.tag))) errors.push(`${prefix} element tag must be a custom-element name.`);
+    if (candidate.layer !== 'element' && candidate.tag !== undefined) errors.push(`${prefix} only an element may declare tag.`);
+    if (candidate.tag) { if (tags.has(candidate.tag)) errors.push(`${prefix} duplicates tag ${candidate.tag}.`); else tags.add(candidate.tag); }
+  }
+  return { valid: errors.length === 0, errors };
+}

--- a/packages/quarks/src/index.ts
+++ b/packages/quarks/src/index.ts
@@ -37,3 +37,9 @@ export {
   type UiContractEntry,
   type UiPackageManifest,
 } from './manifest.js';
+export {
+  validateComponentLibraryManifest,
+  type ComponentLibraryEntry,
+  type ComponentLibraryManifest,
+  type ComponentLibraryManifestValidation,
+} from './component-library.js';

--- a/tests-node/ui.types.ts
+++ b/tests-node/ui.types.ts
@@ -27,6 +27,8 @@ import {
   unsafeQuarkProps,
   type FocusScope,
   type QuarkProps,
+  type ComponentLibraryManifest,
+  validateComponentLibraryManifest,
 } from '@gluonjs/quarks';
 
 const buttonProps: ButtonProps = { label: 'Save', variant: 'primary' };
@@ -56,6 +58,12 @@ owner.setTheme('light');
 owner.styleOwner.retain(theme);
 owner.dispose();
 const manifests = [quarkManifest, atomManifest, moleculeManifest, organismManifest] as const;
+const componentLibraryManifest = {
+  schemaVersion: 1,
+  name: '@acme/shop-components',
+  entries: [{ id: 'purchase-action', module: '@acme/shop-components/purchase-action', exportName: 'PurchaseAction', layer: 'molecule', styles: ['acme-purchase-action'], dependencies: [], accessibility: 'Renders a named purchase action.', storyId: 'purchase-action--default' }],
+} as const satisfies ComponentLibraryManifest;
+const componentLibraryValidation: boolean = validateComponentLibraryManifest(componentLibraryManifest).valid;
 const buttonRef: { value?: HTMLButtonElement } = {};
 const svgRef: { value?: SVGSVGElement } = {};
 const nativeButton = {
@@ -100,6 +108,7 @@ void theme;
 void selection;
 void manifests;
 void buttonStyleId;
+void componentLibraryValidation;
 
 // @ts-expect-error component style metadata is immutable
 Button.styles.push(Button.styles[0]!);

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '../src/index.js';
-import { fragment, htmlTagNames, q, quark } from '@gluonjs/quarks';
+import { fragment, htmlTagNames, q, quark, validateComponentLibraryManifest } from '@gluonjs/quarks';
 
 describe('quarks', () => {
   beforeEach(() => {
@@ -56,5 +56,42 @@ describe('quarks', () => {
 
   it('rejects children for void elements', () => {
     expect(() => q.input({ children: 'invalid' })).toThrow(/cannot receive children/i);
+  });
+
+  it('validates a serializable public component-library manifest without importing it', () => {
+    const result = validateComponentLibraryManifest({
+      schemaVersion: 1,
+      name: '@acme/shop-components',
+      entries: [{
+        id: 'product-configurator',
+        module: '@acme/shop-components/product-configurator',
+        exportName: 'ProductConfigurator',
+        layer: 'element',
+        tag: 'acme-product-configurator',
+        styles: ['acme-product-configurator'],
+        dependencies: ['purchase-action'],
+        accessibility: 'Uses labelled native choices.',
+      }],
+    });
+
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it('rejects unsafe module targets and duplicate element registration names in a manifest', () => {
+    const result = validateComponentLibraryManifest({
+      schemaVersion: 1,
+      name: 'example',
+      entries: [
+        { id: 'one', module: './private', exportName: 'One', layer: 'element', tag: 'acme-panel', styles: [], dependencies: [], accessibility: 'A.' },
+        { id: 'one', module: '@acme/library/two', exportName: 'Two', layer: 'element', tag: 'acme-panel', styles: [], dependencies: [], accessibility: 'B.' },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      'Entry 0 module must be a bare public ESM specifier.',
+      'Entry 1 duplicates id one.',
+      'Entry 1 duplicates tag acme-panel.',
+    ]));
   });
 });

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -94,4 +94,42 @@ describe('quarks', () => {
       'Entry 1 duplicates tag acme-panel.',
     ]));
   });
+
+  it('reports malformed manifests and each invalid entry boundary without importing modules', () => {
+    expect(validateComponentLibraryManifest(null)).toEqual({
+      valid: false,
+      errors: ['Manifest must be an object.'],
+    });
+    expect(validateComponentLibraryManifest({ schemaVersion: 2, name: '', entries: null }).errors).toEqual([
+      'Manifest schemaVersion must be 1.',
+      'Manifest name must be a non-empty string.',
+      'Manifest entries must be an array.',
+    ]);
+
+    const result = validateComponentLibraryManifest({
+      schemaVersion: 1,
+      name: 'example',
+      entries: [null, {
+        id: 'Invalid_Key', module: 'https://untrusted.invalid/component', exportName: 'not an export', layer: 'unknown',
+        tag: 'not-an-element', styles: [''], dependencies: [''], accessibility: '',
+      }, {
+        id: 'functional', module: '@acme/library/functional', exportName: 'Functional', layer: 'atom',
+        tag: 'acme-not-allowed', styles: [], dependencies: [], accessibility: 'A.',
+      }],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(expect.arrayContaining([
+      'Entry 0 must be an object.',
+      'Entry 1 id must be a kebab-case string.',
+      'Entry 1 module must be a bare public ESM specifier.',
+      'Entry 1 exportName must be an identifier.',
+      'Entry 1 layer is invalid.',
+      'Entry 1 styles must be non-empty string ids.',
+      'Entry 1 dependencies must be string ids.',
+      'Entry 1 accessibility must be a non-empty string.',
+      'Entry 1 only an element may declare tag.',
+      'Entry 2 only an element may declare tag.',
+    ]));
+  });
 });


### PR DESCRIPTION
## Summary
- add the public, versioned component-library manifest contract and non-importing structural validator
- document loader authority, registration, stylesheet, SSR/hydration, error and cleanup requirements
- retain runtime, public type, UI-contract and generated API-example evidence

Closes #212

## Checks
- `npx vitest run tests/quarks.spec.ts`
- `npm run build:quarks`
- `npm run typecheck:ui-api`
- `npm run check:ui-contract`
- `npm run check:docs`