### PR TITLE
fix(release): support incremental package bootstrap

### DIFF
--- a/docs/adrs/0002-package-release-and-supply-chain-governance.md
+++ b/docs/adrs/0002-package-release-and-supply-chain-governance.md
@@ -319,7 +319,11 @@ retained as a superseded record. Each bootstrap archive contains only its
 manifest, bootstrap notice, and MIT license; it exports no implementation. The
 executable release contract, artifact builder, and bootstrap publisher verify
 that boundary and make partial publication recoverable without replacing an
-immutable matching version.
+immutable matching version. They verify incremental additions without
+comparing a released package's immutable historical bootstrap archive with
+regenerated current documentation. Existing packages are skipped only when
+their contracted bootstrap record exists and their current supported `latest`
+release has registry integrity and provenance.
 
 ## Supply-chain evidence
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -235,6 +235,13 @@ package record exists. The one-time bootstrap therefore publishes a minimal
 `README.md`, and `LICENSE`: they expose no runtime, executable, types, exports,
 dependencies, or supported API. They do not use provenance, because this is an
 interactive owner publication rather than the protected release workflow.
+When a new official package joins after a supported release, the same builder
+regenerates the complete reviewed archive set from clean `main`. Existing
+packages are skipped only after the publisher verifies their current `latest`
+release, registry integrity, provenance, and bootstrap-record presence. Their
+historical bootstrap archives are immutable and are not compared with newly
+generated notices or READMEs. A package that has not reached a supported
+release still requires an exact bootstrap-archive integrity match.
 
 The first live bootstrap attempt created
 `@gluonjs/reactivity@0.0.0-bootstrap.0` with the reviewed archive integrity, but
