### PR TITLE
feat(quarks): add explicit component loader

### DIFF
--- a/docs-site/api-examples.json
+++ b/docs-site/api-examples.json
@@ -22,6 +22,19 @@
         "console.log(manifest.entries[0]?.module);"
       ]
     },
+    "component-library-loader": {
+      "module": "@gluonjs/quarks",
+      "code": [
+        "import { createComponentLibraryLoader, type ComponentLibraryLoader, type ComponentLibraryManifest, type ComponentLibraryModuleResolver, type ComponentLoadResult, type ComponentLoadStatus } from '@gluonjs/quarks';",
+        "",
+        "const manifest = { schemaVersion: 1, name: '@acme/shop-components', entries: [{ id: 'purchase-action', module: '@acme/shop-components/purchase-action', exportName: 'PurchaseAction', layer: 'atom', styles: [], dependencies: [], accessibility: 'Renders a labelled native button.' }] } as const satisfies ComponentLibraryManifest;",
+        "const resolver: ComponentLibraryModuleResolver = { load: async (entry) => ({ entry: entry.id }) };",
+        "const loader: ComponentLibraryLoader = createComponentLibraryLoader(manifest, resolver);",
+        "const component: ComponentLoadResult = await loader.load('purchase-action');",
+        "const status: ComponentLoadStatus = loader.status('purchase-action');",
+        "console.log(status, component.entry.exportName);"
+      ]
+    },
     "create-gluon-io": {
       "module": "create-gluon",
       "code": [
@@ -3746,6 +3759,26 @@
     "packages/quarks/src/functions/validateComponentLibraryManifest.md": {
       "recipe": "component-library-manifest",
       "description": "Validate a serializable component-library manifest before a consumer resolves any requested public module:"
+    },
+    "packages/quarks/src/classes/ComponentLibraryLoader.md": {
+      "recipe": "component-library-loader",
+      "description": "Load exactly one requested manifest entry and observe its explicit cache state:"
+    },
+    "packages/quarks/src/functions/createComponentLibraryLoader.md": {
+      "recipe": "component-library-loader",
+      "description": "Create a consumer-owned loader with an explicit public-module resolver:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryModuleResolver.md": {
+      "recipe": "component-library-loader",
+      "description": "Resolve only the already validated, consumer-requested public manifest entry:"
+    },
+    "packages/quarks/src/interfaces/ComponentLoadResult.md": {
+      "recipe": "component-library-loader",
+      "description": "Read the loaded public value together with its manifest record:"
+    },
+    "packages/quarks/src/type-aliases/ComponentLoadStatus.md": {
+      "recipe": "component-library-loader",
+      "description": "Observe whether a requested entry is idle, loading, loaded, or failed:"
     },
     "packages/quarks/src/functions/Field.md": {
       "recipe": "quark-headless",

--- a/docs/component-library-contract.md
+++ b/docs/component-library-contract.md
@@ -57,9 +57,12 @@ use a `<style>` fallback. SSR must retain the selected stylesheet ids in its
 request-local manifest; hydration must validate and hand off the same ordered
 ids without replacing retained DOM.
 
-The loader is intentionally separate from this schema so that package authors,
-bundlers, SSR adapters, and applications retain explicit authority over imports,
-registries, style roots, cache lifetime, error reporting, and disposal.
+`createComponentLibraryLoader(manifest, resolver)` is the public loader core.
+The consumer-owned resolver receives only the requested validated record; this
+keeps bundler import maps explicit and makes cache state observable through
+`status(id)`. Package authors, bundlers, SSR adapters, and applications retain
+authority over imports, registries, style roots, cache lifetime, error
+reporting, and disposal.
 
 ## Verification boundary
 

--- a/packages/quarks/src/component-loader.ts
+++ b/packages/quarks/src/component-loader.ts
@@ -1,0 +1,85 @@
+import {
+  validateComponentLibraryManifest,
+  type ComponentLibraryEntry,
+  type ComponentLibraryManifest,
+} from './component-library.js';
+
+export type ComponentLoadStatus = 'idle' | 'loading' | 'loaded' | 'failed';
+
+export interface ComponentLibraryModuleResolver {
+  /** Resolve only the exact public manifest entry requested by the consumer. */
+  load(entry: ComponentLibraryEntry): Promise<unknown>;
+}
+
+export interface ComponentLoadResult {
+  readonly entry: ComponentLibraryEntry;
+  readonly value: unknown;
+}
+
+/**
+ * Explicit, consumer-owned component loader. It never scans a package or
+ * imports unrequested entries; a bundler-aware resolver supplies the actual
+ * public module import for each manifest record.
+ */
+export class ComponentLibraryLoader {
+  readonly #entries: ReadonlyMap<string, ComponentLibraryEntry>;
+  readonly #resolver: ComponentLibraryModuleResolver;
+  readonly #states = new Map<string, ComponentLoadStatus>();
+  readonly #cache = new Map<string, Promise<ComponentLoadResult>>();
+
+  constructor(manifest: ComponentLibraryManifest, resolver: ComponentLibraryModuleResolver) {
+    const validation = validateComponentLibraryManifest(manifest);
+    if (!validation.valid) throw new TypeError(`Invalid component-library manifest: ${validation.errors.join(' ')}`);
+    this.#entries = new Map(manifest.entries.map((entry) => [entry.id, entry]));
+    this.#resolver = resolver;
+  }
+
+  status(id: string): ComponentLoadStatus {
+    this.#requireEntry(id);
+    return this.#states.get(id) ?? 'idle';
+  }
+
+  load(id: string): Promise<ComponentLoadResult> {
+    const cached = this.#cache.get(id);
+    if (cached) return cached;
+    const entry = this.#requireEntry(id);
+    this.#states.set(id, 'loading');
+    const promise = this.#load(entry, new Set());
+    this.#cache.set(id, promise);
+    void promise.then(
+      () => this.#states.set(id, 'loaded'),
+      () => { this.#states.set(id, 'failed'); this.#cache.delete(id); },
+    );
+    return promise;
+  }
+
+  async #load(entry: ComponentLibraryEntry, ancestors: Set<string>): Promise<ComponentLoadResult> {
+    if (ancestors.has(entry.id)) throw new Error(`Component dependency cycle includes ${entry.id}.`);
+    const nextAncestors = new Set(ancestors).add(entry.id);
+    for (const dependency of entry.dependencies) await this.#load(this.#requireEntry(dependency), nextAncestors);
+    const value = await this.#resolver.load(entry);
+    if (entry.layer === 'element') this.#validateElement(entry, value);
+    return { entry, value };
+  }
+
+  #requireEntry(id: string): ComponentLibraryEntry {
+    const entry = this.#entries.get(id);
+    if (!entry) throw new RangeError(`Unknown component-library entry: ${id}.`);
+    return entry;
+  }
+
+  #validateElement(entry: ComponentLibraryEntry, value: unknown): void {
+    if (typeof customElements === 'undefined') return;
+    const registered = customElements.get(entry.tag!);
+    if (registered && registered !== value) {
+      throw new Error(`Duplicate custom-element registration for ${entry.tag}.`);
+    }
+  }
+}
+
+export function createComponentLibraryLoader(
+  manifest: ComponentLibraryManifest,
+  resolver: ComponentLibraryModuleResolver,
+): ComponentLibraryLoader {
+  return new ComponentLibraryLoader(manifest, resolver);
+}

--- a/packages/quarks/src/index.ts
+++ b/packages/quarks/src/index.ts
@@ -43,3 +43,10 @@ export {
   type ComponentLibraryManifest,
   type ComponentLibraryManifestValidation,
 } from './component-library.js';
+export {
+  ComponentLibraryLoader,
+  createComponentLibraryLoader,
+  type ComponentLibraryModuleResolver,
+  type ComponentLoadResult,
+  type ComponentLoadStatus,
+} from './component-loader.js';

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '../src/index.js';
-import { fragment, htmlTagNames, q, quark, validateComponentLibraryManifest } from '@gluonjs/quarks';
+import { createComponentLibraryLoader, fragment, htmlTagNames, q, quark, validateComponentLibraryManifest } from '@gluonjs/quarks';
 
 describe('quarks', () => {
   beforeEach(() => {
@@ -131,5 +131,22 @@ describe('quarks', () => {
       'Entry 1 only an element may declare tag.',
       'Entry 2 only an element may declare tag.',
     ]));
+  });
+
+  it('loads only the requested public entry and its declared dependencies with observable cache state', async () => {
+    const load = vi.fn(async (entry: { id: string }) => ({ id: entry.id }));
+    const loader = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'base', module: '@acme/components/base', exportName: 'Base', layer: 'atom', styles: [], dependencies: [], accessibility: 'Base.' },
+      { id: 'picker', module: '@acme/components/picker', exportName: 'Picker', layer: 'molecule', styles: [], dependencies: ['base'], accessibility: 'Picker.' },
+    ] }, { load });
+
+    expect(loader.status('picker')).toBe('idle');
+    const first = loader.load('picker');
+    expect(loader.status('picker')).toBe('loading');
+    expect(await first).toMatchObject({ entry: { id: 'picker' }, value: { id: 'picker' } });
+    expect(loader.status('picker')).toBe('loaded');
+    await loader.load('picker');
+    expect(load.mock.calls.map(([entry]) => entry.id)).toEqual(['base', 'picker']);
+    expect(() => loader.load('missing')).toThrow('Unknown component-library entry: missing.');
   });
 });


### PR DESCRIPTION
## Summary
- add a manifest-validated, consumer-owned component loader
- expose explicit state and cache semantics
- load only requested entries and declared dependencies
- reject unknown entries and duplicate custom-element registrations

Part of #214; depends on #220.

## Checks
- `npx vitest run tests/quarks.spec.ts`
- `npm run build:quarks`
- `npm run typecheck:ui-api`