### PR TITLE
Document compiler and devtools package usage

### DIFF
--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -39,6 +39,37 @@ Inline `<style>` elements in `html` templates produce
 `GLUON_TEMPLATE_STYLE_ELEMENT`; Gluon browser styling uses constructable
 stylesheets and `adoptedStyleSheets` only.
 
+## Transform a module
+
+Pass the original source and its filename to `transformGluonModule()`. The
+result preserves transformed code and its source map while reporting the
+templates and diagnostics that tooling can display:
+
+```ts
+import {
+  transformGluonModule,
+  type GluonTransformResult,
+} from '@gluonjs/compiler';
+
+const source = `
+  import { html } from '@gluonjs/core';
+  export const ProductName = (name: string) => html\`<h1>\${name}</h1>\`;
+`;
+
+const result: GluonTransformResult = transformGluonModule(
+  source,
+  '/src/product-name.ts',
+  { development: true },
+);
+
+console.log(result.templates[0]?.tag); // "html"
+console.log(result.diagnostics); // source-located compiler diagnostics
+```
+
+Use `result.code` and `result.map` together when passing the output to the next
+build transform. Production callers omit `development: true`; development mode
+adds the HMR bridges described above.
+
 ## Presentational SFC compiler
 
 `compileGluonSfc(source, { filename })` lowers a `.gluon` presentational

--- a/packages/devtools-api/README.md
+++ b/packages/devtools-api/README.md
@@ -11,6 +11,52 @@ records. Snapshots are JSON-safe and preserve independent application IDs.
 
 The package has no browser or framework dependency.
 
+## Record an application timeline
+
+Create one protocol per Devtools client, register each application with a
+snapshot provider, and retain every returned cleanup function:
+
+```ts
+import {
+  DevtoolsProtocol,
+  type ApplicationInspector,
+} from '@gluonjs/devtools-api';
+
+const inspector: ApplicationInspector = {
+  id: 'shop',
+  name: 'GLUON GOODS',
+  snapshot: (selected) => ({
+    id: 'shop',
+    name: 'GLUON GOODS',
+    selected,
+    mounted: true,
+    route: '/products/orbit-lamp',
+    state: { bagCount: 1 },
+    context: {},
+    components: [],
+    stylesheets: 3,
+  }),
+};
+
+const protocol = new DevtoolsProtocol();
+const unregister = protocol.registerApplication(inspector);
+const unsubscribe = protocol.subscribe((snapshot, event) => {
+  console.log(snapshot.selectedApplicationId, event?.sequence);
+});
+
+protocol.record('shop', 'store', { action: 'add', product: 'orbit-lamp' });
+console.log(protocol.snapshot().timeline);
+
+unsubscribe();
+unregister();
+```
+
+`record()` accepts unknown payloads and converts them to the JSON-safe
+`DevtoolsValue` contract. It rejects non-application events for unknown
+application IDs. `snapshot()` returns immutable application and timeline
+arrays; `clearTimeline()` removes recorded events without unregistering
+applications.
+
 ## License
 
 MIT License, Copyright © 2026 Marc Malerei.

--- a/packages/devtools/README.md
+++ b/packages/devtools/README.md
@@ -9,10 +9,34 @@ Gluon Devtools is explicitly opt-in. `createDevtoolsBridge()` defaults to
 entry points enable it deliberately and register each application root with an
 independent ID plus optional Router, Store, state, and context inspectors.
 
+## Inspect an application
+
 ```ts
+import { createApp, html } from '@gluonjs/core';
+import {
+  createDevtoolsBridge,
+  mountGluonDevtools,
+} from '@gluonjs/devtools';
+
+const root = document.querySelector<HTMLElement>('#app');
+if (!root) throw new Error('Missing #app');
+
+const app = createApp(() => html`<main>GLUON GOODS</main>`);
+app.mount(root);
 const bridge = createDevtoolsBridge({ enabled: true, exposeGlobal: true });
-bridge.registerApplication({ id: 'shop', app, root, router, store });
-mountGluonDevtools(bridge);
+const unregister = bridge.registerApplication({
+  id: 'shop',
+  name: 'GLUON GOODS',
+  app,
+  root,
+  state: () => ({ bagCount: 1 }),
+});
+const panel = mountGluonDevtools(bridge);
+
+panel.unmount();
+unregister();
+bridge.dispose();
+app.unmount();
 ```
 
 Render records include scheduling causes, reactive dependency counts, timing,

--- a/scripts/validate-package-contract.mjs
+++ b/scripts/validate-package-contract.mjs
@@ -118,6 +118,18 @@ async function validateCurrentPackage(entry) {
       throw new Error(`${entry.name} README must contain exactly one ${token}.`);
     }
   }
+  if (!/```(?:bash|html|js|sh|ts|tsx)\n[\s\S]+?```/.test(readme)) {
+    throw new Error(`${entry.name} README must contain a fenced, runnable usage example.`);
+  }
+  if ((entry.bins ?? []).length === 0) {
+    const escapedPackageName = entry.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const publicImport = new RegExp(
+      `(?:from\\s+['"]${escapedPackageName}(?:\\/[^'"]+)?['"]|import\\s*\\(\\s*['"]${escapedPackageName}(?:\\/[^'"]+)?['"]\\s*\\))`,
+    );
+    if (!publicImport.test(readme)) {
+      throw new Error(`${entry.name} README usage example must import its public package entry point.`);
+    }
+  }
 
   const actualOfficialDependencies = new Set(
     ['dependencies', 'peerDependencies']


### PR DESCRIPTION
Closes #248

## Summary
- document complete public-entry-point usage for the compiler transform API
- add lifecycle-complete examples for the devtools protocol and browser bridge
- require every published package README to contain a usage example, and every library example to import its public package boundary

## Verification
- `npm run build`
- `npm run check:packages`
- `npm run check:docs`
- `npm run typecheck:tooling-api`
- `git diff --check`

## Shop application
This documentation validation change has no user-visible shop application; it documents and enforces published package onboarding rather than adding a framework capability.

<!-- mission-control:idempotency=repository-delivery:1ad34993-9976-46ce-8eb2-73a025049c54:pull-request -->