### PR TITLE
test(example): prove component-library lifecycle

### DIFF
--- a/examples/component-library/README.md
+++ b/examples/component-library/README.md
@@ -29,3 +29,9 @@ build it and inspect the exact tarball contents before a clean-consumer install.
 Gluon dependencies, installs them in an empty temporary consumer, typechecks
 and production-builds that consumer, then verifies its browser interaction and
 teardown flow.
+
+Repository SSR coverage renders both public exports, including the picker's
+declarative Shadow DOM. Browser coverage retains the Atom's server nodes during
+hydration, confirms that picker styles remain owned by its ShadowRoot, verifies
+repeat imports keep the identical registered constructor, and removes the
+element during consumer teardown.

--- a/tests-node/ssr.spec.ts
+++ b/tests-node/ssr.spec.ts
@@ -54,6 +54,7 @@ import { product } from '../benchmarks/dx/stateful-form-control/shared.js';
 import { renderVueQuantityShadow } from '../benchmarks/dx/stateful-form-control/vue.js';
 import { Button } from '@gluonjs/atoms';
 import { Card } from '@gluonjs/molecules';
+import { ProductBadge, ProductPicker } from '@gluonjs/example-component-library';
 
 describe('@gluonjs/ssr DOM-independent serialization', () => {
   it('renders request-isolated Eleventy pages and disposes success and failure ownership', async () => {
@@ -358,6 +359,20 @@ describe('@gluonjs/ssr DOM-independent serialization', () => {
     );
     expect(connected).not.toHaveBeenCalled();
     expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('server-renders the packed component-library public exports', async () => {
+    const atom = withoutHydrationMarkers(await renderToString(ProductBadge('In stock')));
+    expect(atom).toBe('<span class="gluon quark example-product-badge">In stock</span>');
+
+    const element = withoutHydrationMarkers(await renderToString(renderElement(
+      ProductPicker as import('@gluonjs/core').GluonElementClass,
+      { properties: { value: 2 } },
+    )));
+    expect(element).toContain('<example-product-picker value="2">');
+    expect(element).toContain('<template shadowrootmode="open">');
+    expect(element).toContain('aria-label="Increase quantity"');
+    expect(element).toContain('<output aria-live="polite">2</output>');
   });
 
   it('serializes scoped class and functional definitions for declarative registry hydration', async () => {

--- a/tests/component-library-example.spec.ts
+++ b/tests/component-library-example.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { createApp, html } from '../src/index.js';
-import { ProductBadge } from '@gluonjs/example-component-library';
+import { ProductBadge, ProductPicker } from '@gluonjs/example-component-library';
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -9,6 +9,7 @@ afterEach(() => {
 
 describe('component-library consumer example', () => {
   it('uses public functional and Custom Element exports in a consumer flow', async () => {
+    const documentSheetCount = document.adoptedStyleSheets.length;
     const host = document.createElement('main');
     document.body.append(host);
     const app = createApp(() => html`<section>${ProductBadge('In stock')}<example-product-picker value="2"></example-product-picker></section>`).mount(host);
@@ -17,6 +18,9 @@ describe('component-library consumer example', () => {
 
     expect(host.textContent).toContain('In stock');
     expect(picker.shadowRoot?.adoptedStyleSheets).toHaveLength(1);
+    expect(document.adoptedStyleSheets).toHaveLength(documentSheetCount);
+    expect(customElements.get('example-product-picker')).toBe(ProductPicker);
+    expect((await import('@gluonjs/example-component-library')).ProductPicker).toBe(ProductPicker);
     const event = new Promise<CustomEvent<{ quantity: number }>>((resolve) => picker.addEventListener('change', resolve as EventListener, { once: true }));
     (picker.shadowRoot?.querySelector('[aria-label="Increase quantity"]') as HTMLButtonElement).click();
     expect((await event).detail).toEqual({ quantity: 3 });
@@ -24,6 +28,8 @@ describe('component-library consumer example', () => {
     expect(picker.shadowRoot?.querySelector('output')?.textContent).toBe('3');
 
     app.unmount();
+    expect(host.querySelector('example-product-picker')).toBeNull();
+    expect(document.adoptedStyleSheets).toHaveLength(documentSheetCount);
     expect(host.replaceChildren()).toBeUndefined();
   });
 });

--- a/tests/hydration.spec.ts
+++ b/tests/hydration.spec.ts
@@ -21,6 +21,7 @@ import {
 } from '@gluonjs/core';
 import { Button, buttonStyles } from '@gluonjs/atoms';
 import { Card, cardStyles } from '@gluonjs/molecules';
+import { ProductBadge } from '@gluonjs/example-component-library';
 import { nextTick, ref } from '@gluonjs/reactivity';
 import {
   hydrateApplication,
@@ -82,6 +83,19 @@ describe('SSR hydration', () => {
     const result = await hydrateTemplate(value, root);
     expect(result.retained).toBe(true);
     expect(root.querySelector('section')).toBe(section);
+  });
+
+  it('retains the server DOM produced by the component-library public Atom', async () => {
+    const value = html`<section>${ProductBadge('In stock')}</section>`;
+    const prepared = await prepareForHydration(value);
+    const root = document.createElement('div');
+    root.innerHTML = prepared.html;
+    const badge = root.querySelector('.example-product-badge');
+
+    const result = await hydrateTemplate(value, root);
+
+    expect(result).toMatchObject({ retained: true, recovered: false });
+    expect(root.querySelector('.example-product-badge')).toBe(badge);
   });
 
   it('retains matching nodes while activating refs, events, context, and reactive updates', async () => {

--- a/vitest.ssr.config.ts
+++ b/vitest.ssr.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     alias: {
       '@gluonjs/core/decorators': resolve(import.meta.dirname, 'src/decorators.ts'),
       '@gluonjs/core': resolve(import.meta.dirname, 'src/index.ts'),
+      '@gluonjs/example-component-library': resolve(import.meta.dirname, 'examples/component-library/library/src/index.ts'),
       '@gluonjs/reactivity/signals': resolve(import.meta.dirname, 'packages/reactivity/src/signals/index.ts'),
       '@gluonjs/reactivity': resolve(import.meta.dirname, 'packages/reactivity/src/index.ts'),
       '@gluonjs/router/memory': resolve(import.meta.dirname, 'packages/router/src/memory.ts'),


### PR DESCRIPTION
## Summary
- prove server rendering of the public component-library Atom and stateful element
- retain the Atom server DOM through hydration
- verify ShadowRoot-only style ownership, repeat-import registration identity, and consumer teardown
- document the retained package evidence

Closes #213.

## Checks
- `npm run test:ssr`
- `npx vitest run tests/component-library-example.spec.ts tests/hydration.spec.ts`
- `npm run typecheck:core`