### PR TITLE
docs: add junior learning and component guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,13 @@ export const Available: StoryObj<{ label: string }> = {
 See the [Storybook guide](docs/storybook.md) and the runnable
 [`examples/component-library`](examples/component-library/README.md) catalog.
 
+For a first project, use the versioned
+[step-by-step learning path](docs-site/content/1.2.0/guides/learning-path/index.md).
+Before extracting shop UI, use the
+[component decision guide](docs-site/content/1.2.0/guides/component-decisions/index.md):
+official packages require a cross-application semantic and accessibility
+contract; branded GLUON GOODS compositions remain application-local.
+
 ## Vite and state-preserving HMR
 
 `@gluonjs/vite` records `html` and `css` template and interpolation locations,

--- a/docs-site/content/1.2.0/cookbook/index.md
+++ b/docs-site/content/1.2.0/cookbook/index.md
@@ -7,6 +7,14 @@ Every TypeScript recipe below is sourced from a file compiled by
 
 <<< ../../../examples/basic-app.ts
 
+## Build a searchable keyed list with owned styles
+
+<<< ../../../examples/beginner-feature.ts
+
+## Compose Atom, Molecule, and Organism boundaries
+
+<<< ../../../examples/component-decisions.ts
+
 ## Publish a Custom Element
 
 <<< ../../../examples/custom-element.ts

--- a/docs-site/content/1.2.0/guides/component-decisions/index.md
+++ b/docs-site/content/1.2.0/guides/component-decisions/index.md
@@ -1,0 +1,92 @@
+# Choose Atom, Molecule, Organism, or Custom Element
+
+Component levels describe responsibility, not visual size. Start with the
+smallest honest boundary and promote it only when reuse and ownership require
+more.
+
+## Decision tree
+
+1. Is this only a native element or headless browser behavior?
+   Use a Quark or `q.<tag>()`.
+2. Is it one stateless, reusable presentational value or control?
+   Use an Atom.
+3. Does it combine a few related controls or values into one reusable task?
+   Use a Molecule.
+4. Does it arrange a reusable section or multi-part workflow?
+   Use an Organism.
+5. Does it need an independent host, connection lifecycle, form association,
+   internal state, or a stable platform tag?
+   Use `defineGluonElement()` or subclass `GluonElement`.
+6. Is it meaningful only inside one product or brand?
+   Keep it application-local even if it uses layer metadata.
+
+`defineAtom()`, `defineMolecule()`, and `defineOrganism()` add immutable layer
+and display-name metadata to stateless functions. They do not create DOM hosts,
+state, lifecycle, registration, or accessibility semantics.
+
+## Promotion rule for official packages
+
+An implementation belongs in `@gluonjs/atoms`, `@gluonjs/molecules`, or
+`@gluonjs/organisms` only when all of these are true:
+
+- more than one application can use the same semantic contract;
+- its accessibility behavior is stable and testable without product copy;
+- its API does not depend on GLUON GOODS routes, product fields, analytics, or
+  brand classes;
+- it has package documentation, unit/browser evidence, and a real shop use;
+- consumers can customize it through public props, native attributes, slots,
+  or tokens without importing repository internals.
+
+Reuse inside one application is not sufficient evidence for an official
+package.
+
+## Verified GLUON GOODS classification
+
+| Surface | Current boundary | Why |
+| --- | --- | --- |
+| Button, Input, Icon, Label | Official Atoms | Cross-application native controls/values with stable accessibility contracts. |
+| FormField, Card | Official Molecules | Reusable small compositions whose labels, errors, content, and actions have stable semantics. |
+| AppShell | Official Organism | Reusable landmark composition independent of shop product data. |
+| PurchaseAction | App-local Molecule | It combines shop price copy, bag icon, analytics class, and purchase intent. |
+| CheckoutExperience | App-local Organism | It owns the GLUON GOODS checkout form and order workflow. |
+| Product configurator | App-local Custom Element | It owns product variants, form association, internal state, and a stable shop-facing host. |
+| Editorial Journal link | App-local Atom/SFC | It is a branded navigation detail, not a cross-application primitive. |
+
+The shop should continue using official primitives inside real customer flows.
+It should not become a component gallery, and branded domain compositions
+should not be promoted merely to increase the official inventory.
+
+## Compiled example
+
+This example shows the same data moving through a reusable Atom, a task-level
+Molecule, and a section-level Organism:
+
+<<< ../../../../examples/component-decisions.ts
+
+The example is intentionally stateless. If quantity, validity, focus, or form
+ownership must survive independently of its parent render, move that stateful
+boundary to a Custom Element rather than hiding lifecycle inside a functional
+component.
+
+## Props and events
+
+- Props are inputs. Keep them readonly at the component boundary.
+- Native or custom events are outputs. Do not mutate a parent-owned object to
+  report a change.
+- Keep accessible names, disabled state, validation, and required structure as
+  explicit semantic props when the component owns them.
+- Forward ordinary native customization through typed `attributes` or Quark
+  props; do not add arbitrary string variants for application-specific CSS.
+
+## Styles
+
+Official components own constructable stylesheet dependencies with stable IDs
+and layer order. Applications style their own classes and documented tokens.
+Neither application code nor Storybook stories may depend on `.gluon-*`
+implementation classes.
+
+## When not to create a component
+
+Keep plain template markup when the fragment is short, used once, owns no
+semantic contract, and becomes clearer when read in place. A wrapper with only
+a new name is not automatically a useful abstraction.

--- a/docs-site/content/1.2.0/guides/getting-started/index.md
+++ b/docs-site/content/1.2.0/guides/getting-started/index.md
@@ -10,6 +10,11 @@ npm install
 npm run dev
 ```
 
+New to frontend frameworks? Follow the
+[step-by-step learning path](../learning-path/) next. It explains the generated
+files, templates, bindings, reactivity, keyed lists, styles, cleanup, tests, and
+the words used throughout the rest of the documentation.
+
 To add the runtime to an existing project, install its public package entry
 point:
 
@@ -35,3 +40,21 @@ application owns its render effect and releases it during unmount.
 `npm run check` typechecks public API fixtures, runs Node and browser tests,
 builds client/server/static outputs, validates package archives, compiles every
 maintained starter, and builds this documentation site.
+
+## Package chooser
+
+| Goal | Start with |
+| --- | --- |
+| Render templates or create an application/Custom Element | `@gluonjs/core` |
+| Add reactive values and derived state | `@gluonjs/reactivity` |
+| Use native/headless building blocks | `@gluonjs/quarks` |
+| Use optional reusable UI | `@gluonjs/atoms`, `@gluonjs/molecules`, `@gluonjs/organisms` |
+| Add URLs | `@gluonjs/router` |
+| Add shared application state | `@gluonjs/store` |
+| Build with Vite and `.gluon` files | `@gluonjs/vite` |
+| Build a Storybook catalog | `@gluonjs/gluon-components-vite` |
+| Test public browser behavior | `@gluonjs/test-utils` |
+| Render on a server or generate static HTML | `@gluonjs/ssr` |
+
+Install a package when the feature enters the application. A minimal browser
+app does not need Router, Store, SSR, or the optional UI packages.

--- a/docs-site/content/1.2.0/guides/index.md
+++ b/docs-site/content/1.2.0/guides/index.md
@@ -6,6 +6,8 @@ contracts exercised by GLUON GOODS.
 ## Start
 
 - [Getting started](getting-started/): install, author, check, and build a browser application.
+- [Learn Gluon step by step](learning-path/): a junior-friendly path through templates, reactivity, lists, styles, cleanup, and tests.
+- [Choose a component level](component-decisions/): decide between native markup, Quark, Atom, Molecule, Organism, Custom Element, and app-local code.
 - [Components: properties, events, and lifecycle](components/): choose an authoring model and build typed component boundaries.
 - [Application architecture](application/): application ownership, Router, Store, and cleanup.
 - [Universal rendering](universal-rendering/): SSR, hydration, streaming, and SSG boundaries.

--- a/docs-site/content/1.2.0/guides/learning-path/index.md
+++ b/docs-site/content/1.2.0/guides/learning-path/index.md
@@ -1,0 +1,175 @@
+# Learn Gluon step by step
+
+This path assumes basic TypeScript, HTML, and npm knowledge. It does not assume
+framework experience. Complete the steps in order; each one adds a single new
+idea.
+
+## The mental model
+
+Keep these five facts in mind:
+
+1. `html` returns a description of DOM, called a `TemplateResult`.
+2. A `ref` owns one reactive value. Reading `.value` while rendering creates the
+   dependency; writing `.value` schedules the update.
+3. Gluon updates bindings inside existing DOM when the template callsite stays
+   the same.
+4. A Gluon application owns effects and cleanup until `unmount()`.
+5. Browser standards stay visible: events are native events, Custom Elements
+   are real Custom Elements, and styles are constructable `CSSStyleSheet`s.
+
+## Step 1: create and run a project
+
+```sh
+npm create gluon@latest my-shop
+cd my-shop
+npm install
+npm run dev
+```
+
+Open the URL printed by Vite. The generated project contains:
+
+| File | Junior-friendly purpose |
+| --- | --- |
+| `index.html` | Provides the mount element such as `<div id="app"></div>`. |
+| `src/main.ts` | Creates state, returns the root template, and mounts the app. |
+| `vite.config.ts` | Activates the official Gluon transform and diagnostics. |
+| `package.json` | Lists the run, build, typecheck, and test commands. |
+
+Run `npm run build` before committing. A successful dev page alone does not
+prove that TypeScript and the production bundle are valid.
+
+## Step 2: read a template
+
+```ts
+const name = 'Orbit Lamp';
+const price = 128;
+
+html`
+  <article>
+    <h2>${name}</h2>
+    <p>$${price}</p>
+  </article>
+`;
+```
+
+Static markup remains normal HTML. `${...}` is a binding. Do not build HTML by
+concatenating strings; Gluon escapes ordinary values and updates the exact
+binding.
+
+The most common binding forms are:
+
+| Syntax | Meaning | Example |
+| --- | --- | --- |
+| `${value}` | Text, child template, node, or list content | `<p>${message}</p>` |
+| `name=${value}` | String attribute | `aria-label=${label}` |
+| `.name=${value}` | JavaScript property | `.product=${product}` |
+| `?name=${value}` | Boolean attribute | `?disabled=${saving.value}` |
+| `@name=${listener}` | Native event listener | `@click=${save}` |
+
+Use a property binding for objects, arrays, or live DOM properties such as
+`input.value`. Use an attribute for serializable HTML text.
+
+## Step 3: add state
+
+```ts
+import { createApp, html } from '@gluonjs/core';
+import { ref } from '@gluonjs/reactivity';
+
+const count = ref(0);
+
+createApp(() => html`
+  <button @click=${() => { count.value += 1; }}>
+    Added ${count.value} time(s)
+  </button>
+`).mount(document.querySelector('#app')!);
+```
+
+The event writes the state; the template reads it. Do not call `render()`
+manually after changing a ref.
+
+## Step 4: render a stable list
+
+Use `repeat()` when items have stable identities:
+
+```ts
+repeat(
+  products,
+  (product) => product.id,
+  (product) => html`<article>${product.name}</article>`,
+);
+```
+
+The key must be unique and stable. An array index is unsuitable when items can
+be reordered or removed because the index describes a position, not the item.
+
+## Step 5: own styles and cleanup
+
+Gluon intentionally uses constructable stylesheets. A `StyleSheetOwner` retains
+only the sheets it owns and releases them during application cleanup:
+
+```ts
+const owner = createStyleSheetOwner(document);
+owner.retain(css`main { max-inline-size: 40rem; }`);
+app.onUnmounted(() => owner.dispose());
+```
+
+The full compiled feature below combines typed data, a controlled search input,
+derived state, a keyed list, stylesheet ownership, and page cleanup:
+
+<<< ../../../../examples/beginner-feature.ts
+
+## Step 6: test public behavior
+
+Test through the rendered surface:
+
+<<< ../../../../examples/testing.ts
+
+Prefer queries and assertions a user or platform consumer can observe. Do not
+assert renderer comments, private fields, or implementation classes.
+
+## Step 7: choose the next guide
+
+- Need a reusable visual part? Continue with
+  [choosing a component level](../component-decisions/).
+- Need a stateful Custom Element? Continue with
+  [properties, events, and lifecycle](../components/).
+- Need URLs or shared state? Continue with
+  [application architecture](../application/).
+- Need server HTML? Continue with
+  [universal rendering](../universal-rendering/).
+- Something failed? Read the error message and code, then open the
+  [diagnostic reference](../../reference/diagnostics/).
+
+## Common first-project mistakes
+
+| Symptom | Check |
+| --- | --- |
+| The page is empty | Confirm `index.html` has the queried mount ID and that `mount()` receives that element. |
+| State changed but the UI did not | Read the ref as `.value` inside the app render function; do not copy it to a non-reactive variable first. |
+| An object becomes `[object Object]` | Use `.property=${value}` rather than an attribute binding. |
+| A checkbox or disabled control is wrong | Use `?checked=${value}` or `?disabled=${value}` for boolean attributes. |
+| A list keeps the wrong row after removal | Give `repeat()` a stable domain key instead of the array index. |
+| TypeScript accepts dev code but production fails | Run `npm run build`; do not rely only on the dev server. |
+| Styles disappear or leak between surfaces | Retain constructable sheets with an explicit owner and dispose that owner. |
+| Event code survives after navigation | Prefer template event bindings, or register imperative listeners with owner cleanup. |
+| A component has hidden state but no lifecycle | Move the stateful boundary to `defineGluonElement()` or `GluonElement`. |
+
+Every public symbol also has a compiled, task-oriented example in the
+[API reference](../../api/). Use the [Cookbook](../../cookbook/) when you know
+the task and the API reference when you know the symbol.
+
+## Small glossary
+
+| Term | Meaning |
+| --- | --- |
+| Template | A `TemplateResult` created by `html` or `svg`. |
+| Binding | One dynamic value inside a template. |
+| Ref | A reactive object whose current value is `.value`. |
+| Component | A function that returns a template, optionally with layer metadata. |
+| Custom Element | A registered browser element with its own host and lifecycle. |
+| Mount | Start an application in a specific container. |
+| Unmount | Stop effects, release owned resources, and remove renderer DOM. |
+| Quark | A thin native element or headless behavior building block. |
+| Atom | One reusable presentational control or value. |
+| Molecule | A small composition of related parts. |
+| Organism | A larger reusable section or workflow boundary. |

--- a/docs-site/content/1.2.0/index.md
+++ b/docs-site/content/1.2.0/index.md
@@ -5,6 +5,10 @@ and deployment.
 
 [Get started](/gluon/1.2.0/guides/getting-started/) [Browse API →](/gluon/1.2.0/api/)
 
+First framework project? Use the
+[junior learning path](/gluon/1.2.0/guides/learning-path/) for a progressive
+feature and plain-language glossary.
+
 <<< ../../examples/basic-app.ts
 
 ## Guides
@@ -23,6 +27,8 @@ constructable stylesheets, SSR style snapshots, and disposal. The maintained
 package consumer and Storybook catalog exercise those same public boundaries.
 
 [Build component boundaries →](/gluon/1.2.0/guides/components/)
+
+[Choose Atom, Molecule, Organism, or Custom Element →](/gluon/1.2.0/guides/component-decisions/)
 
 ## API reference
 

--- a/docs-site/examples/beginner-feature.ts
+++ b/docs-site/examples/beginner-feature.ts
@@ -1,0 +1,70 @@
+import {
+  createApp,
+  createStyleSheetOwner,
+  css,
+  html,
+  repeat,
+} from '@gluonjs/core';
+import {
+  computed,
+  ref,
+} from '@gluonjs/reactivity';
+
+interface Product {
+  readonly id: string;
+  readonly name: string;
+  readonly price: string;
+}
+
+const products: readonly Product[] = [
+  { id: 'orbit-lamp', name: 'Orbit Lamp', price: '$128' },
+  { id: 'field-tote', name: 'Field Tote', price: '$84' },
+];
+const query = ref('');
+const visibleProducts = computed(() => {
+  const needle = query.value.trim().toLowerCase();
+  return needle
+    ? products.filter((product) => product.name.toLowerCase().includes(needle))
+    : products;
+});
+const styles = css`
+  main { max-inline-size: 40rem; margin: 2rem auto; font: 1rem/1.5 system-ui; }
+  label, article { display: grid; gap: 0.5rem; }
+  section { display: grid; gap: 1rem; margin-block-start: 1.5rem; }
+  article { padding: 1rem; border: 1px solid #d8d8d8; }
+`;
+const styleOwner = createStyleSheetOwner(document);
+styleOwner.retain(styles);
+
+const app = createApp(() => html`
+  <main>
+    <h1>Products</h1>
+    <label>
+      Search
+      <input
+        type="search"
+        .value=${query.value}
+        @input=${(event: Event) => {
+          query.value = (event.currentTarget as HTMLInputElement).value;
+        }}
+      >
+    </label>
+    <p>${visibleProducts.value.length} result(s)</p>
+    <section>
+      ${repeat(
+        visibleProducts.value,
+        (product) => product.id,
+        (product) => html`
+          <article>
+            <strong>${product.name}</strong>
+            <span>${product.price}</span>
+          </article>
+        `,
+      )}
+    </section>
+  </main>
+`);
+
+app.onUnmounted(() => styleOwner.dispose());
+const mounted = app.mount(document.querySelector('#app')!);
+window.addEventListener('pagehide', () => mounted.unmount(), { once: true });

--- a/docs-site/examples/component-decisions.ts
+++ b/docs-site/examples/component-decisions.ts
@@ -1,0 +1,56 @@
+import {
+  Button,
+  defineUiAtom,
+} from '@gluonjs/atoms';
+import {
+  css,
+  html,
+} from '@gluonjs/core';
+import { defineMolecule } from '@gluonjs/molecules';
+import { defineOrganism } from '@gluonjs/organisms';
+
+export const StockBadge = defineUiAtom<
+  { readonly status: 'available' | 'back-order' },
+  'span'
+>({
+  displayName: 'StockBadge',
+  tag: 'span',
+  nativeProps: ({ status }) => ({
+    class: `stock-badge stock-badge--${status}`,
+    children: status === 'available' ? 'In stock' : 'Back order',
+  }),
+  style: {
+    id: 'example-stock-badge',
+    sheet: css`
+      .stock-badge { font-weight: 700; }
+      .stock-badge--available { color: #315d19; }
+      .stock-badge--back-order { color: #815400; }
+    `,
+  },
+});
+
+export const ProductSummary = defineMolecule((props: Readonly<{
+  name: string;
+  price: string;
+  status: 'available' | 'back-order';
+}>) => html`
+  <article>
+    <h2>${props.name}</h2>
+    <p>${props.price}</p>
+    ${StockBadge({ status: props.status })}
+  </article>
+`, 'ProductSummary');
+
+export const CatalogSection = defineOrganism((props: Readonly<{
+  heading: string;
+}>) => html`
+  <section aria-labelledby="catalog-heading">
+    <h1 id="catalog-heading">${props.heading}</h1>
+    ${ProductSummary({
+      name: 'Orbit Lamp',
+      price: '$128',
+      status: 'available',
+    })}
+    ${Button({ label: 'View all products' })}
+  </section>
+`, 'CatalogSection');


### PR DESCRIPTION
Closes #242

## Summary
- add a progressive junior learning path from scaffold and template bindings through reactivity, keyed lists, stylesheet ownership, cleanup, tests, and common mistakes
- add an evidence-backed component decision guide for Quarks, Atoms, Molecules, Organisms, Custom Elements, and app-local shop compositions
- add two compiled examples and connect them through Getting Started, Guides, Cookbook, the docs home, and the root README
- document the package chooser and confirm all 674 public API pages retain compiled task-oriented examples

## Verified GLUON GOODS decision
- official: Button/Input/Icon/Label Atoms, FormField/Card Molecules, AppShell Organism
- app-local: PurchaseAction Molecule, CheckoutExperience Organism, product-configurator Custom Element, editorial Journal Atom/SFC

## Verification
- `npm run check:docs`
- `git diff --check`
- documentation validator: 735 pages, 33 public entry points, 14 compiled examples, 1 supported version