@@ -263,15 +270,18 @@ npm run release:bootstrap:publish -- --dry-run
 ```
 
 The builder records the exact source commit, archive integrity, SHA-1, SHA-256,
-and file allowlist for all 17 packages. Review every name and archive before the
+and file allowlist for all 18 packages. Review every name and archive before the
 irreversible step. The publisher rejects `NPM_TOKEN` and `NODE_AUTH_TOKEN`, an
 artifact set that is not byte-identical to an independent rebuild, a dirty or
 non-`main` checkout, a source commit that is not the exact current
 `origin/main`, a user who is not an npm organization owner, a conflicting
-existing package record, any unexpected `latest`, and a rerun whose registry
-integrity differs from the reviewed archive. Registry visibility is allowed up
-to ten minutes after a successful publish before the operation stops; this wait
-does not weaken the exact integrity and dist-tag checks.
+existing package record, any unexpected `latest`, and a rerun whose unpublished
+bootstrap integrity differs from the reviewed archive. For already released
+packages it instead requires the current released version under `latest`, its
+registry integrity and provenance, and the contracted bootstrap record.
+Registry visibility is allowed up to ten minutes after a successful publish
+before the operation stops; this wait does not weaken the exact integrity and
+dist-tag checks.
 
 The npm owner then runs this command in an interactive terminal and completes
 the registry's 2FA challenges without copying credentials or one-time codes
@@ -294,7 +304,7 @@ with GitHub Actions, repository owner `marcmalerei`, repository `gluon`,
 workflow filename `release.yml`, environment `npm`, and the `npm publish`
 allowed action required by this repository's workflow. npm does not validate
 these coordinates when they are saved, so review them exactly. Configure and
-verify all 17 bindings before restricting traditional token publishing; no
+verify all 18 bindings before restricting traditional token publishing; no
 long-lived publication token may be added to GitHub.
 
 ## Release-candidate commit

--- a/scripts/publish-npm-bootstrap.mjs
+++ b/scripts/publish-npm-bootstrap.mjs
@@ -9,7 +9,9 @@ const execFile = promisify(execFileCallback);
 const root = resolve(import.meta.dirname, '..');
 const releaseContract = await readJson('release/release-contract.json');
 const packageContract = await readJson('package-contract.json');
+const rootManifest = await readJson('package.json');
 const bootstrap = releaseContract.bootstrap;
+const releasedVersion = rootManifest.version;
 const directory = resolve(root, option('--directory') ?? bootstrap.artifactDirectory);
 const dryRun = process.argv.includes('--dry-run');
 const confirmed = process.argv.includes('--confirm-owner-controlled-bootstrap');
@@ -35,27 +37,35 @@ validateEvidence(evidence);
 await verifyChecksums();
 await reproduceArtifacts(evidence);
 
+if (packageContract.registry.publicationState !== 'released'
+  || releaseContract.targetVersion !== releasedVersion) {
+  throw new Error('Incremental bootstrap requires the current clean main release to remain recorded as released.');
+}
 if (!dryRun) {
   await requireCleanMain(evidence.sourceCommit);
   await requireNpmOwner();
 }
 
 const registryState = new Map();
-if (!dryRun) {
-  for (const entry of evidence.packages) {
-    const packument = await registryPackument(entry.name);
-    if (packument?.versions?.[bootstrap.version]) {
-      verifyBootstrapMetadata(entry, packument);
-      registryState.set(entry.name, true);
-      continue;
-    }
-    if (packument) verifySupersededPackageRecord(entry.name, packument);
-    registryState.set(entry.name, false);
+for (const entry of evidence.packages) {
+  const packument = await registryPackument(entry.name);
+  if (packument?.versions?.[bootstrap.version]) {
+    const released = packument.versions?.[releasedVersion] !== undefined;
+    if (released) verifyReleasedPackageRecord(entry.name, packument);
+    else verifyBootstrapMetadata(entry, packument);
+    registryState.set(entry.name, released ? 'released' : 'bootstrap');
+    continue;
   }
+  if (packument) verifySupersededPackageRecord(entry.name, packument);
+  registryState.set(entry.name, 'missing');
 }
 
 for (const entry of evidence.packages) {
-  if (!dryRun && registryState.get(entry.name) === true) {
+  if (registryState.get(entry.name) === 'released') {
+    console.log(`verified existing released ${entry.name}@${releasedVersion} and bootstrap record; regenerated bootstrap archive skipped`);
+    continue;
+  }
+  if (registryState.get(entry.name) === 'bootstrap') {
     console.log(`verified existing ${entry.name}@${bootstrap.version}; immutable matching bootstrap skipped`);
     continue;
   }
@@ -160,6 +170,19 @@ function verifyBootstrapMetadata(entry, packument) {
   ]);
   if (latest && !allowedLatest.has(latest)) {
     throw new Error(`${entry.name} unexpectedly has latest=${latest}; only reviewed bootstrap placeholders are permitted before the first supported release.`);
+  }
+}
+
+function verifyReleasedPackageRecord(name, packument) {
+  const metadata = packument.versions?.[releasedVersion];
+  if (metadata?.name !== name || metadata.version !== releasedVersion) {
+    throw new Error(`${name}@${releasedVersion} does not match the current released package record.`);
+  }
+  if (packument['dist-tags']?.latest !== releasedVersion) {
+    throw new Error(`${name} latest is not the current released version ${releasedVersion}.`);
+  }
+  if (!metadata.dist?.integrity || !metadata.dist?.attestations) {
+    throw new Error(`${name}@${releasedVersion} is missing registry integrity or provenance attestations.`);
   }
 }
 

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -625,6 +625,8 @@ function validateWorkflow() {
     'requireCleanMain',
     'requireNpmOwner',
     'reproduceArtifacts',
+    'verifyReleasedPackageRecord',
+    'regenerated bootstrap archive skipped',
   ]) if (!bootstrapPublishScript.includes(required)) throw new Error(`npm bootstrap publisher is missing ${required}.`);
   for (const match of workflow.matchAll(/uses:\s+[^\s@]+@([^\s#]+)/g)) {
     if (!/^[a-f0-9]{40}$/.test(match[1])) {


### PR DESCRIPTION
Part of #244

## Summary
- allow a newly contracted npm package to bootstrap after earlier packages already reached a supported release
- verify every skipped package against its current latest release, registry integrity, provenance, and contracted bootstrap record
- keep exact archive-integrity verification for packages that have not reached a supported release
- make the dry run exercise the live registry decision path and document the incremental contract

## Verification
- `npm run release:bootstrap:publish -- --dry-run` (17 released records verified and skipped; only `@gluonjs/gluon-components-vite` planned)
- `npm run check:release-contract`
- `npm run check`

## Shop application
No shop change is appropriate: this is an owner-controlled release bootstrap correction and does not change a framework capability or public API.