### PR TITLE
benchmark: add expanded runtime performance scorecard

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -100,6 +100,7 @@ jobs:
       - run: npm run check:storybook:component-library
       - run: npm run benchmark:rendering -- --samples=10 --warmup=4 --output=.tmp/quality-evidence/rendering.json
       - run: npm run benchmark:components -- --samples=10 --warmup=4 --output=.tmp/quality-evidence/components.json
+      - run: npm run benchmark:runtime -- --samples=10 --warmup=3 --output=.tmp/quality-evidence/runtime-scorecard.json
       - run: npm run check:shop-performance
       - name: Retain quality evidence
         if: ${{ !cancelled() }}

--- a/benchmarks/results/runtime-scorecard-50c6448.json
+++ b/benchmarks/results/runtime-scorecard-50c6448.json
@@ -1,0 +1,709 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-07-21T08:52:10.517Z",
+  "source": {
+    "commit": "50c64480d1b9acac450a3fc6c08bb09c97363ab9",
+    "branch": "codex/217-runtime-performance-scorecard",
+    "workingTreeDirty": false
+  },
+  "environment": {
+    "platform": "darwin",
+    "release": "25.3.0",
+    "cpu": "Apple M4",
+    "logicalCpus": 10,
+    "totalMemoryBytes": 17179869184,
+    "node": "v24.18.0",
+    "npm": "11.16.0",
+    "packages": {
+      "gluon": "1.1.0",
+      "playwright": "1.61.1",
+      "vite": "8.1.4"
+    }
+  },
+  "methodology": {
+    "productionBuild": true,
+    "headless": true,
+    "samples": 20,
+    "warmupRounds": 5,
+    "teardownCycles": 30,
+    "browserTimeoutMs": 300000,
+    "lanes": {
+      "ssr": "Node renderToString of one 100-row Gluon template",
+      "hydration": "retain marker-bearing server DOM in place",
+      "routing": "await one public memory-router transition",
+      "loader": "load one cached dynamic module through a fresh manifest-driven loader",
+      "styles": "retain and release one constructable stylesheet through 100 owners; milliseconds per owner",
+      "memory": "mount, interact with, unmount, and probe detached listeners for 30 application roots",
+      "interaction": "dispatch one application-owned button interaction and await the reactive update",
+      "longTasks": "record PerformanceObserver longtask entries only in engines that expose that entry type"
+    },
+    "correctnessGate": "every warm-up and measured operation validates its observable output before evidence is accepted",
+    "isolation": "one fresh browser context per engine; engine results are never averaged together",
+    "unit": "milliseconds; lower is faster"
+  },
+  "criteria": {
+    "schemaVersion": 1,
+    "samples": 20,
+    "warmupRounds": 5,
+    "teardownCycles": 30,
+    "metrics": {
+      "ssrRenderMs": {
+        "maxP95": 50
+      },
+      "hydrationMs": {
+        "maxP95": 100
+      },
+      "routeTransitionMs": {
+        "maxP95": 100
+      },
+      "loaderCachedModuleLoadMs": {
+        "maxP95": 100
+      },
+      "styleOwnershipMs": {
+        "maxP95": 10
+      },
+      "teardownThirtyCyclesMs": {
+        "maxP95": 250
+      },
+      "interactionMs": {
+        "maxP95": 100
+      }
+    },
+    "invariants": {
+      "hydrationRetainsServerDom": true,
+      "routeMatchesRequestedLocation": true,
+      "loaderReusesCachedModule": true,
+      "stylesReleasedAfterOwnershipEnds": true,
+      "retainedDomNodesAfterTeardown": 0,
+      "detachedListenersAfterTeardown": 0,
+      "longTasksWhenObservable": 0
+    }
+  },
+  "ssr": {
+    "metric": "ssrRenderMs",
+    "samples": [
+      0.7339579999999728,
+      0.9277500000000032,
+      0.8447500000000332,
+      1.7532079999999723,
+      0.4755000000000109,
+      0.4742500000000405,
+      0.47604200000000674,
+      0.4863330000000019,
+      0.4914590000000203,
+      0.5593749999999886,
+      0.6330000000000382,
+      0.7830000000000155,
+      0.7763749999999732,
+      0.758542000000034,
+      0.6644999999999754,
+      0.6747500000000173,
+      1.6959999999999695,
+      1.3176669999999717,
+      0.9434170000000108,
+      0.5202919999999835
+    ],
+    "correctness": {
+      "rowCount": 100,
+      "markupBytes": 12608
+    },
+    "statistics": {
+      "min": 0.4742500000000405,
+      "median": 0.6747500000000173,
+      "p95": 1.6959999999999695,
+      "max": 1.7532079999999723
+    }
+  },
+  "browsers": [
+    {
+      "browser": "chromium",
+      "browserVersion": "149.0.7827.55",
+      "result": {
+        "schemaVersion": 1,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/149.0.7827.55 Safari/537.36",
+        "samples": 20,
+        "warmupRounds": 5,
+        "teardownCycles": 30,
+        "metrics": {
+          "hydrationMs": [
+            0.10000000894069672,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.09999999403953552,
+            0.19999998807907104,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.09999999403953552,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.19999998807907104,
+            0.20000000298023224,
+            0.10000000894069672,
+            0.09999999403953552,
+            0.20000000298023224,
+            0.19999998807907104,
+            0.20000000298023224,
+            0.29999999701976776
+          ],
+          "routeTransitionMs": [
+            0.29999999701976776,
+            0.09999999403953552,
+            0.10000000894069672,
+            0.10000000894069672,
+            0.09999999403953552,
+            0,
+            0,
+            0,
+            0,
+            0.10000000894069672,
+            0.09999999403953552,
+            0,
+            0.10000000894069672,
+            0,
+            0.09999999403953552,
+            0.20000000298023224,
+            0.09999999403953552,
+            0.10000000894069672,
+            0.19999998807907104,
+            0.10000000894069672
+          ],
+          "loaderCachedModuleLoadMs": [
+            0.20000000298023224,
+            0.29999999701976776,
+            0.20000000298023224,
+            0.29999999701976776,
+            0.10000000894069672,
+            0.20000000298023224,
+            0.09999999403953552,
+            0.29999999701976776,
+            0.20000000298023224,
+            0.19999998807907104,
+            0.09999999403953552,
+            0.29999999701976776,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.20000000298023224,
+            0.19999998807907104
+          ],
+          "styleOwnershipMs": [
+            0.0009999999403953552,
+            0.001000000089406967,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0029999999701976776,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0019999998807907105,
+            0.0020000000298023225,
+            0.0020000000298023225,
+            0.0009999999403953552,
+            0.0029999999701976776,
+            0.0020000000298023225,
+            0.0019999998807907105,
+            0.0029999999701976776,
+            0.0030000001192092896
+          ],
+          "teardownThirtyCyclesMs": [
+            0.9000000059604645,
+            1.0999999940395355,
+            0.5,
+            0.5999999940395355,
+            0.5,
+            0.4000000059604645,
+            0.5999999940395355,
+            0.699999988079071,
+            0.7000000029802322,
+            1.3999999910593033,
+            0.5999999940395355,
+            0.7000000029802322,
+            0.7000000029802322,
+            0.4000000059604645,
+            0.5999999940395355,
+            0.4000000059604645,
+            0.5,
+            0.7000000029802322,
+            0.4000000059604645,
+            0.3999999910593033
+          ],
+          "interactionMs": [
+            0,
+            0,
+            0,
+            0.10000000894069672,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.09999999403953552,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.09999999403953552,
+            0
+          ]
+        },
+        "correctness": {
+          "hydrationRetainsServerDom": true,
+          "routeMatchesRequestedLocation": true,
+          "loaderReusesCachedModule": true,
+          "stylesReleasedAfterOwnershipEnds": true,
+          "retainedDomNodesAfterTeardown": 0,
+          "detachedListenersAfterTeardown": 0
+        },
+        "longTasks": {
+          "supported": true,
+          "count": 0,
+          "durationsMs": []
+        }
+      },
+      "statistics": {
+        "hydrationMs": {
+          "min": 0.09999999403953552,
+          "median": 0.20000000298023224,
+          "p95": 0.20000000298023224,
+          "max": 0.29999999701976776
+        },
+        "routeTransitionMs": {
+          "min": 0,
+          "median": 0.09999999403953552,
+          "p95": 0.20000000298023224,
+          "max": 0.29999999701976776
+        },
+        "loaderCachedModuleLoadMs": {
+          "min": 0.09999999403953552,
+          "median": 0.20000000298023224,
+          "p95": 0.29999999701976776,
+          "max": 0.29999999701976776
+        },
+        "styleOwnershipMs": {
+          "min": 0.0009999999403953552,
+          "median": 0.0020000000298023225,
+          "p95": 0.0029999999701976776,
+          "max": 0.0030000001192092896
+        },
+        "teardownThirtyCyclesMs": {
+          "min": 0.3999999910593033,
+          "median": 0.5999999940395355,
+          "p95": 1.0999999940395355,
+          "max": 1.3999999910593033
+        },
+        "interactionMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 0.09999999403953552,
+          "max": 0.10000000894069672
+        }
+      }
+    },
+    {
+      "browser": "firefox",
+      "browserVersion": "151.0",
+      "result": {
+        "schemaVersion": 1,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:151.0) Gecko/20100101 Firefox/151.0",
+        "samples": 20,
+        "warmupRounds": 5,
+        "teardownCycles": 30,
+        "metrics": {
+          "hydrationMs": [
+            1,
+            1,
+            2,
+            2,
+            1,
+            0,
+            1,
+            1,
+            0,
+            1,
+            0,
+            1,
+            0,
+            1,
+            2,
+            1,
+            0,
+            1,
+            1,
+            0
+          ],
+          "routeTransitionMs": [
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+            1
+          ],
+          "loaderCachedModuleLoadMs": [
+            0,
+            1,
+            0,
+            1,
+            1,
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            2,
+            0,
+            1
+          ],
+          "styleOwnershipMs": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.01,
+            0.01,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "teardownThirtyCyclesMs": [
+            1,
+            2,
+            1,
+            1,
+            2,
+            4,
+            2,
+            1,
+            1,
+            2,
+            1,
+            2,
+            8,
+            3,
+            1,
+            1,
+            1,
+            1,
+            2,
+            3
+          ],
+          "interactionMs": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "correctness": {
+          "hydrationRetainsServerDom": true,
+          "routeMatchesRequestedLocation": true,
+          "loaderReusesCachedModule": true,
+          "stylesReleasedAfterOwnershipEnds": true,
+          "retainedDomNodesAfterTeardown": 0,
+          "detachedListenersAfterTeardown": 0
+        },
+        "longTasks": {
+          "supported": false,
+          "count": 0,
+          "durationsMs": []
+        }
+      },
+      "statistics": {
+        "hydrationMs": {
+          "min": 0,
+          "median": 1,
+          "p95": 2,
+          "max": 2
+        },
+        "routeTransitionMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 1,
+          "max": 1
+        },
+        "loaderCachedModuleLoadMs": {
+          "min": 0,
+          "median": 1,
+          "p95": 1,
+          "max": 2
+        },
+        "styleOwnershipMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 0.01,
+          "max": 0.01
+        },
+        "teardownThirtyCyclesMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 4,
+          "max": 8
+        },
+        "interactionMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "browser": "webkit",
+      "browserVersion": "26.5",
+      "result": {
+        "schemaVersion": 1,
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5 Safari/605.1.15",
+        "samples": 20,
+        "warmupRounds": 5,
+        "teardownCycles": 30,
+        "metrics": {
+          "hydrationMs": [
+            0,
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0
+          ],
+          "routeTransitionMs": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "loaderCachedModuleLoadMs": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "styleOwnershipMs": [
+            0,
+            0,
+            0.01,
+            0,
+            0.01,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.01,
+            0,
+            0,
+            0,
+            0
+          ],
+          "teardownThirtyCyclesMs": [
+            2,
+            1,
+            1,
+            2,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            1,
+            1,
+            0,
+            0,
+            1,
+            1,
+            1,
+            2
+          ],
+          "interactionMs": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ]
+        },
+        "correctness": {
+          "hydrationRetainsServerDom": true,
+          "routeMatchesRequestedLocation": true,
+          "loaderReusesCachedModule": true,
+          "stylesReleasedAfterOwnershipEnds": true,
+          "retainedDomNodesAfterTeardown": 0,
+          "detachedListenersAfterTeardown": 0
+        },
+        "longTasks": {
+          "supported": false,
+          "count": 0,
+          "durationsMs": []
+        }
+      },
+      "statistics": {
+        "hydrationMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 1,
+          "max": 1
+        },
+        "routeTransitionMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 1,
+          "max": 1
+        },
+        "loaderCachedModuleLoadMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 1,
+          "max": 1
+        },
+        "styleOwnershipMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 0.01,
+          "max": 0.01
+        },
+        "teardownThirtyCyclesMs": {
+          "min": 0,
+          "median": 1,
+          "p95": 2,
+          "max": 2
+        },
+        "interactionMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 0,
+          "max": 0
+        }
+      }
+    }
+  ],
+  "passed": true,
+  "failures": []
+}

