### PR TITLE
Record Gluon 1.3.0 publication

### DIFF
--- a/docs-site/content/1.3.0/guides/releasing/index.md
+++ b/docs-site/content/1.3.0/guides/releasing/index.md
@@ -1,10 +1,12 @@
 # Release readiness
 
-The `1.3.0` documentation describes the prepared lockstep candidate. All 18
-official manifests are at `1.3.0`. The package contract records the exact
-registry preflight, while immutable GitHub release `v1.2.0` remains the current
-finalized release during candidate review. The `v1.0.9` GitHub release remains
-a draft after its public-type verification failure.
+The `1.3.0` documentation describes the completed lockstep release. All 18
+official manifests are at `1.3.0`. Release run `30035135735` published every
+contracted package under `latest` with npm provenance, passed clean-room
+installation and public-type verification, and published immutable GitHub
+release `v1.3.0` on 2026-07-23. The `v1.0.9` GitHub release remains a draft
+after its public-type verification failure. The `@gluonjs` scope, package
+records, and trusted-publisher bindings are verified in the package contract.
 
 Gluon's release group contains 18 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -8,11 +8,11 @@ and `.github/workflows/release.yml` is the only supported publication path.
 ## Current publication state
 
 The machine-readable package contract records `publicationState: released` and
-`scopeControl: verified` for the completed `1.2.0` release. Every official
-manifest is public and lockstep at `1.2.0`. Release run `29822468758` published
-all 17 contracted npm packages under `latest` with SLSA provenance, passed
+`scopeControl: verified` for the completed `1.3.0` release. Every official
+manifest is public and lockstep at `1.3.0`. Release run `30035135735` published
+all 18 contracted npm packages under `latest` with npm provenance, passed
 clean-room installation and public-type verification, and published immutable
-GitHub release `v1.2.0` on 2026-07-21. The `v1.0.9` GitHub release remains a
+GitHub release `v1.3.0` on 2026-07-23. The `v1.0.9` GitHub release remains a
 draft after its public-type verification failure. This is enforced locally by:
 
 ```sh

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-07-23",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-07-23 verified all 18 contracted package records under the owner-controlled @gluonjs scope. The 17 previously released packages expose 1.2.0 as latest with provenance, and @gluonjs/gluon-components-vite exposes the reviewed 0.0.0-bootstrap.1 placeholder with matching integrity and a GitHub Actions trusted publisher for marcmalerei/gluon, release.yml, environment npm, and npm publish. Version 1.3.0 is absent from every package record."
+    "publicationState": "released",
+    "observation": "Release run 30035135735 published all 18 contracted packages at 1.3.0 under latest with npm provenance on 2026-07-23. Independent public-registry verification confirmed matching reviewed archive integrity, provenance attestations, clean-room installation, and public type declarations for every package. Immutable GitHub release v1.3.0 is published from commit e3e62e751a5ea170bd95c42e0915b671ef001087."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary
- mark the 1.3.0 package contract as released
- record release run 30035135735, npm provenance, independent clean-room verification, and immutable GitHub release evidence
- align release documentation with the published state

## Verification
- `npm run check:release-contract`
- `npm run check:security`
- `npm run check:docs`
- `git diff --check`
- independent live npm verification: all 18 contracted packages expose 1.3.0 as latest with provenance and matching reviewed integrity
- independent clean-room installation and public-type verification
- live GitHub verification: v1.3.0 is published and immutable

## Shop application
No shop change is appropriate: this slice records external publication state and does not change a framework capability or public API.

Closes #244.