### PR TITLE
docs: date graph 1.5.0 changelog

### DIFF
--- a/packages/graph/CHANGELOG.md
+++ b/packages/graph/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 1.5.0
+## [1.5.0] - 2026-07-27
 
 - Add the first public, interactive `@gluonjs/graph` network graph element.


### PR DESCRIPTION
Completes the release-contract documentation requirement discovered while cutting v1.5.0.

- Adds the required release date to `@gluonjs/graph`’s 1.5.0 changelog heading.
- `npm run check:release-contract` passes.

Part of #263.