--- a/benchmarks/results/runtime-scorecard-50c6448.md
+++ b/benchmarks/results/runtime-scorecard-50c6448.md
@@ -1,0 +1,42 @@
+# Runtime performance scorecard
+
+Generated: 2026-07-21T08:52:10.517Z
+
+Source: `50c64480d1b9acac450a3fc6c08bb09c97363ab9` on `codex/217-runtime-performance-scorecard` (working tree clean)
+
+Environment: Apple M4, 10 logical CPUs, 16.0 GiB memory, darwin 25.3.0, Node v24.18.0
+
+Method: production builds, 5 warm-ups and 20 measured samples per lane. Browser engines are reported separately.
+
+| Lane | Metric | Median ms | p95 ms | Criterion p95 ms | Status |
+| --- | --- | ---: | ---: | ---: | --- |
+| node | ssrRenderMs | 0.675 | 1.696 | 50.000 | pass |
+| chromium 149.0.7827.55 | hydrationMs | 0.200 | 0.200 | 100.000 | pass |
+| chromium 149.0.7827.55 | routeTransitionMs | 0.100 | 0.200 | 100.000 | pass |
+| chromium 149.0.7827.55 | loaderCachedModuleLoadMs | 0.200 | 0.300 | 100.000 | pass |
+| chromium 149.0.7827.55 | styleOwnershipMs | 0.002000 | 0.003000 | 10.000 | pass |
+| chromium 149.0.7827.55 | teardownThirtyCyclesMs | 0.600 | 1.100 | 250.000 | pass |
+| chromium 149.0.7827.55 | interactionMs | 0.000000 | 0.100 | 100.000 | pass |
+| firefox 151.0 | hydrationMs | 1.000 | 2.000 | 100.000 | pass |
+| firefox 151.0 | routeTransitionMs | 0.000000 | 1.000 | 100.000 | pass |
+| firefox 151.0 | loaderCachedModuleLoadMs | 1.000 | 1.000 | 100.000 | pass |
+| firefox 151.0 | styleOwnershipMs | 0.000000 | 0.010 | 10.000 | pass |
+| firefox 151.0 | teardownThirtyCyclesMs | 1.000 | 4.000 | 250.000 | pass |
+| firefox 151.0 | interactionMs | 0.000000 | 0.000000 | 100.000 | pass |
+| webkit 26.5 | hydrationMs | 0.000000 | 1.000 | 100.000 | pass |
+| webkit 26.5 | routeTransitionMs | 0.000000 | 1.000 | 100.000 | pass |
+| webkit 26.5 | loaderCachedModuleLoadMs | 0.000000 | 1.000 | 100.000 | pass |
+| webkit 26.5 | styleOwnershipMs | 0.000000 | 0.010 | 10.000 | pass |
+| webkit 26.5 | teardownThirtyCyclesMs | 1.000 | 2.000 | 250.000 | pass |
+| webkit 26.5 | interactionMs | 0.000000 | 0.000000 | 100.000 | pass |
+
+## Correctness and retention
+
+- chromium: all deterministic invariants passed; long-task observation supported with 0 entries.
+- firefox: all deterministic invariants passed; long-task observation not exposed by this engine.
+- webkit: all deterministic invariants passed; long-task observation not exposed by this engine.
+
+Overall: **pass**. Every raw latency sample, correctness value, browser version, and observed long-task duration is preserved in the accompanying JSON file.
+
+This is a Gluon production regression scorecard. It does not compare equivalent implementations in other frameworks and does not support a universal framework-performance ranking.
+

