### PR TITLE
Record Gluon 1.2.0 publication

### DIFF
--- a/docs-site/content/1.2.0/guides/releasing/index.md
+++ b/docs-site/content/1.2.0/guides/releasing/index.md
@@ -1,13 +1,12 @@
 # Release readiness
 
-The `1.2.0` documentation describes the prepared lockstep candidate. All 17
-official manifests are at `1.2.0`. Registry preflight on 2026-07-21 confirmed
-that every contracted package still exposes `1.1.0` as `latest` with SLSA
-provenance and that `1.2.0` is absent. Immutable GitHub release `v1.1.0` remains
-the current finalized release while the candidate is reviewed. The `v1.0.9`
-GitHub release remains a draft after its public-type verification failure. The
-`@gluonjs` scope, package records, and trusted-publisher bindings are verified
-in the package contract.
+The `1.2.0` documentation describes the completed lockstep release. All 17
+official manifests are at `1.2.0`. Release run `29822468758` published every
+contracted package under `latest` with SLSA provenance, passed clean-room
+installation and public-type verification, and published immutable GitHub
+release `v1.2.0` on 2026-07-21. The `v1.0.9` GitHub release remains a draft
+after its public-type verification failure. The `@gluonjs` scope, package
+records, and trusted-publisher bindings are verified in the package contract.
 
 Gluon's release group contains 17 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,12 +7,12 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.2.0` candidate. Every official
-manifest is public and lockstep at `1.2.0`. Registry preflight on 2026-07-21
-confirmed that all 17 contracted npm packages expose `1.1.0` as `latest` with
-SLSA provenance and that `1.2.0` is absent. Immutable GitHub release `v1.1.0`
-remains the current finalized release; the `v1.0.9` GitHub release remains a
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for the completed `1.2.0` release. Every official
+manifest is public and lockstep at `1.2.0`. Release run `29822468758` published
+all 17 contracted npm packages under `latest` with SLSA provenance, passed
+clean-room installation and public-type verification, and published immutable
+GitHub release `v1.2.0` on 2026-07-21. The `v1.0.9` GitHub release remains a
 draft after its public-type verification failure. This is enforced locally by:
 
 ```sh

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,6 +1,6 @@
 # Security threat model
 
-This threat model applies to the prepared `1.2.0` release line. Its
+This threat model applies to the released `1.2.0` release line. Its
 machine-readable source is
 [`quality/security-threat-model.json`](../quality/security-threat-model.json),
 and `npm run check:security` rejects missing threat areas or evidence paths.

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-07-21",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-07-21 confirmed that all 17 contracted npm package records expose 1.1.0 as latest with SLSA provenance and that version 1.2.0 is absent. The prepared 1.2.0 candidate advances the current verified capability set."
+    "publicationState": "released",
+    "observation": "Release run 29822468758 completed on 2026-07-21. All 17 contracted npm packages expose 1.2.0 as latest with SLSA provenance; clean-room installation and public-type verification passed, and GitHub release v1.2.0 is published and immutable."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary
- mark the 1.2.0 package contract as released
- record release run 29822468758, npm provenance, clean-room verification, and immutable GitHub release evidence
- align release and security documentation with the published state

## Verification
- `npm run check:release-contract`
- `npm run check:security`
- `npm run check:docs`
- live npm verification: all 17 contracted packages expose 1.2.0 as latest with SLSA provenance
- live GitHub verification: v1.2.0 is published and immutable

## Shop application
No shop change is appropriate: this slice records external publication state and does not change a framework capability or public API.

Part of #232.