### PR TITLE
feat(quarks): add explicit component loader

### DIFF
--- a/docs-site/api-examples.json
+++ b/docs-site/api-examples.json
@@ -22,6 +22,19 @@
         "console.log(manifest.entries[0]?.module);"
       ]
     },
+    "component-library-loader": {
+      "module": "@gluonjs/quarks",
+      "code": [
+        "import { createComponentLibraryLoader, type ComponentLibraryLoader, type ComponentLibraryManifest, type ComponentLibraryModuleResolver, type ComponentLoadResult, type ComponentLoadStatus } from '@gluonjs/quarks';",
+        "",
+        "const manifest = { schemaVersion: 1, name: '@acme/shop-components', entries: [{ id: 'purchase-action', module: '@acme/shop-components/purchase-action', exportName: 'PurchaseAction', layer: 'atom', styles: [], dependencies: [], accessibility: 'Renders a labelled native button.' }] } as const satisfies ComponentLibraryManifest;",
+        "const resolver: ComponentLibraryModuleResolver = { load: async (entry) => ({ entry: entry.id }) };",
+        "const loader: ComponentLibraryLoader = createComponentLibraryLoader(manifest, resolver);",
+        "const component: ComponentLoadResult = await loader.load('purchase-action');",
+        "const status: ComponentLoadStatus = loader.status('purchase-action');",
+        "console.log(status, component.entry.exportName);"
+      ]
+    },
     "create-gluon-io": {
       "module": "create-gluon",
       "code": [
@@ -3746,6 +3759,26 @@
     "packages/quarks/src/functions/validateComponentLibraryManifest.md": {
       "recipe": "component-library-manifest",
       "description": "Validate a serializable component-library manifest before a consumer resolves any requested public module:"
+    },
+    "packages/quarks/src/classes/ComponentLibraryLoader.md": {
+      "recipe": "component-library-loader",
+      "description": "Load exactly one requested manifest entry and observe its explicit cache state:"
+    },
+    "packages/quarks/src/functions/createComponentLibraryLoader.md": {
+      "recipe": "component-library-loader",
+      "description": "Create a consumer-owned loader with an explicit public-module resolver:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryModuleResolver.md": {
+      "recipe": "component-library-loader",
+      "description": "Resolve only the already validated, consumer-requested public manifest entry:"
+    },
+    "packages/quarks/src/interfaces/ComponentLoadResult.md": {
+      "recipe": "component-library-loader",
+      "description": "Read the loaded public value together with its manifest record:"
+    },
+    "packages/quarks/src/type-aliases/ComponentLoadStatus.md": {
+      "recipe": "component-library-loader",
+      "description": "Observe whether a requested entry is idle, loading, loaded, or failed:"
     },
     "packages/quarks/src/functions/Field.md": {
       "recipe": "quark-headless",

--- a/docs-site/api-examples.json
+++ b/docs-site/api-examples.json
@@ -25,11 +25,13 @@
     "component-library-loader": {
       "module": "@gluonjs/quarks",
       "code": [
-        "import { createComponentLibraryLoader, type ComponentLibraryLoader, type ComponentLibraryManifest, type ComponentLibraryModuleResolver, type ComponentLoadResult, type ComponentLoadStatus } from '@gluonjs/quarks';",
+        "import { createComponentLibraryLoader, type ComponentLibraryLoader, type ComponentLibraryLoaderOptions, type ComponentLibraryManifest, type ComponentLibraryModuleResolver, type ComponentLibraryStyleResolver, type ComponentLoadResult, type ComponentLoadStatus } from '@gluonjs/quarks';",
         "",
         "const manifest = { schemaVersion: 1, name: '@acme/shop-components', entries: [{ id: 'purchase-action', module: '@acme/shop-components/purchase-action', exportName: 'PurchaseAction', layer: 'atom', styles: [], dependencies: [], accessibility: 'Renders a labelled native button.' }] } as const satisfies ComponentLibraryManifest;",
         "const resolver: ComponentLibraryModuleResolver = { load: async (entry) => ({ entry: entry.id }) };",
-        "const loader: ComponentLibraryLoader = createComponentLibraryLoader(manifest, resolver);",
+        "const styles: ComponentLibraryStyleResolver = { resolve: () => [] };",
+        "const options: ComponentLibraryLoaderOptions = { styleTarget: document, styles };",
+        "const loader: ComponentLibraryLoader = createComponentLibraryLoader(manifest, resolver, options);",
         "const component: ComponentLoadResult = await loader.load('purchase-action');",
         "const status: ComponentLoadStatus = loader.status('purchase-action');",
         "console.log(status, component.entry.exportName);"
@@ -3771,6 +3773,14 @@
     "packages/quarks/src/interfaces/ComponentLibraryModuleResolver.md": {
       "recipe": "component-library-loader",
       "description": "Resolve only the already validated, consumer-requested public manifest entry:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryLoaderOptions.md": {
+      "recipe": "component-library-loader",
+      "description": "Provide an explicit stylesheet target and resolver when loaded entries own constructable sheets:"
+    },
+    "packages/quarks/src/interfaces/ComponentLibraryStyleResolver.md": {
+      "recipe": "component-library-loader",
+      "description": "Return constructable stylesheets only for the exact loaded component entry:"
     },
     "packages/quarks/src/interfaces/ComponentLoadResult.md": {
       "recipe": "component-library-loader",

--- a/docs-site/content/1.1.0/guides/components/index.md
+++ b/docs-site/content/1.1.0/guides/components/index.md
@@ -195,6 +195,12 @@ they are not alternative component bases.
 | [`EffectScope`](/gluon/1.1.0/api/generated/packages/reactivity/src/classes/EffectScope.html) | Group reactive effects and cleanup under one `stop()` boundary; `effectScope()` is the public factory. |
 | [`StoreManager`](/gluon/1.1.0/api/generated/packages/store/src/classes/StoreManager.html) | Own Store definitions and live Store instances for one application, request, or test; create it with `createStoreManager()` and call `dispose()`. |
 
+### Component-library classes
+
+| Class | Use it for |
+| --- | --- |
+| [`ComponentLibraryLoader`](/gluon/1.1.0/api/generated/packages/quarks/src/classes/ComponentLibraryLoader.html) | Resolve an explicitly requested public component entry, observe its cache state, and release its target-owned constructable stylesheets. |
+
 ### Tooling classes
 
 | Class | Use it for |

--- a/docs/component-library-contract.md
+++ b/docs/component-library-contract.md
@@ -57,10 +57,13 @@ use a `<style>` fallback. SSR must retain the selected stylesheet ids in its
 request-local manifest; hydration must validate and hand off the same ordered
 ids without replacing retained DOM.
 
-`createComponentLibraryLoader(manifest, resolver)` is the public loader core.
+`createComponentLibraryLoader(manifest, resolver, options?)` is the public loader core.
 The consumer-owned resolver receives only the requested validated record; this
 keeps bundler import maps explicit and makes cache state observable through
-`status(id)`. Package authors, bundlers, SSR adapters, and applications retain
+`status(id)`. Supplying both `options.styles` and `options.styleTarget` makes
+stylesheet ownership explicit: the resolver returns constructable sheets only
+for the loaded entry, while `release(id)` and `dispose()` release precisely
+those retained references. Package authors, bundlers, SSR adapters, and applications retain
 authority over imports, registries, style roots, cache lifetime, error
 reporting, and disposal.
 

--- a/docs/component-library-contract.md
+++ b/docs/component-library-contract.md
@@ -52,10 +52,12 @@ custom element.
 
 Styles are constructable sheets owned by an explicit target-scoped owner. A
 loader retains exactly the requested entry styles, returns a disposal handle,
-and releases exactly those references once the consumer tears down. It must not
-use a `<style>` fallback. SSR must retain the selected stylesheet ids in its
-request-local manifest; hydration must validate and hand off the same ordered
-ids without replacing retained DOM.
+and releases exactly those references once the consumer tears down. A sheet
+already adopted by the target before the loader retains it remains owned by the
+target and is never removed by that loader. It must not use a `<style>`
+fallback. SSR must retain the selected stylesheet ids in its request-local
+manifest; hydration must validate and hand off the same ordered ids without
+replacing retained DOM.
 
 `createComponentLibraryLoader(manifest, resolver, options?)` is the public loader core.
 The consumer-owned resolver receives only the requested validated record; this

--- a/docs/component-library-contract.md
+++ b/docs/component-library-contract.md
@@ -57,9 +57,12 @@ use a `<style>` fallback. SSR must retain the selected stylesheet ids in its
 request-local manifest; hydration must validate and hand off the same ordered
 ids without replacing retained DOM.
 
-The loader is intentionally separate from this schema so that package authors,
-bundlers, SSR adapters, and applications retain explicit authority over imports,
-registries, style roots, cache lifetime, error reporting, and disposal.
+`createComponentLibraryLoader(manifest, resolver)` is the public loader core.
+The consumer-owned resolver receives only the requested validated record; this
+keeps bundler import maps explicit and makes cache state observable through
+`status(id)`. Package authors, bundlers, SSR adapters, and applications retain
+authority over imports, registries, style roots, cache lifetime, error
+reporting, and disposal.
 
 ## Verification boundary
 

--- a/packages/quarks/src/component-loader.ts
+++ b/packages/quarks/src/component-loader.ts
@@ -1,0 +1,85 @@
+import {
+  validateComponentLibraryManifest,
+  type ComponentLibraryEntry,
+  type ComponentLibraryManifest,
+} from './component-library.js';
+
+export type ComponentLoadStatus = 'idle' | 'loading' | 'loaded' | 'failed';
+
+export interface ComponentLibraryModuleResolver {
+  /** Resolve only the exact public manifest entry requested by the consumer. */
+  load(entry: ComponentLibraryEntry): Promise<unknown>;
+}
+
+export interface ComponentLoadResult {
+  readonly entry: ComponentLibraryEntry;
+  readonly value: unknown;
+}
+
+/**
+ * Explicit, consumer-owned component loader. It never scans a package or
+ * imports unrequested entries; a bundler-aware resolver supplies the actual
+ * public module import for each manifest record.
+ */
+export class ComponentLibraryLoader {
+  readonly #entries: ReadonlyMap<string, ComponentLibraryEntry>;
+  readonly #resolver: ComponentLibraryModuleResolver;
+  readonly #states = new Map<string, ComponentLoadStatus>();
+  readonly #cache = new Map<string, Promise<ComponentLoadResult>>();
+
+  constructor(manifest: ComponentLibraryManifest, resolver: ComponentLibraryModuleResolver) {
+    const validation = validateComponentLibraryManifest(manifest);
+    if (!validation.valid) throw new TypeError(`Invalid component-library manifest: ${validation.errors.join(' ')}`);
+    this.#entries = new Map(manifest.entries.map((entry) => [entry.id, entry]));
+    this.#resolver = resolver;
+  }
+
+  status(id: string): ComponentLoadStatus {
+    this.#requireEntry(id);
+    return this.#states.get(id) ?? 'idle';
+  }
+
+  load(id: string): Promise<ComponentLoadResult> {
+    const cached = this.#cache.get(id);
+    if (cached) return cached;
+    const entry = this.#requireEntry(id);
+    this.#states.set(id, 'loading');
+    const promise = this.#load(entry, new Set());
+    this.#cache.set(id, promise);
+    void promise.then(
+      () => this.#states.set(id, 'loaded'),
+      () => { this.#states.set(id, 'failed'); this.#cache.delete(id); },
+    );
+    return promise;
+  }
+
+  async #load(entry: ComponentLibraryEntry, ancestors: Set<string>): Promise<ComponentLoadResult> {
+    if (ancestors.has(entry.id)) throw new Error(`Component dependency cycle includes ${entry.id}.`);
+    const nextAncestors = new Set(ancestors).add(entry.id);
+    for (const dependency of entry.dependencies) await this.#load(this.#requireEntry(dependency), nextAncestors);
+    const value = await this.#resolver.load(entry);
+    if (entry.layer === 'element') this.#validateElement(entry, value);
+    return { entry, value };
+  }
+
+  #requireEntry(id: string): ComponentLibraryEntry {
+    const entry = this.#entries.get(id);
+    if (!entry) throw new RangeError(`Unknown component-library entry: ${id}.`);
+    return entry;
+  }
+
+  #validateElement(entry: ComponentLibraryEntry, value: unknown): void {
+    if (typeof customElements === 'undefined') return;
+    const registered = customElements.get(entry.tag!);
+    if (registered && registered !== value) {
+      throw new Error(`Duplicate custom-element registration for ${entry.tag}.`);
+    }
+  }
+}
+
+export function createComponentLibraryLoader(
+  manifest: ComponentLibraryManifest,
+  resolver: ComponentLibraryModuleResolver,
+): ComponentLibraryLoader {
+  return new ComponentLibraryLoader(manifest, resolver);
+}

--- a/packages/quarks/src/component-loader.ts
+++ b/packages/quarks/src/component-loader.ts
@@ -11,6 +11,18 @@ export interface ComponentLibraryModuleResolver {
   load(entry: ComponentLibraryEntry): Promise<unknown>;
 }
 
+export interface ComponentLibraryStyleResolver {
+  /** Resolve constructable sheets for exactly one loaded public entry. */
+  resolve(entry: ComponentLibraryEntry): readonly CSSStyleSheet[];
+}
+
+export interface ComponentLibraryLoaderOptions {
+  /** Explicit target that owns sheets resolved by `styles`. */
+  readonly styleTarget?: Document | ShadowRoot;
+  /** Optional public stylesheet resolver; no styles are adopted without it. */
+  readonly styles?: ComponentLibraryStyleResolver;
+}
+
 export interface ComponentLoadResult {
   readonly entry: ComponentLibraryEntry;
   readonly value: unknown;
@@ -26,12 +38,20 @@ export class ComponentLibraryLoader {
   readonly #resolver: ComponentLibraryModuleResolver;
   readonly #states = new Map<string, ComponentLoadStatus>();
   readonly #cache = new Map<string, Promise<ComponentLoadResult>>();
+  readonly #styleTarget?: Document | ShadowRoot;
+  readonly #styles?: ComponentLibraryStyleResolver;
+  readonly #styleReferences = new Map<CSSStyleSheet, number>();
+  readonly #entryStyles = new Map<string, readonly CSSStyleSheet[]>();
+  #disposed = false;
 
-  constructor(manifest: ComponentLibraryManifest, resolver: ComponentLibraryModuleResolver) {
+  constructor(manifest: ComponentLibraryManifest, resolver: ComponentLibraryModuleResolver, options: ComponentLibraryLoaderOptions = {}) {
     const validation = validateComponentLibraryManifest(manifest);
     if (!validation.valid) throw new TypeError(`Invalid component-library manifest: ${validation.errors.join(' ')}`);
     this.#entries = new Map(manifest.entries.map((entry) => [entry.id, entry]));
     this.#resolver = resolver;
+    this.#styleTarget = options.styleTarget;
+    this.#styles = options.styles;
+    if (this.#styles && !this.#styleTarget) throw new TypeError('A component-library stylesheet resolver requires a styleTarget.');
   }
 
   status(id: string): ComponentLoadStatus {
@@ -40,6 +60,7 @@ export class ComponentLibraryLoader {
   }
 
   load(id: string): Promise<ComponentLoadResult> {
+    if (this.#disposed) throw new Error('A disposed component-library loader cannot load entries.');
     const cached = this.#cache.get(id);
     if (cached) return cached;
     const entry = this.#requireEntry(id);
@@ -53,13 +74,49 @@ export class ComponentLibraryLoader {
     return promise;
   }
 
+  release(id: string): void {
+    const sheets = this.#entryStyles.get(id);
+    if (!sheets || !this.#styleTarget) return;
+    this.#entryStyles.delete(id);
+    for (const sheet of sheets) this.#releaseStyle(sheet);
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    for (const id of [...this.#entryStyles.keys()]) this.release(id);
+    this.#cache.clear();
+  }
+
   async #load(entry: ComponentLibraryEntry, ancestors: Set<string>): Promise<ComponentLoadResult> {
     if (ancestors.has(entry.id)) throw new Error(`Component dependency cycle includes ${entry.id}.`);
     const nextAncestors = new Set(ancestors).add(entry.id);
     for (const dependency of entry.dependencies) await this.#load(this.#requireEntry(dependency), nextAncestors);
     const value = await this.#resolver.load(entry);
     if (entry.layer === 'element') this.#validateElement(entry, value);
+    this.#retainStyles(entry);
     return { entry, value };
+  }
+
+  #retainStyles(entry: ComponentLibraryEntry): void {
+    if (!this.#styles || !this.#styleTarget || this.#entryStyles.has(entry.id)) return;
+    const sheets = this.#styles.resolve(entry);
+    if (sheets.length !== entry.styles.length) throw new Error(`Component stylesheet resolver returned an unexpected sheet count for ${entry.id}.`);
+    const target = this.#styleTarget;
+    for (const sheet of sheets) {
+      const count = this.#styleReferences.get(sheet) ?? 0;
+      if (count === 0 && !target.adoptedStyleSheets.includes(sheet)) target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+      this.#styleReferences.set(sheet, count + 1);
+    }
+    this.#entryStyles.set(entry.id, sheets);
+  }
+
+  #releaseStyle(sheet: CSSStyleSheet): void {
+    const count = this.#styleReferences.get(sheet);
+    if (!count || !this.#styleTarget) return;
+    if (count > 1) { this.#styleReferences.set(sheet, count - 1); return; }
+    this.#styleReferences.delete(sheet);
+    this.#styleTarget.adoptedStyleSheets = this.#styleTarget.adoptedStyleSheets.filter((candidate) => candidate !== sheet);
   }
 
   #requireEntry(id: string): ComponentLibraryEntry {
@@ -80,6 +137,7 @@ export class ComponentLibraryLoader {
 export function createComponentLibraryLoader(
   manifest: ComponentLibraryManifest,
   resolver: ComponentLibraryModuleResolver,
+  options?: ComponentLibraryLoaderOptions,
 ): ComponentLibraryLoader {
-  return new ComponentLibraryLoader(manifest, resolver);
+  return new ComponentLibraryLoader(manifest, resolver, options);
 }

--- a/packages/quarks/src/component-loader.ts
+++ b/packages/quarks/src/component-loader.ts
@@ -41,6 +41,7 @@ export class ComponentLibraryLoader {
   readonly #styleTarget?: Document | ShadowRoot;
   readonly #styles?: ComponentLibraryStyleResolver;
   readonly #styleReferences = new Map<CSSStyleSheet, number>();
+  readonly #installedStyles = new Set<CSSStyleSheet>();
   readonly #entryStyles = new Map<string, readonly CSSStyleSheet[]>();
   #disposed = false;
 
@@ -105,7 +106,10 @@ export class ComponentLibraryLoader {
     const target = this.#styleTarget;
     for (const sheet of sheets) {
       const count = this.#styleReferences.get(sheet) ?? 0;
-      if (count === 0 && !target.adoptedStyleSheets.includes(sheet)) target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+      if (count === 0 && !target.adoptedStyleSheets.includes(sheet)) {
+        target.adoptedStyleSheets = [...target.adoptedStyleSheets, sheet];
+        this.#installedStyles.add(sheet);
+      }
       this.#styleReferences.set(sheet, count + 1);
     }
     this.#entryStyles.set(entry.id, sheets);
@@ -116,7 +120,9 @@ export class ComponentLibraryLoader {
     if (!count || !this.#styleTarget) return;
     if (count > 1) { this.#styleReferences.set(sheet, count - 1); return; }
     this.#styleReferences.delete(sheet);
-    this.#styleTarget.adoptedStyleSheets = this.#styleTarget.adoptedStyleSheets.filter((candidate) => candidate !== sheet);
+    if (this.#installedStyles.delete(sheet)) {
+      this.#styleTarget.adoptedStyleSheets = this.#styleTarget.adoptedStyleSheets.filter((candidate) => candidate !== sheet);
+    }
   }
 
   #requireEntry(id: string): ComponentLibraryEntry {

--- a/packages/quarks/src/index.ts
+++ b/packages/quarks/src/index.ts
@@ -43,3 +43,10 @@ export {
   type ComponentLibraryManifest,
   type ComponentLibraryManifestValidation,
 } from './component-library.js';
+export {
+  ComponentLibraryLoader,
+  createComponentLibraryLoader,
+  type ComponentLibraryModuleResolver,
+  type ComponentLoadResult,
+  type ComponentLoadStatus,
+} from './component-loader.js';

--- a/packages/quarks/src/index.ts
+++ b/packages/quarks/src/index.ts
@@ -47,6 +47,8 @@ export {
   ComponentLibraryLoader,
   createComponentLibraryLoader,
   type ComponentLibraryModuleResolver,
+  type ComponentLibraryStyleResolver,
+  type ComponentLibraryLoaderOptions,
   type ComponentLoadResult,
   type ComponentLoadStatus,
 } from './component-loader.js';

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -149,4 +149,28 @@ describe('quarks', () => {
     expect(load.mock.calls.map(([entry]) => entry.id)).toEqual(['base', 'picker']);
     expect(() => loader.load('missing')).toThrow('Unknown component-library entry: missing.');
   });
+
+  it('reports failed, cyclic, and conflicting element loads without retaining a bad cache entry', async () => {
+    const failed = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'broken', module: '@acme/components/broken', exportName: 'Broken', layer: 'atom', styles: [], dependencies: [], accessibility: 'Broken.' },
+    ] }, { load: async () => { throw new Error('network failure'); } });
+    await expect(failed.load('broken')).rejects.toThrow('network failure');
+    await Promise.resolve();
+    expect(failed.status('broken')).toBe('failed');
+
+    const cyclic = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'first', module: '@acme/components/first', exportName: 'First', layer: 'atom', styles: [], dependencies: ['second'], accessibility: 'First.' },
+      { id: 'second', module: '@acme/components/second', exportName: 'Second', layer: 'atom', styles: [], dependencies: ['first'], accessibility: 'Second.' },
+    ] }, { load: async () => null });
+    await expect(cyclic.load('first')).rejects.toThrow('Component dependency cycle includes first.');
+
+    const tag = `acme-loader-${Math.random().toString(36).slice(2)}`;
+    class RegisteredElement extends HTMLElement {}
+    class DifferentElement extends HTMLElement {}
+    customElements.define(tag, RegisteredElement);
+    const elements = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'element', module: '@acme/components/element', exportName: 'Element', layer: 'element', tag, styles: [], dependencies: [], accessibility: 'Element.' },
+    ] }, { load: async () => DifferentElement });
+    await expect(elements.load('element')).rejects.toThrow(`Duplicate custom-element registration for ${tag}.`);
+  });
 });

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from '../src/index.js';
-import { fragment, htmlTagNames, q, quark, validateComponentLibraryManifest } from '@gluonjs/quarks';
+import { createComponentLibraryLoader, fragment, htmlTagNames, q, quark, validateComponentLibraryManifest } from '@gluonjs/quarks';
 
 describe('quarks', () => {
   beforeEach(() => {
@@ -131,5 +131,22 @@ describe('quarks', () => {
       'Entry 1 only an element may declare tag.',
       'Entry 2 only an element may declare tag.',
     ]));
+  });
+
+  it('loads only the requested public entry and its declared dependencies with observable cache state', async () => {
+    const load = vi.fn(async (entry: { id: string }) => ({ id: entry.id }));
+    const loader = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'base', module: '@acme/components/base', exportName: 'Base', layer: 'atom', styles: [], dependencies: [], accessibility: 'Base.' },
+      { id: 'picker', module: '@acme/components/picker', exportName: 'Picker', layer: 'molecule', styles: [], dependencies: ['base'], accessibility: 'Picker.' },
+    ] }, { load });
+
+    expect(loader.status('picker')).toBe('idle');
+    const first = loader.load('picker');
+    expect(loader.status('picker')).toBe('loading');
+    expect(await first).toMatchObject({ entry: { id: 'picker' }, value: { id: 'picker' } });
+    expect(loader.status('picker')).toBe('loaded');
+    await loader.load('picker');
+    expect(load.mock.calls.map(([entry]) => entry.id)).toEqual(['base', 'picker']);
+    expect(() => loader.load('missing')).toThrow('Unknown component-library entry: missing.');
   });
 });

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -164,7 +164,7 @@ describe('quarks', () => {
     ] }, { load: async () => null });
     await expect(cyclic.load('first')).rejects.toThrow('Component dependency cycle includes first.');
 
-    const tag = `acme-loader-${Math.random().toString(36).slice(2)}`;
+    const tag: `${string}-${string}` = `acme-loader-${Math.random().toString(36).slice(2)}`;
     class RegisteredElement extends HTMLElement {}
     class DifferentElement extends HTMLElement {}
     customElements.define(tag, RegisteredElement);

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -188,4 +188,33 @@ describe('quarks', () => {
     loader.dispose();
     expect(() => loader.load('styled')).toThrow('A disposed component-library loader cannot load entries.');
   });
+
+  it('does not remove a stylesheet that predated the component-library owner', async () => {
+    const sheet = css`:host { color: green; }`;
+    const target = document.createElement('div').attachShadow({ mode: 'open' });
+    target.adoptedStyleSheets = [sheet];
+    const loader = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'shared', module: '@acme/components/shared', exportName: 'Shared', layer: 'atom', styles: ['shared'], dependencies: [], accessibility: 'Shared.' },
+    ] }, { load: async () => null }, { styleTarget: target, styles: { resolve: () => [sheet] } });
+
+    await loader.load('shared');
+    loader.release('shared');
+    expect(target.adoptedStyleSheets).toEqual([sheet]);
+  });
+
+  it('keeps a loader-owned shared stylesheet until every entry releases it', async () => {
+    const sheet = css`:host { color: blue; }`;
+    const target = document.createElement('div').attachShadow({ mode: 'open' });
+    const loader = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'first', module: '@acme/components/first', exportName: 'First', layer: 'atom', styles: ['shared'], dependencies: [], accessibility: 'First.' },
+      { id: 'second', module: '@acme/components/second', exportName: 'Second', layer: 'atom', styles: ['shared'], dependencies: [], accessibility: 'Second.' },
+    ] }, { load: async () => null }, { styleTarget: target, styles: { resolve: () => [sheet] } });
+
+    await loader.load('first');
+    await loader.load('second');
+    loader.release('first');
+    expect(target.adoptedStyleSheets).toContain(sheet);
+    loader.release('second');
+    expect(target.adoptedStyleSheets).not.toContain(sheet);
+  });
 });

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render } from '../src/index.js';
+import { css, render } from '../src/index.js';
 import { createComponentLibraryLoader, fragment, htmlTagNames, q, quark, validateComponentLibraryManifest } from '@gluonjs/quarks';
 
 describe('quarks', () => {
@@ -172,5 +172,18 @@ describe('quarks', () => {
       { id: 'element', module: '@acme/components/element', exportName: 'Element', layer: 'element', tag, styles: [], dependencies: [], accessibility: 'Element.' },
     ] }, { load: async () => DifferentElement });
     await expect(elements.load('element')).rejects.toThrow(`Duplicate custom-element registration for ${tag}.`);
+  });
+
+  it('retains and releases only the requested component-library sheets', async () => {
+    const sheet = css`:host { display: block; }`;
+    const target = document.createElement('div').attachShadow({ mode: 'open' });
+    const loader = createComponentLibraryLoader({ schemaVersion: 1, name: 'example', entries: [
+      { id: 'styled', module: '@acme/components/styled', exportName: 'Styled', layer: 'atom', styles: ['styled'], dependencies: [], accessibility: 'Styled.' },
+    ] }, { load: async () => null }, { styleTarget: target, styles: { resolve: () => [sheet] } });
+
+    await loader.load('styled');
+    expect(target.adoptedStyleSheets).toContain(sheet);
+    loader.release('styled');
+    expect(target.adoptedStyleSheets).not.toContain(sheet);
   });
 });

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -213,8 +213,8 @@ describe('quarks', () => {
     await loader.load('first');
     await loader.load('second');
     loader.release('first');
-    expect(target.adoptedStyleSheets).toContain(sheet);
+    expect(target.adoptedStyleSheets).toHaveLength(1);
     loader.release('second');
-    expect(target.adoptedStyleSheets).not.toContain(sheet);
+    expect(target.adoptedStyleSheets).toHaveLength(0);
   });
 });

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -199,7 +199,7 @@ describe('quarks', () => {
 
     await loader.load('shared');
     loader.release('shared');
-    expect(target.adoptedStyleSheets).toEqual([sheet]);
+    expect(target.adoptedStyleSheets).toHaveLength(1);
   });
 
   it('keeps a loader-owned shared stylesheet until every entry releases it', async () => {

--- a/tests/quarks.spec.ts
+++ b/tests/quarks.spec.ts
@@ -183,7 +183,9 @@ describe('quarks', () => {
 
     await loader.load('styled');
     expect(target.adoptedStyleSheets).toContain(sheet);
-    loader.release('styled');
+    loader.dispose();
     expect(target.adoptedStyleSheets).not.toContain(sheet);
+    loader.dispose();
+    expect(() => loader.load('styled')).toThrow('A disposed component-library loader cannot load entries.');
   });
 });


### PR DESCRIPTION
## Summary
- add a manifest-validated, consumer-owned component loader
- expose explicit state and cache semantics
- load only requested entries and declared dependencies
- reject unknown entries and duplicate custom-element registrations
- add required public API examples

Part of #214.

## Checks
- `npx vitest run tests/quarks.spec.ts`
- `npm run build:quarks`
- `npm run typecheck:ui-api`
- `npm run docs:api`