--- a/benchmarks/runtime-scorecard/index.html
+++ b/benchmarks/runtime-scorecard/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gluon runtime scorecard</title>
+  </head>
+  <body>
+    <main>
+      <h1>Gluon runtime scorecard</h1>
+      <p>Use <code>npm run benchmark:runtime</code> to retain production evidence.</p>
+    </main>
+    <script type="module" src="/main.ts"></script>
+  </body>
+</html>

--- a/benchmarks/runtime-scorecard/main.ts
+++ b/benchmarks/runtime-scorecard/main.ts
@@ -1,0 +1,263 @@
+import {
+  createApp,
+  createStyleSheetOwner,
+  css,
+  html,
+  unmount,
+} from '@gluonjs/core';
+import { componentLibraryManifest } from '@gluonjs/example-component-library/manifest';
+import { createComponentLibraryLoader } from '@gluonjs/quarks';
+import { nextTick, reactive } from '@gluonjs/reactivity';
+import { createMemoryHistory, createRouter } from '@gluonjs/router/memory';
+import { prepareForHydration } from '@gluonjs/ssr';
+import { hydrateTemplate } from '@gluonjs/ssr/hydration';
+
+export interface RuntimeBrowserConfig {
+  readonly samples?: number;
+  readonly warmupRounds?: number;
+  readonly teardownCycles?: number;
+}
+
+export interface RuntimeBrowserResult {
+  readonly schemaVersion: 1;
+  readonly userAgent: string;
+  readonly samples: number;
+  readonly warmupRounds: number;
+  readonly teardownCycles: number;
+  readonly metrics: Readonly<Record<BrowserMetric, readonly number[]>>;
+  readonly correctness: {
+    readonly hydrationRetainsServerDom: true;
+    readonly routeMatchesRequestedLocation: true;
+    readonly loaderReusesCachedModule: true;
+    readonly stylesReleasedAfterOwnershipEnds: true;
+    readonly retainedDomNodesAfterTeardown: 0;
+    readonly detachedListenersAfterTeardown: 0;
+  };
+  readonly longTasks: {
+    readonly supported: boolean;
+    readonly count: number;
+    readonly durationsMs: readonly number[];
+  };
+}
+
+type BrowserMetric =
+  | 'hydrationMs'
+  | 'routeTransitionMs'
+  | 'loaderCachedModuleLoadMs'
+  | 'styleOwnershipMs'
+  | 'teardownThirtyCyclesMs'
+  | 'interactionMs';
+
+const styleOperations = 100;
+const benchmarkSheet = css`:host { color: rgb(16 32 48); }`;
+const loaderSheet = css`.example-product-badge { font-weight: 700; }`;
+
+export async function runRuntimeBrowserScorecard(
+  config: RuntimeBrowserConfig = {},
+): Promise<RuntimeBrowserResult> {
+  const samples = positiveInteger(config.samples ?? 20, 'samples');
+  const warmupRounds = nonNegativeInteger(config.warmupRounds ?? 5, 'warmupRounds');
+  const teardownCycles = positiveInteger(config.teardownCycles ?? 30, 'teardownCycles');
+  const metrics: Record<BrowserMetric, number[]> = {
+    hydrationMs: [],
+    routeTransitionMs: [],
+    loaderCachedModuleLoadMs: [],
+    styleOwnershipMs: [],
+    teardownThirtyCyclesMs: [],
+    interactionMs: [],
+  };
+  const longTaskDurations: number[] = [];
+  const longTaskSupported = PerformanceObserver.supportedEntryTypes?.includes('longtask') ?? false;
+  const observer = longTaskSupported
+    ? new PerformanceObserver((list) => {
+        longTaskDurations.push(...list.getEntries().map((entry) => entry.duration));
+      })
+    : undefined;
+  observer?.observe({ entryTypes: ['longtask'] });
+
+  const history = createMemoryHistory(['/alpha']);
+  const router = createRouter({
+    history,
+    routes: [{ path: '/alpha' }, { path: '/beta' }],
+  });
+  await router.isReady();
+  let nextRoute = '/beta';
+
+  const hydrationValue = html`<main><h2>${'Hydrated product'}</h2><p>${'Available'}</p></main>`;
+  const preparedHydration = await prepareForHydration(hydrationValue);
+
+  try {
+    for (let round = 0; round < warmupRounds + samples; round += 1) {
+      const measured = round >= warmupRounds;
+      const hydration = await measureHydration(hydrationValue, preparedHydration.html);
+      const route = await measureRoute(router, nextRoute);
+      nextRoute = nextRoute === '/alpha' ? '/beta' : '/alpha';
+      const loader = await measureLoader();
+      const styles = measureStyles();
+      const teardown = await measureTeardown(teardownCycles);
+      const interaction = await measureInteraction();
+      if (measured) {
+        metrics.hydrationMs.push(hydration.durationMs);
+        metrics.routeTransitionMs.push(route.durationMs);
+        metrics.loaderCachedModuleLoadMs.push(loader.durationMs);
+        metrics.styleOwnershipMs.push(styles.durationMs);
+        metrics.teardownThirtyCyclesMs.push(teardown.durationMs);
+        metrics.interactionMs.push(interaction.durationMs);
+      }
+      await nextFrame();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  } finally {
+    observer?.disconnect();
+    router.destroy();
+  }
+
+  return Object.freeze({
+    schemaVersion: 1 as const,
+    userAgent: navigator.userAgent,
+    samples,
+    warmupRounds,
+    teardownCycles,
+    metrics,
+    correctness: Object.freeze({
+      hydrationRetainsServerDom: true as const,
+      routeMatchesRequestedLocation: true as const,
+      loaderReusesCachedModule: true as const,
+      stylesReleasedAfterOwnershipEnds: true as const,
+      retainedDomNodesAfterTeardown: 0 as const,
+      detachedListenersAfterTeardown: 0 as const,
+    }),
+    longTasks: Object.freeze({
+      supported: longTaskSupported,
+      count: longTaskDurations.length,
+      durationsMs: Object.freeze(longTaskDurations),
+    }),
+  });
+}
+
+async function measureHydration(value: ReturnType<typeof html>, markup: string): Promise<{ durationMs: number }> {
+  const root = document.createElement('div');
+  root.innerHTML = markup;
+  const serverMain = root.querySelector('main');
+  const started = performance.now();
+  const result = await hydrateTemplate(value, root);
+  const durationMs = performance.now() - started;
+  if (!result.retained || result.recovered || root.querySelector('main') !== serverMain) {
+    throw new Error('Hydration correctness gate did not retain the server DOM in place.');
+  }
+  unmount(root);
+  if (root.childNodes.length !== 0) throw new Error('Hydration cleanup retained DOM nodes.');
+  return { durationMs };
+}
+
+async function measureRoute(
+  router: ReturnType<typeof createRouter>,
+  location: string,
+): Promise<{ durationMs: number }> {
+  const started = performance.now();
+  await router.push(location);
+  const durationMs = performance.now() - started;
+  if (router.currentRoute.value.fullPath !== location) {
+    throw new Error(`Router correctness gate expected ${location}.`);
+  }
+  return { durationMs };
+}
+
+async function measureLoader(): Promise<{ durationMs: number }> {
+  const baselineSheets = document.adoptedStyleSheets.length;
+  const resolver = {
+    load: async () => (await import('@gluonjs/example-component-library/product-badge')).ProductBadge,
+  };
+  const loader = createComponentLibraryLoader(componentLibraryManifest, resolver, {
+    styleTarget: document,
+    styles: { resolve: () => [loaderSheet] },
+  });
+  const started = performance.now();
+  const first = loader.load('product-badge');
+  const second = loader.load('product-badge');
+  if (first !== second) throw new Error('Loader correctness gate did not reuse its cached promise.');
+  await first;
+  const durationMs = performance.now() - started;
+  if (loader.status('product-badge') !== 'loaded') throw new Error('Loader correctness gate did not reach loaded state.');
+  loader.release('product-badge');
+  loader.dispose();
+  if (document.adoptedStyleSheets.length !== baselineSheets) {
+    throw new Error('Loader correctness gate retained a stylesheet after release.');
+  }
+  return { durationMs };
+}
+
+function measureStyles(): { durationMs: number } {
+  const host = document.createElement('div');
+  const root = host.attachShadow({ mode: 'open' });
+  const started = performance.now();
+  for (let index = 0; index < styleOperations; index += 1) {
+    const owner = createStyleSheetOwner(root);
+    owner.retain(benchmarkSheet);
+    owner.dispose();
+  }
+  const durationMs = (performance.now() - started) / styleOperations;
+  if (root.adoptedStyleSheets.length !== 0) throw new Error('Stylesheet ownership correctness gate retained a sheet.');
+  return { durationMs };
+}
+
+async function measureTeardown(cycles: number): Promise<{ durationMs: number }> {
+  let retainedDomNodes = 0;
+  let detachedListenerMutations = 0;
+  const started = performance.now();
+  for (let cycle = 0; cycle < cycles; cycle += 1) {
+    const state = reactive({ count: 0 });
+    const root = document.createElement('div');
+    const app = createApp(() => html`<button @click=${() => { state.count += 1; }}>${state.count}</button>`);
+    const mount = app.mount(root);
+    const button = root.querySelector('button');
+    button?.click();
+    await nextTick();
+    if (state.count !== 1 || button?.textContent !== '1') throw new Error('Teardown setup correctness gate failed.');
+    mount.unmount();
+    retainedDomNodes += root.childNodes.length;
+    button.click();
+    detachedListenerMutations += state.count - 1;
+  }
+  const durationMs = performance.now() - started;
+  if (retainedDomNodes !== 0 || detachedListenerMutations !== 0) {
+    throw new Error(`Teardown correctness gate retained ${retainedDomNodes} nodes and ${detachedListenerMutations} listener mutations.`);
+  }
+  return { durationMs };
+}
+
+async function measureInteraction(): Promise<{ durationMs: number }> {
+  const state = reactive({ count: 0 });
+  const root = document.createElement('div');
+  const mount = createApp(() => html`<button @click=${() => { state.count += 1; }}>${state.count}</button>`).mount(root);
+  const button = root.querySelector('button');
+  const started = performance.now();
+  button?.click();
+  await nextTick();
+  const durationMs = performance.now() - started;
+  if (state.count !== 1 || button?.textContent !== '1') throw new Error('Interaction correctness gate failed.');
+  mount.unmount();
+  return { durationMs };
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value <= 0) throw new TypeError(`${name} must be a positive integer.`);
+  return value;
+}
+
+function nonNegativeInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) throw new TypeError(`${name} must be a non-negative integer.`);
+  return value;
+}
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+declare global {
+  interface Window {
+    runRuntimeBrowserScorecard: typeof runRuntimeBrowserScorecard;
+  }
+}
+
+window.runRuntimeBrowserScorecard = runRuntimeBrowserScorecard;

