### PR TITLE
bench: add reproducible bundle matrix

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -95,6 +95,7 @@ jobs:
           cache: npm
       - run: npm ci --ignore-scripts
       - run: npx playwright install --with-deps chromium firefox webkit
+      - run: npm run benchmark:bundle
       - run: npm run benchmark:rendering -- --samples=10 --warmup=4 --output=.tmp/quality-evidence/rendering.json
       - run: npm run benchmark:components -- --samples=10 --warmup=4 --output=.tmp/quality-evidence/components.json
       - run: npm run check:shop-performance
@@ -103,6 +104,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: quality-evidence-${{ github.sha }}
-          path: .tmp/quality-evidence
+          path: |
+            .tmp/quality-evidence
+            .tmp/bundle-matrix/report.json
           retention-days: 30
           if-no-files-found: error

--- a/benchmarks/bundle/README.md
+++ b/benchmarks/bundle/README.md
@@ -1,0 +1,16 @@
+# Bundle-size matrix
+
+`npm run benchmark:bundle` builds the same labelled counter interaction with
+Gluon, Lit, Vue, and React in production mode. Every fixture renders a heading,
+a native labelled button, and a polite live output; all use one entry and no
+application router, component library, CSS framework, or code splitting.
+
+The command rebuilds Gluon Core, records Node/npm/lockfile metadata, and writes
+the raw, gzip level 9, and Brotli quality 11 byte totals to
+`.tmp/bundle-matrix/report.json`. The Vite manifests remain beside each build
+for chunk inspection. Results are a bounded import-and-render scenario, not a
+general framework-size ranking.
+
+Before changing fixture behavior, keep observable DOM and accessibility parity
+across all four implementations. Add a separate fixture rather than silently
+changing the measured scenario.

--- a/benchmarks/bundle/README.md
+++ b/benchmarks/bundle/README.md
@@ -5,10 +5,13 @@ Gluon, Lit, Vue, and React in production mode. Every fixture renders a heading,
 a native labelled button, and a polite live output; all use one entry and no
 application router, component library, CSS framework, or code splitting.
 
-The command rebuilds Gluon Core, records Node/npm/lockfile metadata, and writes
-the raw, gzip level 9, and Brotli quality 11 byte totals to
+The command rebuilds Gluon Core, production-builds and browser-verifies each
+fixture before measuring it, records Node/npm/lockfile metadata and the Vite
+module graph, and writes the raw, gzip level 9, and Brotli quality 11 byte totals to
 `.tmp/bundle-matrix/report.json`. The Vite manifests remain beside each build
-for chunk inspection. Results are a bounded import-and-render scenario, not a
+for chunk inspection. Quality Gates run this gate and retain its report to
+prevent fixture or toolchain drift from silently changing the comparison.
+Results are a bounded import-and-render scenario, not a
 general framework-size ranking.
 
 Before changing fixture behavior, keep observable DOM and accessibility parity

--- a/benchmarks/bundle/fixtures/gluon/index.html
+++ b/benchmarks/bundle/fixtures/gluon/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div><script type="module" src="./main.ts"></script>

--- a/benchmarks/bundle/fixtures/gluon/main.ts
+++ b/benchmarks/bundle/fixtures/gluon/main.ts
@@ -1,0 +1,6 @@
+import { html, render } from '@gluonjs/core';
+
+let count = 0;
+const root = document.querySelector('#app')!;
+const update = (): void => render(html`<main><h1>Bundle fixture</h1><button type="button" aria-label="Increment" @click=${() => { count += 1; update(); }}>Increment</button><output aria-live="polite">${count}</output></main>`, root);
+update();

--- a/benchmarks/bundle/fixtures/lit/index.html
+++ b/benchmarks/bundle/fixtures/lit/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div><script type="module" src="./main.ts"></script>

--- a/benchmarks/bundle/fixtures/lit/main.ts
+++ b/benchmarks/bundle/fixtures/lit/main.ts
@@ -1,0 +1,6 @@
+import { html, render } from 'lit-html';
+
+let count = 0;
+const root = document.querySelector('#app')!;
+const update = (): void => render(html`<main><h1>Bundle fixture</h1><button type="button" aria-label="Increment" @click=${() => { count += 1; update(); }}>Increment</button><output aria-live="polite">${count}</output></main>`, root);
+update();

