### PR TITLE
release: cut v1.5.0 evidence

### DIFF
--- a/release/compatibility/1.5.0.json
+++ b/release/compatibility/1.5.0.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "../compatibility-manifest.schema.json",
+  "schemaVersion": 1,
+  "releaseVersion": "1.5.0",
+  "sourceCommit": "1f038c710d5f85780657db3615e353793a90e968",
+  "cutAt": "2026-07-27T13:07:47Z",
+  "automatedQualityRun": {
+    "url": "https://github.com/marcmalerei/gluon/actions/runs/30267995544",
+    "conclusion": "success"
+  },
+  "supportBoundary": {
+    "model": "playwright-engine-and-node-evidence",
+    "brandedProductSupportClaimed": false
+  },
+  "engineTargets": [
+    {
+      "id": "playwright-chromium",
+      "browserBinary": "Chrome for Testing",
+      "browserVersion": "149.0.7827.55",
+      "engine": "Playwright Chromium",
+      "engineVersion": "1228",
+      "runner": "GitHub Actions ubuntu-24.04 image release 20260720.247.2",
+      "mode": "headless-automated",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235190"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "playwright-firefox",
+      "browserBinary": "Firefox",
+      "browserVersion": "151.0",
+      "engine": "Playwright Firefox",
+      "engineVersion": "1532",
+      "runner": "GitHub Actions ubuntu-24.04 image release 20260720.247.2",
+      "mode": "headless-automated",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235093"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "playwright-webkit",
+      "browserBinary": "WebKit",
+      "browserVersion": "26.5",
+      "engine": "Playwright WebKit",
+      "engineVersion": "2311",
+      "runner": "GitHub Actions ubuntu-24.04 image release 20260720.247.2",
+      "mode": "headless-automated",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235121"
+      ],
+      "outcome": "pass"
+    }
+  ],
+  "nodeTargets": [
+    {
+      "id": "node-22-lts",
+      "version": "22.12.0",
+      "releaseStatus": "maintenance-lts",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235101"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "node-24-lts",
+      "version": "24.18.0",
+      "releaseStatus": "active-lts",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235223"
+      ],
+      "outcome": "pass"
+    }
+  ],
+  "surfaces": [
+    {
+      "id": "client-rendering",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235190",
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235093",
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235121"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "server-rendering",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "streaming",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "hydration",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "static-generation",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+      ],
+      "outcome": "pass"
+    }
+  ]
+}

--- a/release/evidence/1.5.0.json
+++ b/release/evidence/1.5.0.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../release-cut-evidence.schema.json",
+  "schemaVersion": 1,
+  "releaseVersion": "1.5.0",
+  "testedCommit": "1f038c710d5f85780657db3615e353793a90e968",
+  "cutAt": "2026-07-27T13:07:47Z",
+  "automatedQualityRun": {
+    "url": "https://github.com/marcmalerei/gluon/actions/runs/30267995544",
+    "conclusion": "success"
+  },
+  "hostingPreflight": {
+    "immutableReleases": {
+      "enabled": true,
+      "enforcedByOwner": false,
+      "checkedBy": "marcmalerei",
+      "checkedAt": "2026-07-27T13:07:47Z"
+    },
+    "releaseTagRulesets": {
+      "creationRulesetId": 18869893,
+      "immutabilityRulesetId": 18869897,
+      "creationBypass": {
+        "actorId": 25964605,
+        "actorType": "User",
+        "bypassMode": "always"
+      },
+      "immutabilityBypassActorCount": 0,
+      "checkedBy": "marcmalerei",
+      "checkedAt": "2026-07-27T13:07:47Z"
+    }
+  },
+  "supportBoundary": {
+    "model": "automated-engine-evidence-only",
+    "brandedBrowserSupportClaimed": false,
+    "operatingSystemSupportClaimed": false,
+    "deviceSupportClaimed": false,
+    "assistiveTechnologySupportClaimed": false,
+    "manualBrowserDeviceEvidenceRequired": false,
+    "manualAssistiveTechnologyEvidenceRequired": false,
+    "singleOperatorRiskAccepted": true
+  },
+  "acceptedBy": "marcmalerei",
+  "acceptedAt": "2026-07-27T13:07:47Z"
+}


### PR DESCRIPTION
Cuts the immutable v1.5.0 release evidence for the graph-view release.

- Binds the release to successful Main Quality Gates run [30267995544](https://github.com/marcmalerei/gluon/actions/runs/30267995544) on `1f038c710d5f85780657db3615e353793a90e968`.
- Records exact Playwright-engine and Node-LTS compatibility evidence.
- Records protected-tag and immutable-release preflight evidence.
- `npm run release:validate -- --candidate 1.5.0` and release-artifact assembly pass locally.

After this PR merges, `v1.5.0` can be created and the release workflow can publish the 19 public packages.

Closes #263.