--- a/benchmarks/runtime-scorecard/ssr.ts
+++ b/benchmarks/runtime-scorecard/ssr.ts
@@ -1,0 +1,38 @@
+import { html } from '@gluonjs/core';
+import { renderToString } from '@gluonjs/ssr';
+
+export interface SsrScorecardConfig {
+  readonly samples: number;
+  readonly warmupRounds: number;
+}
+
+/** Runs the production-bundled, DOM-independent SSR scorecard lane. */
+export async function runSsrScorecard(config: SsrScorecardConfig): Promise<{
+  readonly metric: 'ssrRenderMs';
+  readonly samples: readonly number[];
+  readonly correctness: { readonly rowCount: 100; readonly markupBytes: number };
+}> {
+  const rows = Array.from({ length: 100 }, (_, index) => html`<li data-row=${index}>Product ${index}</li>`);
+  const value = html`<main><h1>${'Catalog'}</h1><ul>${rows}</ul></main>`;
+  const verify = async (): Promise<number> => {
+    const rendered = await renderToString(value);
+    const rowCount = rendered.match(/data-row=/g)?.length ?? 0;
+    if (rowCount !== 100 || !rendered.includes('Catalog') || !rendered.includes('data-row="99"')) {
+      throw new Error(`SSR correctness gate produced ${rowCount} rows.`);
+    }
+    return rendered.length;
+  };
+  const markupBytes = await verify();
+  const samples: number[] = [];
+  for (let round = 0; round < config.warmupRounds + config.samples; round += 1) {
+    const started = performance.now();
+    await verify();
+    const duration = performance.now() - started;
+    if (round >= config.warmupRounds) samples.push(duration);
+  }
+  return {
+    metric: 'ssrRenderMs',
+    samples,
+    correctness: { rowCount: 100, markupBytes },
+  };
+}

