### PR TITLE
feat(example): package component library consumer

### DIFF
--- a/examples/component-library/README.md
+++ b/examples/component-library/README.md
@@ -11,3 +11,7 @@ quantity.
 
 Run `npm run build:component-library` to build the consumer. Loader and
 Storybook integration are intentionally delivered by issues #214 and #215.
+
+`library/` is the separately buildable package boundary. Run
+`npm run check:component-library-package` to build it and inspect the exact
+tarball contents before a clean-consumer install.

--- a/examples/component-library/library/package.json
+++ b/examples/component-library/library/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@gluonjs/example-component-library",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "files": ["dist"],
+  "peerDependencies": {
+    "@gluonjs/core": "^1.1.0",
+    "@gluonjs/quarks": "^1.1.0"
+  },
+  "scripts": {
+    "build": "vite build --config vite.config.ts",
+    "pack:check": "npm pack --dry-run"
+  }
+}

--- a/examples/component-library/library/src/index.ts
+++ b/examples/component-library/library/src/index.ts
@@ -1,0 +1,1 @@
+export { ProductBadge, ProductPicker, productPickerStyles, type ProductPickerChange } from '../../src/library.js';

--- a/examples/component-library/library/vite.config.ts
+++ b/examples/component-library/library/vite.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  resolve: { alias: {
+    '@gluonjs/core': resolve(import.meta.dirname, '../../../src/index.ts'),
+    '@gluonjs/quarks': resolve(import.meta.dirname, '../../../packages/quarks/src/index.ts'),
+    '@gluonjs/reactivity': resolve(import.meta.dirname, '../../../packages/reactivity/src/index.ts'),
+  } },
+  build: {
+    emptyOutDir: true,
+    lib: { entry: resolve(import.meta.dirname, 'src/index.ts'), formats: ['es'], fileName: 'index' },
+    rollupOptions: { external: ['@gluonjs/core', '@gluonjs/quarks'] },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "build:virtualizer-example": "vite build --config examples/virtualizer/vite.config.ts",
     "build:signals-example": "vite build --config examples/signals/vite.config.ts",
     "build:component-library": "vite build --config examples/component-library/vite.config.ts",
+    "build:component-library-package": "npm run build --prefix examples/component-library/library",
+    "check:component-library-package": "npm run build:component-library-package && npm run pack:check --prefix examples/component-library/library",
     "docs:api": "typedoc --options typedoc.json --treatWarningsAsErrors && node scripts/generate-api-examples.mjs",
     "build:docs": "npm run docs:api && node scripts/build-docs.mjs && npm run build:docs-examples",
     "build:docs-examples": "vite build --config docs-site/examples/vite.config.ts",


### PR DESCRIPTION
## Summary
- add a separately buildable component-library package boundary
- retain explicit peer public-package dependencies and package-content verification
- document the package consumer contract

Part of #213.

## Checks
- `npm run check:component-library-package`