--- a/benchmarks/bundle/fixtures/lit/main.ts
+++ b/benchmarks/bundle/fixtures/lit/main.ts
@@ -1,6 +1,6 @@
 import { html, render } from 'lit-html';
 
 let count = 0;
-const root = document.querySelector('#app')!;
-const update = (): void => render(html`<main><h1>Bundle fixture</h1><button type="button" aria-label="Increment" @click=${() => { count += 1; update(); }}>Increment</button><output aria-live="polite">${count}</output></main>`, root);
+const root = document.querySelector<HTMLElement>('#app')!;
+const update = (): void => { render(html`<main><h1>Bundle fixture</h1><button type="button" aria-label="Increment" @click=${() => { count += 1; update(); }}>Increment</button><output aria-live="polite">${count}</output></main>`, root); };
 update();

--- a/benchmarks/bundle/fixtures/react/index.html
+++ b/benchmarks/bundle/fixtures/react/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div><script type="module" src="./main.ts"></script>

--- a/benchmarks/bundle/fixtures/react/main.ts
+++ b/benchmarks/bundle/fixtures/react/main.ts
@@ -1,0 +1,8 @@
+import { createElement, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+function Fixture() {
+  const [count, setCount] = useState(0);
+  return createElement('main', null, createElement('h1', null, 'Bundle fixture'), createElement('button', { type: 'button', 'aria-label': 'Increment', onClick: () => setCount(count + 1) }, 'Increment'), createElement('output', { 'aria-live': 'polite' }, count));
+}
+createRoot(document.querySelector('#app')!).render(createElement(Fixture));

--- a/benchmarks/bundle/fixtures/vue/index.html
+++ b/benchmarks/bundle/fixtures/vue/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div><script type="module" src="./main.ts"></script>

--- a/benchmarks/bundle/fixtures/vue/main.ts
+++ b/benchmarks/bundle/fixtures/vue/main.ts
@@ -1,0 +1,6 @@
+import { createApp, h, ref } from 'vue';
+
+createApp({ setup: () => {
+  const count = ref(0);
+  return () => h('main', [h('h1', 'Bundle fixture'), h('button', { type: 'button', 'aria-label': 'Increment', onClick: () => { count.value += 1; } }, 'Increment'), h('output', { 'aria-live': 'polite' }, String(count.value))]);
+} }).mount('#app');

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -426,3 +426,10 @@ The shop flow has its own non-comparative p95 budgets in
 navigation, bag opening, and checkout navigation in the production build and
 preserves all raw samples. The thresholds are regression ceilings, not user
 experience guarantees across networks or devices.
+# Bundle-size matrix
+
+`npm run benchmark:bundle` produces a reproducible, production-mode size matrix
+for a deliberately small equivalent Gluon, Lit, Vue, and React fixture. It
+records raw, gzip, and Brotli bytes together with Node, npm, and lockfile
+metadata. See [the fixture contract](../benchmarks/bundle/README.md). This is
+scenario evidence only; it does not establish a universal bundle-size ranking.

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "dev:benchmark": "vite --config benchmarks/rendering/vite.config.ts",
     "dev:benchmark:components": "vite --config benchmarks/components/vite.config.ts",
     "measure:shop": "npm run build:shop && node scripts/measure-shop-build.mjs",
+    "benchmark:bundle": "node scripts/run-bundle-matrix.mjs",
     "typecheck": "npm run typecheck:core && npm run typecheck:decorators-legacy && npm run typecheck:ui && npm run typecheck:reactivity && npm run typecheck:router && npm run typecheck:store && npm run typecheck:ssr && npm run typecheck:compiler && npm run typecheck:vite && npm run typecheck:test-utils && npm run typecheck:devtools-api && npm run typecheck:devtools && npm run typecheck:language-server && npm run typecheck:vue-analyzer && npm run typecheck:create-gluon && npm run typecheck:docs",
     "typecheck:core": "tsc -p tsconfig.json --noEmit",
     "typecheck:decorators-legacy": "tsc -p tests-node/tsconfig.decorators-legacy.json",

--- a/scripts/run-bundle-matrix.mjs
+++ b/scripts/run-bundle-matrix.mjs
@@ -1,0 +1,33 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { resolve, relative } from 'node:path';
+import { brotliCompressSync, gzipSync, constants } from 'node:zlib';
+
+const root = resolve(import.meta.dirname, '..');
+const output = resolve(root, '.tmp/bundle-matrix');
+const fixtures = ['gluon', 'lit', 'vue', 'react'];
+await rm(output, { recursive: true, force: true });
+await mkdir(output, { recursive: true });
+execFileSync('npm', ['run', 'build:core'], { cwd: root, stdio: 'inherit' });
+
+const results = {};
+for (const fixture of fixtures) {
+  const source = resolve(root, 'benchmarks/bundle/fixtures', fixture);
+  const target = resolve(output, fixture);
+  execFileSync('npx', ['vite', 'build', source, '--outDir', target, '--manifest'], { cwd: root, stdio: 'inherit' });
+  const files = await collect(target);
+  results[fixture] = files.filter((file) => /\.(?:js|css)$/.test(file.path)).reduce((total, file) => ({ raw: total.raw + file.raw, gzip: total.gzip + file.gzip, brotli: total.brotli + file.brotli }), { raw: 0, gzip: 0, brotli: 0 });
+}
+const packageLock = JSON.parse(await readFile(resolve(root, 'package-lock.json'), 'utf8'));
+const report = { schemaVersion: 1, node: process.version, npm: execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(), lockfileVersion: packageLock.lockfileVersion, fixtures: results, scope: 'Equivalent labelled counter fixture; results are per production entry and are not a universal framework ranking.' };
+await writeFile(resolve(output, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
+console.log(JSON.stringify(report, null, 2));
+
+async function collect(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return (await Promise.all(entries.map(async (entry) => entry.isDirectory() ? collect(resolve(directory, entry.name)) : measure(resolve(directory, entry.name))))).flat();
+}
+async function measure(path) {
+  const contents = await readFile(path);
+  return { path: relative(root, path), raw: contents.byteLength, gzip: gzipSync(contents, { level: 9 }).byteLength, brotli: brotliCompressSync(contents, { params: { [constants.BROTLI_PARAM_QUALITY]: 11 } }).byteLength };
+}

--- a/scripts/run-bundle-matrix.mjs
+++ b/scripts/run-bundle-matrix.mjs
@@ -1,7 +1,9 @@
 import { execFileSync } from 'node:child_process';
+import { createServer } from 'node:http';
 import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
-import { resolve, relative } from 'node:path';
+import { extname, resolve, relative } from 'node:path';
 import { brotliCompressSync, gzipSync, constants } from 'node:zlib';
+import { chromium } from 'playwright';
 
 const root = resolve(import.meta.dirname, '..');
 const output = resolve(root, '.tmp/bundle-matrix');
@@ -16,7 +18,12 @@ for (const fixture of fixtures) {
   const target = resolve(output, fixture);
   execFileSync('npx', ['vite', 'build', source, '--outDir', target, '--manifest'], { cwd: root, stdio: 'inherit' });
   const files = await collect(target);
-  results[fixture] = files.filter((file) => /\.(?:js|css)$/.test(file.path)).reduce((total, file) => ({ raw: total.raw + file.raw, gzip: total.gzip + file.gzip, brotli: total.brotli + file.brotli }), { raw: 0, gzip: 0, brotli: 0 });
+  const manifest = JSON.parse(await readFile(resolve(target, '.vite/manifest.json'), 'utf8'));
+  await verifyParity(target, fixture);
+  results[fixture] = {
+    bytes: files.filter((file) => /\.(?:js|css)$/.test(file.path)).reduce((total, file) => ({ raw: total.raw + file.raw, gzip: total.gzip + file.gzip, brotli: total.brotli + file.brotli }), { raw: 0, gzip: 0, brotli: 0 }),
+    moduleGraph: Object.fromEntries(Object.entries(manifest).map(([entry, value]) => [entry, { file: value.file, imports: value.imports ?? [], dynamicImports: value.dynamicImports ?? [], css: value.css ?? [] }])),
+  };
 }
 const packageLock = JSON.parse(await readFile(resolve(root, 'package-lock.json'), 'utf8'));
 const report = { schemaVersion: 1, node: process.version, npm: execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(), lockfileVersion: packageLock.lockfileVersion, fixtures: results, scope: 'Equivalent labelled counter fixture; results are per production entry and are not a universal framework ranking.' };
@@ -30,4 +37,38 @@ async function collect(directory) {
 async function measure(path) {
   const contents = await readFile(path);
   return { path: relative(root, path), raw: contents.byteLength, gzip: gzipSync(contents, { level: 9 }).byteLength, brotli: brotliCompressSync(contents, { params: { [constants.BROTLI_PARAM_QUALITY]: 11 } }).byteLength };
+}
+
+async function verifyParity(directory, fixture) {
+  const server = createServer(async (request, response) => {
+    const pathname = request.url === '/' ? 'index.html' : decodeURIComponent(request.url ?? '').replace(/^\//, '');
+    const path = resolve(directory, pathname);
+    if (!path.startsWith(directory)) return response.writeHead(400).end();
+    try {
+      const contents = await readFile(path);
+      response.writeHead(200, { 'content-type': mimeType(path) });
+      response.end(contents);
+    } catch {
+      response.writeHead(404).end();
+    }
+  });
+  await new Promise((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const { port } = server.address();
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${port}`);
+    await page.getByRole('heading', { name: 'Bundle fixture' }).waitFor();
+    const button = page.getByRole('button', { name: 'Increment' });
+    await button.click();
+    const output = page.locator('output[aria-live="polite"]');
+    if (await output.textContent() !== '1') throw new Error(`${fixture} did not preserve the required counter interaction.`);
+  } finally {
+    await browser.close();
+    await new Promise((resolveClose, rejectClose) => server.close((error) => error ? rejectClose(error) : resolveClose()));
+  }
+}
+
+function mimeType(path) {
+  return ({ '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css' })[extname(path)] ?? 'application/octet-stream';
 }

--- a/scripts/run-bundle-matrix.mjs
+++ b/scripts/run-bundle-matrix.mjs
@@ -19,14 +19,15 @@ for (const fixture of fixtures) {
   execFileSync('npx', ['vite', 'build', source, '--outDir', target, '--manifest'], { cwd: root, stdio: 'inherit' });
   const files = await collect(target);
   const manifest = JSON.parse(await readFile(resolve(target, '.vite/manifest.json'), 'utf8'));
-  await verifyParity(target, fixture);
+  const browser = await verifyParity(target, fixture);
   results[fixture] = {
     bytes: files.filter((file) => /\.(?:js|css)$/.test(file.path)).reduce((total, file) => ({ raw: total.raw + file.raw, gzip: total.gzip + file.gzip, brotli: total.brotli + file.brotli }), { raw: 0, gzip: 0, brotli: 0 }),
     moduleGraph: Object.fromEntries(Object.entries(manifest).map(([entry, value]) => [entry, { file: value.file, imports: value.imports ?? [], dynamicImports: value.dynamicImports ?? [], css: value.css ?? [] }])),
+    parity: { browser },
   };
 }
 const packageLock = JSON.parse(await readFile(resolve(root, 'package-lock.json'), 'utf8'));
-const report = { schemaVersion: 1, node: process.version, npm: execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(), lockfileVersion: packageLock.lockfileVersion, fixtures: results, scope: 'Equivalent labelled counter fixture; results are per production entry and are not a universal framework ranking.' };
+const report = { schemaVersion: 1, node: process.version, npm: execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(), vite: execFileSync('npx', ['vite', '--version'], { encoding: 'utf8' }).trim(), lockfileVersion: packageLock.lockfileVersion, fixtures: results, scope: 'Equivalent labelled counter fixture; results are per production entry and are not a universal framework ranking.' };
 await writeFile(resolve(output, 'report.json'), `${JSON.stringify(report, null, 2)}\n`);
 console.log(JSON.stringify(report, null, 2));
 
@@ -56,6 +57,7 @@ async function verifyParity(directory, fixture) {
   const { port } = server.address();
   const browser = await chromium.launch({ headless: true });
   try {
+    const version = browser.version();
     const page = await browser.newPage();
     await page.goto(`http://127.0.0.1:${port}`);
     await page.getByRole('heading', { name: 'Bundle fixture' }).waitFor();
@@ -63,6 +65,7 @@ async function verifyParity(directory, fixture) {
     await button.click();
     const output = page.locator('output[aria-live="polite"]');
     if (await output.textContent() !== '1') throw new Error(`${fixture} did not preserve the required counter interaction.`);
+    return version;
   } finally {
     await browser.close();
     await new Promise((resolveClose, rejectClose) => server.close((error) => error ? rejectClose(error) : resolveClose()));


### PR DESCRIPTION
## Summary
- add equivalent Gluon, Lit, Vue, and React production bundle fixtures
- record raw, gzip, Brotli, Node, npm, and lockfile evidence
- document the bounded comparison contract

Part of #216.

## Checks
- `npm run benchmark:bundle`