--- a/benchmarks/runtime-scorecard/ssr.vite.config.ts
+++ b/benchmarks/runtime-scorecard/ssr.vite.config.ts
@@ -1,0 +1,28 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+const repositoryRoot = resolve(import.meta.dirname, '../..');
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@gluonjs/core': resolve(repositoryRoot, 'src/index.ts'),
+      '@gluonjs/reactivity': resolve(repositoryRoot, 'packages/reactivity/src/index.ts'),
+      '@gluonjs/router/memory': resolve(repositoryRoot, 'packages/router/src/memory.ts'),
+      '@gluonjs/router': resolve(repositoryRoot, 'packages/router/src/index.ts'),
+      '@gluonjs/ssr': resolve(repositoryRoot, 'packages/ssr/src/index.ts'),
+      '@gluonjs/store': resolve(repositoryRoot, 'packages/store/src/index.ts'),
+    },
+  },
+  define: {
+    __GLUON_DEV__: JSON.stringify(false),
+  },
+  build: {
+    ssr: resolve(import.meta.dirname, 'ssr.ts'),
+    outDir: resolve(repositoryRoot, '.tmp/runtime-scorecard-node'),
+    emptyOutDir: true,
+    rollupOptions: {
+      output: { entryFileNames: 'ssr.js' },
+    },
+  },
+});

--- a/benchmarks/runtime-scorecard/vite.config.ts
+++ b/benchmarks/runtime-scorecard/vite.config.ts
@@ -1,0 +1,34 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+const repositoryRoot = resolve(import.meta.dirname, '../..');
+
+export default defineConfig({
+  root: import.meta.dirname,
+  resolve: {
+    conditions: ['browser'],
+    alias: {
+      '@gluonjs/core': resolve(repositoryRoot, 'src/index.ts'),
+      '@gluonjs/example-component-library/manifest': resolve(repositoryRoot, 'examples/component-library/library/src/manifest.ts'),
+      '@gluonjs/example-component-library/product-badge': resolve(repositoryRoot, 'examples/component-library/library/src/product-badge.ts'),
+      '@gluonjs/quarks': resolve(repositoryRoot, 'packages/quarks/src/index.ts'),
+      '@gluonjs/reactivity': resolve(repositoryRoot, 'packages/reactivity/src/index.ts'),
+      '@gluonjs/router/memory': resolve(repositoryRoot, 'packages/router/src/memory.ts'),
+      '@gluonjs/ssr/hydration': resolve(repositoryRoot, 'packages/ssr/src/hydration.ts'),
+      '@gluonjs/ssr': resolve(repositoryRoot, 'packages/ssr/src/index.ts'),
+      '@gluonjs/store': resolve(repositoryRoot, 'packages/store/src/index.ts'),
+    },
+  },
+  define: {
+    __GLUON_DEV__: JSON.stringify(false),
+  },
+  build: {
+    outDir: resolve(repositoryRoot, '.tmp/runtime-scorecard'),
+    emptyOutDir: true,
+  },
+  preview: {
+    host: '127.0.0.1',
+    port: 4177,
+    strictPort: true,
+  },
+});

--- a/docs/memory-retention.md
+++ b/docs/memory-retention.md
@@ -18,3 +18,11 @@ ownership after teardown in Chromium, Firefox, and WebKit. They do not claim a
 fixed process heap, absence of browser-internal caches, or deterministic garbage
 collection. Heap-growth claims require a separate browser/version-specific
 profile with raw samples and an explicit collection protocol.
+
+The production [`runtime scorecard`](performance.md#expanded-runtime-scorecard)
+adds a timed retention lane. Every sample mounts, interacts with, unmounts, and
+probes 30 application roots. Acceptance requires zero retained root DOM nodes
+and zero mutations from detached button listeners in Chromium, Firefox, and
+WebKit. It reports teardown latency independently per engine. This remains
+deterministic ownership evidence; it does not convert the gate into a browser
+heap-size or garbage-collection claim.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -37,10 +37,47 @@ browser versions, Node and npm versions, operating system, CPU, and memory.
 
 Every pull request and `main` run additionally retains ten-sample template and
 component Chromium/Firefox/WebKit comparisons plus the production GLUON GOODS
-customer-flow budget output for 30 days in the
+customer-flow budget output and the expanded runtime scorecard for 30 days in the
 `quality-evidence-<commit>` workflow artifact. Those shorter CI runs detect
 regressions but do not replace the larger committed matrices used by the
 comparative text below.
+
+## Expanded runtime scorecard
+
+`npm run benchmark:runtime` production-builds the measured code and records
+seven separate lanes: Node SSR, browser hydration, memory-router transitions,
+manifest-driven component loading, constructable stylesheet ownership,
+application teardown, and reactive interaction latency. Chromium, Firefox,
+and WebKit run in separate fresh contexts; their values are never averaged.
+Where an engine exposes `PerformanceObserver` long-task entries, the same run
+also retains their count and raw durations.
+
+The versioned pass criteria live in
+[`quality/runtime-performance-criteria.json`](../quality/runtime-performance-criteria.json).
+They declare sample counts, warm-ups, p95 latency ceilings, thirty teardown
+cycles, retained-resource invariants, and the supported-engine long-task limit
+before measurement. Every warm-up and measured operation validates observable
+correctness. A failed invariant or missing metric criterion rejects the run.
+
+```bash
+npx playwright install chromium firefox webkit
+npm run benchmark:runtime
+
+# Short diagnostic; not a replacement for committed full evidence
+npm run benchmark:runtime -- \
+  --browsers=chromium \
+  --samples=5 \
+  --warmup=2 \
+  --output=.tmp/runtime-scorecard-diagnostic.json
+```
+
+The paired JSON and Markdown output defaults to
+`.tmp/quality-evidence/runtime-scorecard.{json,md}`. JSON preserves every raw
+sample, source state, hardware, OS, Node/npm, package and exact browser
+versions, correctness values, and long-task observations. The scorecard is a
+Gluon production regression gate. It has no equivalent-framework fixtures, so
+it does not extend the Lit/Vue comparisons below and cannot support a universal
+framework-performance ranking.
 
 ## Run the benchmark
 
@@ -51,6 +88,7 @@ production comparison:
 npx playwright install chromium firefox webkit
 npm run benchmark:rendering
 npm run benchmark:components
+npm run benchmark:runtime
 ```
 
 The default run uses Chromium, Firefox, and WebKit with eight warm-up rounds and

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -79,6 +79,16 @@ Gluon production regression gate. It has no equivalent-framework fixtures, so
 it does not extend the Lit/Vue comparisons below and cannot support a universal
 framework-performance ranking.
 
+The current full
+[`runtime-scorecard-50c6448.md`](../benchmarks/results/runtime-scorecard-50c6448.md)
+run measures clean source commit `50c6448` with 20 samples and five warm-ups on
+the recorded Apple M4 environment. All declared p95 criteria and deterministic
+resource invariants passed in Chromium 149, Firefox 151, and WebKit 26.5.
+Chromium exposed the long-task entry type and recorded zero entries; Firefox
+and WebKit did not expose that observer entry type, which is recorded as an
+unsupported observation rather than a zero measurement. The paired JSON keeps
+all raw values and exact environment metadata.
+
 ## Run the benchmark
 
 Install the three Playwright-managed browser engines once, then run the

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "benchmark:keyed": "vitest bench --run benchmarks/keyed-list.bench.ts",
     "benchmark:rendering": "node scripts/run-rendering-benchmark.mjs",
     "benchmark:components": "npm run build:compiler && node scripts/run-component-benchmark.mjs",
+    "benchmark:runtime": "npm run build:core && npm run build:router && npm run build:store && npm run build:ssr && node scripts/run-runtime-scorecard.mjs",
     "benchmark:allocations": "node scripts/run-renderer-allocation-benchmark.mjs",
     "benchmark:dx": "node scripts/run-dx-automation.mjs",
     "benchmark:shop-flow": "node scripts/run-shop-performance.mjs",

--- a/quality/runtime-performance-criteria.json
+++ b/quality/runtime-performance-criteria.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "samples": 20,
+  "warmupRounds": 5,
+  "teardownCycles": 30,
+  "metrics": {
+    "ssrRenderMs": { "maxP95": 50 },
+    "hydrationMs": { "maxP95": 100 },
+    "routeTransitionMs": { "maxP95": 100 },
+    "loaderCachedModuleLoadMs": { "maxP95": 100 },
+    "styleOwnershipMs": { "maxP95": 10 },
+    "teardownThirtyCyclesMs": { "maxP95": 250 },
+    "interactionMs": { "maxP95": 100 }
+  },
+  "invariants": {
+    "hydrationRetainsServerDom": true,
+    "routeMatchesRequestedLocation": true,
+    "loaderReusesCachedModule": true,
+    "stylesReleasedAfterOwnershipEnds": true,
+    "retainedDomNodesAfterTeardown": 0,
+    "detachedListenersAfterTeardown": 0,
+    "longTasksWhenObservable": 0
+  }
+}

--- a/scripts/run-runtime-scorecard.mjs
+++ b/scripts/run-runtime-scorecard.mjs
@@ -1,0 +1,311 @@
+import { execFileSync } from 'node:child_process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { cpus, platform, release, totalmem } from 'node:os';
+import { dirname, extname, resolve } from 'node:path';
+import { chromium, firefox, webkit } from 'playwright';
+import { build, preview } from 'vite';
+
+const root = resolve(import.meta.dirname, '..');
+const configFile = resolve(root, 'benchmarks/runtime-scorecard/vite.config.ts');
+const ssrConfigFile = resolve(root, 'benchmarks/runtime-scorecard/ssr.vite.config.ts');
+const criteriaFile = resolve(root, 'quality/runtime-performance-criteria.json');
+const browserTypes = { chromium, firefox, webkit };
+const criteria = JSON.parse(await readFile(criteriaFile, 'utf8'));
+const options = parseOptions(process.argv.slice(2), criteria);
+const outputPath = resolve(root, options.output);
+const markdownPath = outputPath.slice(0, -extname(outputPath).length) + '.md';
+const packageJson = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+const packageLock = JSON.parse(await readFile(resolve(root, 'package-lock.json'), 'utf8'));
+
+validateCriteria(criteria);
+await build({ configFile: ssrConfigFile });
+const ssr = await measureSsr(options);
+await build({ configFile });
+const server = await preview({
+  configFile,
+  preview: { host: '127.0.0.1', port: 0, strictPort: false },
+});
+const url = server.resolvedUrls?.local[0];
+if (!url) throw new Error('Vite preview did not expose a local runtime-scorecard URL.');
+
+const browserRuns = [];
+try {
+  for (const browserName of options.browsers) {
+    const browserType = browserTypes[browserName];
+    if (!browserType) throw new Error(`Unsupported browser ${browserName}.`);
+    let browser;
+    try {
+      browser = await browserType.launch({ headless: true });
+    } catch (error) {
+      throw new Error(`Could not launch ${browserName}. Run "npx playwright install ${browserName}" first.`, { cause: error });
+    }
+    try {
+      const context = await browser.newContext();
+      try {
+        const page = await context.newPage();
+        const consoleProblems = [];
+        page.on('console', (message) => {
+          if (message.type() === 'error' || message.type() === 'warning') {
+            consoleProblems.push({ type: message.type(), text: message.text() });
+          }
+        });
+        await page.goto(url, { waitUntil: 'networkidle' });
+        const result = await withTimeout(
+          page.evaluate((config) => window.runRuntimeBrowserScorecard(config), {
+            samples: options.samples,
+            warmupRounds: options.warmupRounds,
+            teardownCycles: options.teardownCycles,
+          }),
+          options.browserTimeoutMs,
+          `${browserName} runtime scorecard`,
+        );
+        if (consoleProblems.length > 0) {
+          throw new Error(`${browserName} logged runtime-scorecard errors: ${JSON.stringify(consoleProblems)}`);
+        }
+        browserRuns.push({
+          browser: browserName,
+          browserVersion: browser.version(),
+          result,
+          statistics: Object.fromEntries(
+            Object.entries(result.metrics).map(([name, samples]) => [name, summarize(samples)]),
+          ),
+        });
+      } finally {
+        await context.close();
+      }
+    } finally {
+      await browser.close();
+    }
+  }
+} finally {
+  await server.close();
+}
+
+const failures = validateResults(criteria, ssr, browserRuns);
+const evidence = {
+  schemaVersion: 1,
+  generatedAt: new Date().toISOString(),
+  source: {
+    commit: git('rev-parse', 'HEAD'),
+    branch: sourceRef(),
+    workingTreeDirty: git('status', '--porcelain').length > 0,
+  },
+  environment: {
+    platform: platform(),
+    release: release(),
+    cpu: cpus()[0]?.model ?? 'unknown',
+    logicalCpus: cpus().length,
+    totalMemoryBytes: totalmem(),
+    node: process.version,
+    npm: execFileSync('npm', ['--version'], { encoding: 'utf8' }).trim(),
+    packages: {
+      gluon: packageJson.version,
+      playwright: installedVersion('playwright'),
+      vite: installedVersion('vite'),
+    },
+  },
+  methodology: {
+    productionBuild: true,
+    headless: true,
+    samples: options.samples,
+    warmupRounds: options.warmupRounds,
+    teardownCycles: options.teardownCycles,
+    browserTimeoutMs: options.browserTimeoutMs,
+    lanes: {
+      ssr: 'Node renderToString of one 100-row Gluon template',
+      hydration: 'retain marker-bearing server DOM in place',
+      routing: 'await one public memory-router transition',
+      loader: 'load one cached dynamic module through a fresh manifest-driven loader',
+      styles: 'retain and release one constructable stylesheet through 100 owners; milliseconds per owner',
+      memory: 'mount, interact with, unmount, and probe detached listeners for 30 application roots',
+      interaction: 'dispatch one application-owned button interaction and await the reactive update',
+      longTasks: 'record PerformanceObserver longtask entries only in engines that expose that entry type',
+    },
+    correctnessGate: 'every warm-up and measured operation validates its observable output before evidence is accepted',
+    isolation: 'one fresh browser context per engine; engine results are never averaged together',
+    unit: 'milliseconds; lower is faster',
+  },
+  criteria,
+  ssr,
+  browsers: browserRuns,
+  passed: failures.length === 0,
+  failures,
+};
+
+await mkdir(dirname(outputPath), { recursive: true });
+await writeFile(outputPath, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+const markdown = renderMarkdown(evidence);
+await writeFile(markdownPath, markdown, 'utf8');
+console.log(markdown);
+console.log(`JSON evidence: ${outputPath}`);
+console.log(`Markdown summary: ${markdownPath}`);
+if (failures.length > 0) throw new Error(`Runtime performance scorecard failed:\n- ${failures.join('\n- ')}`);
+
+async function measureSsr(config) {
+  const modulePath = resolve(root, '.tmp/runtime-scorecard-node/ssr.js');
+  const { runSsrScorecard } = await import(`${modulePath}?run=${Date.now()}`);
+  const result = await runSsrScorecard(config);
+  return { ...result, statistics: summarize(result.samples) };
+}
+
+function validateResults(expected, ssrResult, runs) {
+  const failures = [];
+  compareBudget('node', 'ssrRenderMs', ssrResult.statistics.p95, expected, failures);
+  for (const run of runs) {
+    for (const [name, statistics] of Object.entries(run.statistics)) {
+      compareBudget(run.browser, name, statistics.p95, expected, failures);
+    }
+    for (const [name, value] of Object.entries(expected.invariants)) {
+      if (name === 'longTasksWhenObservable') continue;
+      if (run.result.correctness[name] !== value) {
+        failures.push(`${run.browser} invariant ${name} expected ${JSON.stringify(value)} but received ${JSON.stringify(run.result.correctness[name])}`);
+      }
+    }
+    if (run.result.longTasks.supported && run.result.longTasks.count > expected.invariants.longTasksWhenObservable) {
+      failures.push(`${run.browser} observed ${run.result.longTasks.count} long tasks; maximum is ${expected.invariants.longTasksWhenObservable}`);
+    }
+  }
+  return failures;
+}
+
+function compareBudget(lane, name, actual, expected, failures) {
+  const limit = expected.metrics[name]?.maxP95;
+  if (!Number.isFinite(limit)) {
+    failures.push(`${lane} metric ${name} has no declared p95 criterion`);
+  } else if (actual > limit) {
+    failures.push(`${lane} ${name} p95 ${formatMilliseconds(actual)} ms exceeds ${formatMilliseconds(limit)} ms`);
+  }
+}
+
+function validateCriteria(value) {
+  if (value.schemaVersion !== 1) throw new Error('runtime performance criteria schemaVersion must be 1');
+  if (!Number.isInteger(value.samples) || value.samples <= 0) throw new Error('criteria.samples must be a positive integer');
+  if (!Number.isInteger(value.warmupRounds) || value.warmupRounds < 0) throw new Error('criteria.warmupRounds must be a non-negative integer');
+  if (!Number.isInteger(value.teardownCycles) || value.teardownCycles <= 0) throw new Error('criteria.teardownCycles must be a positive integer');
+  const metrics = ['ssrRenderMs', 'hydrationMs', 'routeTransitionMs', 'loaderCachedModuleLoadMs', 'styleOwnershipMs', 'teardownThirtyCyclesMs', 'interactionMs'];
+  for (const name of metrics) {
+    if (!Number.isFinite(value.metrics?.[name]?.maxP95) || value.metrics[name].maxP95 <= 0) {
+      throw new Error(`${name}.maxP95 must be a positive number`);
+    }
+  }
+}
+
+function parseOptions(args, defaults) {
+  const values = Object.fromEntries(args.map((argument) => {
+    const [name, value] = argument.split('=', 2);
+    return [name, value];
+  }));
+  const browsers = (values['--browsers'] ?? 'chromium,firefox,webkit').split(',');
+  if (browsers.length === 0 || new Set(browsers).size !== browsers.length || browsers.some((name) => !browserTypes[name])) {
+    throw new Error('--browsers must contain unique supported browsers.');
+  }
+  const output = values['--output'] ?? '.tmp/quality-evidence/runtime-scorecard.json';
+  if (extname(output) !== '.json') throw new Error('--output must end in .json.');
+  return {
+    browsers,
+    samples: positiveInteger(values['--samples'] ?? defaults.samples, 'samples'),
+    warmupRounds: nonNegativeInteger(values['--warmup'] ?? defaults.warmupRounds, 'warmup'),
+    teardownCycles: positiveInteger(values['--teardown-cycles'] ?? defaults.teardownCycles, 'teardown-cycles'),
+    browserTimeoutMs: positiveInteger(values['--timeout'] ?? '300000', 'timeout'),
+    output,
+  };
+}
+
+function summarize(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    min: sorted[0],
+    median: quantile(sorted, 0.5),
+    p95: quantile(sorted, 0.95),
+    max: sorted.at(-1),
+  };
+}
+
+function quantile(sorted, probability) {
+  return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * probability) - 1)];
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new TypeError(`--${name} must be a positive integer.`);
+  return parsed;
+}
+
+function nonNegativeInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new TypeError(`--${name} must be a non-negative integer.`);
+  return parsed;
+}
+
+function installedVersion(packageName) {
+  const version = packageLock.packages?.[`node_modules/${packageName}`]?.version;
+  if (!version) throw new Error(`package-lock.json has no installed version for ${packageName}.`);
+  return version;
+}
+
+function git(...args) {
+  return execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+}
+
+function sourceRef() {
+  return process.env.GITHUB_REF_NAME || git('branch', '--show-current') || 'detached';
+}
+
+async function withTimeout(promise, timeoutMs, label) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} exceeded ${timeoutMs} ms.`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function renderMarkdown(evidence) {
+  const lines = [
+    '# Runtime performance scorecard',
+    '',
+    `Generated: ${evidence.generatedAt}`,
+    '',
+    `Source: \`${evidence.source.commit}\` on \`${evidence.source.branch}\` (working tree ${evidence.source.workingTreeDirty ? 'dirty' : 'clean'})`,
+    '',
+    `Environment: ${evidence.environment.cpu}, ${evidence.environment.logicalCpus} logical CPUs, ${formatBytes(evidence.environment.totalMemoryBytes)} memory, ${evidence.environment.platform} ${evidence.environment.release}, Node ${evidence.environment.node}`,
+    '',
+    `Method: production builds, ${evidence.methodology.warmupRounds} warm-ups and ${evidence.methodology.samples} measured samples per lane. Browser engines are reported separately.`,
+    '',
+    '| Lane | Metric | Median ms | p95 ms | Criterion p95 ms | Status |',
+    '| --- | --- | ---: | ---: | ---: | --- |',
+  ];
+  const ssrLimit = evidence.criteria.metrics.ssrRenderMs.maxP95;
+  lines.push(`| node | ssrRenderMs | ${formatMilliseconds(evidence.ssr.statistics.median)} | ${formatMilliseconds(evidence.ssr.statistics.p95)} | ${formatMilliseconds(ssrLimit)} | ${evidence.ssr.statistics.p95 <= ssrLimit ? 'pass' : 'fail'} |`);
+  for (const run of evidence.browsers) {
+    for (const [name, statistics] of Object.entries(run.statistics)) {
+      const limit = evidence.criteria.metrics[name].maxP95;
+      lines.push(`| ${run.browser} ${run.browserVersion} | ${name} | ${formatMilliseconds(statistics.median)} | ${formatMilliseconds(statistics.p95)} | ${formatMilliseconds(limit)} | ${statistics.p95 <= limit ? 'pass' : 'fail'} |`);
+    }
+  }
+  lines.push('', '## Correctness and retention', '');
+  for (const run of evidence.browsers) {
+    lines.push(`- ${run.browser}: all deterministic invariants passed; long-task observation ${run.result.longTasks.supported ? `supported with ${run.result.longTasks.count} entries` : 'not exposed by this engine'}.`);
+  }
+  lines.push(
+    '',
+    `Overall: **${evidence.passed ? 'pass' : 'fail'}**. Every raw latency sample, correctness value, browser version, and observed long-task duration is preserved in the accompanying JSON file.`,
+    '',
+    'This is a Gluon production regression scorecard. It does not compare equivalent implementations in other frameworks and does not support a universal framework-performance ranking.',
+    '',
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+function formatBytes(value) {
+  return `${(value / (1024 ** 3)).toFixed(1)} GiB`;
+}
+
+function formatMilliseconds(value) {
+  return Number(value).toFixed(value < 0.01 ? 6 : 3);
+}


### PR DESCRIPTION
## Summary
- add a production-built runtime scorecard for Node SSR plus Chromium, Firefox, and WebKit hydration, routing, component loading, constructable styles, teardown, interaction, and supported-engine long-task observation
- declare versioned p95 and correctness criteria before measurement and retain a clean 20-sample/5-warm-up reference with raw samples and exact environment metadata
- run the shortened three-engine scorecard in CI and document the evidence boundary, including that this Gluon-only regression gate does not support a universal framework ranking

## Verification
- `npm run benchmark:runtime -- --output=benchmarks/results/runtime-scorecard-50c6448.json`
- `npm run test:coverage`
- `npm run check`

## Shop application
No shop source changed. This slice adds repository benchmark and retention evidence; the existing GLUON GOODS customer-flow benchmark remains the user-visible application performance gate, so a decorative shop surface would not be an honest application of the tooling.

Closes #217
