### PR TITLE
fix(release): recover missing graph bootstrap

### DIFF
--- a/docs-site/content/1.5.0/guides/releasing/index.md
+++ b/docs-site/content/1.5.0/guides/releasing/index.md
@@ -2,11 +2,12 @@
 
 The `1.5.0` documentation describes the prepared lockstep candidate. All 19
 official manifests are at `1.5.0`. Registry preflight on 2026-07-27 confirmed
-that every contracted package exposes `1.4.0` as `latest` and that `1.5.0` is
-absent. Immutable GitHub release `v1.4.0` remains the current finalized release
-during candidate review. The historical `v1.0.9` GitHub release remains a draft after its
-public-type verification failure. The `@gluonjs` scope remains verified in the
-package contract.
+that the 18 established package records expose `1.4.0` as `latest`, `1.5.0` is
+absent, and the new `@gluonjs/graph` record needs the reviewed bootstrap before
+trusted publication can begin. Immutable GitHub release `v1.4.0` remains the
+current finalized release during candidate review. The historical `v1.0.9`
+GitHub release remains a draft after its public-type verification failure. The
+`@gluonjs` scope remains verified in the package contract.
 
 Gluon's release group contains 19 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -410,11 +410,14 @@ new package lacks its reviewed bootstrap record, use the distinct
 `missing-bootstrap-record` recovery category. It still preserves the canonical
 package and application tree. Its allowlist additionally permits only the
 release contract's recorded supported baseline and the bootstrap publisher that
-verifies it. After that recovery is merged to `main`, rebuild and review the
-bootstrap artifacts, let the npm owner publish the missing immutable record,
-then create `v<version>-recovery.1`. That execution tag publishes the unchanged
-canonical version and finalizes the GitHub release against the canonical tag;
-neither tag nor package source is rewritten.
+verifies it. While the recovery changes await a new Quality Gates record,
+repository-state artifact checks are explicitly non-publishable; they cannot
+reuse stale evidence. After that recovery passes Quality Gates, refresh the two
+evidence files, rebuild and review the bootstrap artifacts, let the npm owner
+publish the missing immutable record, then create `v<version>-recovery.1`.
+That execution tag publishes the unchanged canonical version and finalizes the
+GitHub release against the canonical tag; neither tag nor package source is
+rewritten.
 
 The publication job verifies public repository visibility, the absence of
 environment reviewers and an uncontracted wait timer, the exact `v*` tag policy,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -161,7 +161,7 @@ that operation with source changes.
 
 ## Owner-controlled prerequisites
 
-Before preparing the `1.5.0` release commit, the repository owner must verify
+Before protected publication of the `1.5.0` release, the repository owner must verify
 all of the following outside the source tree:
 
 1. The GitHub repository is public.
@@ -235,13 +235,15 @@ package record exists. The one-time bootstrap therefore publishes a minimal
 `README.md`, and `LICENSE`: they expose no runtime, executable, types, exports,
 dependencies, or supported API. They do not use provenance, because this is an
 interactive owner publication rather than the protected release workflow.
-When a new official package joins after a supported release, the same builder
-regenerates the complete reviewed archive set from clean `main`. Existing
-packages are skipped only after the publisher verifies their current `latest`
-release, registry integrity, provenance, and bootstrap-record presence. Their
-historical bootstrap archives are immutable and are not compared with newly
-generated notices or READMEs. A package that has not reached a supported
-release still requires an exact bootstrap-archive integrity match.
+When a new official package joins a ready release candidate after a supported
+release, the release contract records that prior supported `baselineVersion`.
+The same builder regenerates the complete reviewed archive set from clean
+`main`. Existing packages are skipped only after the publisher verifies that
+baseline under `latest`, its registry integrity and provenance, and the
+bootstrap-record presence. Their historical bootstrap archives are immutable
+and are not compared with newly generated notices or READMEs. A package that
+has not reached a supported release still requires an exact bootstrap-archive
+integrity match.
 
 The first live bootstrap attempt created
 `@gluonjs/reactivity@0.0.0-bootstrap.0` with the reviewed archive integrity, but
@@ -270,15 +272,16 @@ npm run release:bootstrap:publish -- --dry-run
 ```
 
 The builder records the exact source commit, archive integrity, SHA-1, SHA-256,
-and file allowlist for all 18 packages. Review every name and archive before the
+and file allowlist for all 19 packages. Review every name and archive before the
 irreversible step. The publisher rejects `NPM_TOKEN` and `NODE_AUTH_TOKEN`, an
 artifact set that is not byte-identical to an independent rebuild, a dirty or
 non-`main` checkout, a source commit that is not the exact current
 `origin/main`, a user who is not an npm organization owner, a conflicting
 existing package record, any unexpected `latest`, and a rerun whose unpublished
 bootstrap integrity differs from the reviewed archive. For already released
-packages it instead requires the current released version under `latest`, its
-registry integrity and provenance, and the contracted bootstrap record.
+packages it instead requires the contract's recorded supported baseline under
+`latest`, its registry integrity and provenance, and the contracted bootstrap
+record.
 Registry visibility is allowed up to ten minutes after a successful publish
 before the operation stops; this wait does not weaken the exact integrity and
 dist-tag checks.
@@ -304,7 +307,7 @@ with GitHub Actions, repository owner `marcmalerei`, repository `gluon`,
 workflow filename `release.yml`, environment `npm`, and the `npm publish`
 allowed action required by this repository's workflow. npm does not validate
 these coordinates when they are saved, so review them exactly. Configure and
-verify all 18 bindings before restricting traditional token publishing; no
+verify all 19 bindings before restricting traditional token publishing; no
 long-lived publication token may be added to GitHub.
 
 ## Release-candidate commit
@@ -401,6 +404,17 @@ histories. A hard-coded allowlist excludes every package source, manifest,
 README, license, and changelog path. The recovery workflow therefore publishes
 the unchanged `1.0.7` archives and creates the GitHub release against canonical
 tag `v1.0.7`; the recovery tag is only the protected OIDC execution ref.
+
+If publication instead stops before any release archive is published because a
+new package lacks its reviewed bootstrap record, use the distinct
+`missing-bootstrap-record` recovery category. It still preserves the canonical
+package and application tree. Its allowlist additionally permits only the
+release contract's recorded supported baseline and the bootstrap publisher that
+verifies it. After that recovery is merged to `main`, rebuild and review the
+bootstrap artifacts, let the npm owner publish the missing immutable record,
+then create `v<version>-recovery.1`. That execution tag publishes the unchanged
+canonical version and finalizes the GitHub release against the canonical tag;
+neither tag nor package source is rewritten.
 
 The publication job verifies public repository visibility, the absence of
 environment reviewers and an uncontracted wait timer, the exact `v*` tag policy,

--- a/release/compatibility/1.5.0.json
+++ b/release/compatibility/1.5.0.json
@@ -2,10 +2,10 @@
   "$schema": "../compatibility-manifest.schema.json",
   "schemaVersion": 1,
   "releaseVersion": "1.5.0",
-  "sourceCommit": "1f038c710d5f85780657db3615e353793a90e968",
-  "cutAt": "2026-07-27T13:07:47Z",
+  "sourceCommit": "1e7ddbcbcb9fc3a6ed3837f9e38682048db70890",
+  "cutAt": "2026-07-27T17:29:31Z",
   "automatedQualityRun": {
-    "url": "https://github.com/marcmalerei/gluon/actions/runs/30267995544",
+    "url": "https://github.com/marcmalerei/gluon/actions/runs/30288568692",
     "conclusion": "success"
   },
   "supportBoundary": {
@@ -22,7 +22,7 @@
       "runner": "GitHub Actions ubuntu-24.04 image release 20260720.247.2",
       "mode": "headless-automated",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235190"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363593"
       ],
       "outcome": "pass"
     },
@@ -35,7 +35,7 @@
       "runner": "GitHub Actions ubuntu-24.04 image release 20260720.247.2",
       "mode": "headless-automated",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235093"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363543"
       ],
       "outcome": "pass"
     },
@@ -48,7 +48,7 @@
       "runner": "GitHub Actions ubuntu-24.04 image release 20260720.247.2",
       "mode": "headless-automated",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235121"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363614"
       ],
       "outcome": "pass"
     }
@@ -59,7 +59,7 @@
       "version": "22.12.0",
       "releaseStatus": "maintenance-lts",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235101"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363572"
       ],
       "outcome": "pass"
     },
@@ -68,7 +68,7 @@
       "version": "24.18.0",
       "releaseStatus": "active-lts",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235223"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363568"
       ],
       "outcome": "pass"
     }
@@ -77,37 +77,37 @@
     {
       "id": "client-rendering",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235190",
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235093",
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235121"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363593",
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363543",
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363614"
       ],
       "outcome": "pass"
     },
     {
       "id": "server-rendering",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363544"
       ],
       "outcome": "pass"
     },
     {
       "id": "streaming",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363544"
       ],
       "outcome": "pass"
     },
     {
       "id": "hydration",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363544"
       ],
       "outcome": "pass"
     },
     {
       "id": "static-generation",
       "evidence": [
-        "https://github.com/marcmalerei/gluon/actions/runs/30267995544/job/89983235245"
+        "https://github.com/marcmalerei/gluon/actions/runs/30288568692/job/90052363544"
       ],
       "outcome": "pass"
     }

--- a/release/evidence/1.5.0.json
+++ b/release/evidence/1.5.0.json
@@ -2,10 +2,10 @@
   "$schema": "../release-cut-evidence.schema.json",
   "schemaVersion": 1,
   "releaseVersion": "1.5.0",
-  "testedCommit": "1f038c710d5f85780657db3615e353793a90e968",
-  "cutAt": "2026-07-27T13:07:47Z",
+  "testedCommit": "1e7ddbcbcb9fc3a6ed3837f9e38682048db70890",
+  "cutAt": "2026-07-27T17:29:31Z",
   "automatedQualityRun": {
-    "url": "https://github.com/marcmalerei/gluon/actions/runs/30267995544",
+    "url": "https://github.com/marcmalerei/gluon/actions/runs/30288568692",
     "conclusion": "success"
   },
   "hostingPreflight": {
@@ -13,7 +13,7 @@
       "enabled": true,
       "enforcedByOwner": false,
       "checkedBy": "marcmalerei",
-      "checkedAt": "2026-07-27T13:07:47Z"
+      "checkedAt": "2026-07-27T17:29:31Z"
     },
     "releaseTagRulesets": {
       "creationRulesetId": 18869893,
@@ -25,7 +25,7 @@
       },
       "immutabilityBypassActorCount": 0,
       "checkedBy": "marcmalerei",
-      "checkedAt": "2026-07-27T13:07:47Z"
+      "checkedAt": "2026-07-27T17:29:31Z"
     }
   },
   "supportBoundary": {
@@ -39,5 +39,5 @@
     "singleOperatorRiskAccepted": true
   },
   "acceptedBy": "marcmalerei",
-  "acceptedAt": "2026-07-27T13:07:47Z"
+  "acceptedAt": "2026-07-27T17:29:31Z"
 }

--- a/release/recovery-manifest.schema.json
+++ b/release/recovery-manifest.schema.json
@@ -31,7 +31,12 @@
       "format": "uri",
       "pattern": "^https://github.com/marcmalerei/gluon/actions/runs/[0-9]+$"
     },
-    "failureCategory": { "const": "squash-merge-tested-commit-not-ancestor" },
+    "failureCategory": {
+      "enum": [
+        "squash-merge-tested-commit-not-ancestor",
+        "missing-bootstrap-record"
+      ]
+    },
     "recoveryTag": {
       "type": "string",
       "pattern": "^v[1-9][0-9]*\\.[0-9]+\\.[0-9]+-recovery\\.[1-9][0-9]*$"

--- a/release/recovery/1.5.0.json
+++ b/release/recovery/1.5.0.json
@@ -24,6 +24,7 @@
     "scripts/verify-release-hosting.mjs",
     "release/release-contract.json",
     "release/release-contract.schema.json",
+    "scripts/build-release-artifacts.mjs",
     "scripts/publish-npm-bootstrap.mjs"
   ]
 }

--- a/release/recovery/1.5.0.json
+++ b/release/recovery/1.5.0.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../recovery-manifest.schema.json",
+  "schemaVersion": 1,
+  "releaseVersion": "1.5.0",
+  "canonicalTag": "v1.5.0",
+  "canonicalTagCommit": "db24227a3897510ccb3475becd52d2eab6a94f54",
+  "canonicalTagTree": "86ce5278fe1c7991a0b133c1ee55a2bdce31c900",
+  "failedTestedCommit": "1f038c710d5f85780657db3615e353793a90e968",
+  "failedEvidenceCommit": "db24227a3897510ccb3475becd52d2eab6a94f54",
+  "failedRunUrl": "https://github.com/marcmalerei/gluon/actions/runs/30269940809",
+  "failureCategory": "missing-bootstrap-record",
+  "recoveryTag": "v1.5.0-recovery.1",
+  "allowedCanonicalDeltaPaths": [
+    ".github/workflows/release.yml",
+    "docs-site/content/1.5.0/guides/releasing/index.md",
+    "docs/releasing.md",
+    "release/compatibility/1.5.0.json",
+    "release/evidence/1.5.0.json",
+    "release/recovery-manifest.schema.json",
+    "release/recovery/1.5.0.json",
+    "scripts/publish-release.mjs",
+    "scripts/validate-release-contract.mjs",
+    "scripts/validate-release-recovery.mjs",
+    "scripts/verify-release-hosting.mjs",
+    "release/release-contract.json",
+    "release/release-contract.schema.json",
+    "scripts/publish-npm-bootstrap.mjs"
+  ]
+}

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -10,6 +10,7 @@
   "compatibilityManifestPath": "release/compatibility/{version}.json",
   "bootstrap": {
     "version": "0.0.0-bootstrap.1",
+    "baselineVersion": "1.4.0",
     "artifactDirectory": ".tmp/npm-bootstrap",
     "distTag": "gluon-bootstrap",
     "access": "public",

--- a/release/release-contract.schema.json
+++ b/release/release-contract.schema.json
@@ -36,9 +36,10 @@
     "bootstrap": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["version", "artifactDirectory", "distTag", "access", "identity", "latestPolicy", "supersededRecords", "packageFiles"],
+      "required": ["version", "baselineVersion", "artifactDirectory", "distTag", "access", "identity", "latestPolicy", "supersededRecords", "packageFiles"],
       "properties": {
         "version": { "const": "0.0.0-bootstrap.1" },
+        "baselineVersion": { "type": "string", "pattern": "^[1-9][0-9]*\\.[0-9]+\\.[0-9]+$" },
         "artifactDirectory": { "const": ".tmp/npm-bootstrap" },
         "distTag": { "const": "gluon-bootstrap" },
         "access": { "const": "public" },

--- a/scripts/build-release-artifacts.mjs
+++ b/scripts/build-release-artifacts.mjs
@@ -36,11 +36,13 @@ if (releaseCutEvidenceExists !== compatibilityManifestExists) {
 const evidencePendingCandidate = checkState
   && packageContract.registry.publicationState === 'ready'
   && !releaseCutEvidenceExists;
+const recoveryEvidencePending = checkState && await isRecoveryEvidencePending();
 const postReleaseDevelopment = checkState
   && packageContract.registry.publicationState === 'released';
 const nonPublishableBuild = process.argv.includes('--allow-blocked')
   || (checkState && packageContract.registry.publicationState === 'blocked')
   || evidencePendingCandidate
+  || recoveryEvidencePending
   || postReleaseDevelopment;
 const allowedArguments = new Set(['--version', version, '--output', option('--output'), '--allow-blocked', '--check-state']);
 
@@ -51,7 +53,7 @@ if (process.argv.includes('--allow-blocked') && checkState) throw new Error('Cho
 if (!/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(version)) {
   throw new Error(`Invalid stable release version ${version}.`);
 }
-if (evidencePendingCandidate || postReleaseDevelopment) {
+if (evidencePendingCandidate || recoveryEvidencePending || postReleaseDevelopment) {
   if (version !== rootManifest.version) throw new Error('Repository-state artifact checks require the current package version.');
   await execFile(process.execPath, ['scripts/validate-release-contract.mjs'], { cwd: root });
 } else if (nonPublishableBuild) {
@@ -212,6 +214,21 @@ console.log(`release artifacts built: ${packageResults.length} packages with ver
 function option(name) {
   const index = process.argv.indexOf(name);
   return index < 0 ? undefined : process.argv[index + 1];
+}
+
+async function isRecoveryEvidencePending() {
+  if (packageContract.registry.publicationState !== 'ready') return false;
+  const recovery = await readOptionalJson(`release/recovery/${version}.json`);
+  if (recovery?.failureCategory !== 'missing-bootstrap-record' || !releaseCutEvidenceExists) return false;
+  const evidence = await readJson(releaseCutEvidencePath);
+  if (!/^[a-f0-9]{40}$/.test(evidence.testedCommit ?? '')) return false;
+  const permittedEvidenceChanges = new Set([releaseCutEvidencePath, compatibilityManifestPath]);
+  const { stdout } = await execFile('git', ['diff', '--name-only', evidence.testedCommit, 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  const changed = stdout.trim().split('\n').filter(Boolean);
+  return changed.some((path) => !permittedEvidenceChanges.has(path));
 }
 
 async function pack(directory, destination) {
@@ -495,6 +512,15 @@ function sortObject(value) {
 
 async function readJson(path) {
   return JSON.parse(await readFile(resolve(root, path), 'utf8'));
+}
+
+async function readOptionalJson(path) {
+  try {
+    return await readJson(path);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return null;
+    throw error;
+  }
 }
 
 async function fileExists(path) {

--- a/scripts/publish-npm-bootstrap.mjs
+++ b/scripts/publish-npm-bootstrap.mjs
@@ -11,7 +11,8 @@ const releaseContract = await readJson('release/release-contract.json');
 const packageContract = await readJson('package-contract.json');
 const rootManifest = await readJson('package.json');
 const bootstrap = releaseContract.bootstrap;
-const releasedVersion = rootManifest.version;
+const candidateVersion = rootManifest.version;
+const baselineVersion = bootstrap.baselineVersion;
 const directory = resolve(root, option('--directory') ?? bootstrap.artifactDirectory);
 const dryRun = process.argv.includes('--dry-run');
 const confirmed = process.argv.includes('--confirm-owner-controlled-bootstrap');
@@ -37,10 +38,7 @@ validateEvidence(evidence);
 await verifyChecksums();
 await reproduceArtifacts(evidence);
 
-if (packageContract.registry.publicationState !== 'released'
-  || releaseContract.targetVersion !== releasedVersion) {
-  throw new Error('Incremental bootstrap requires the current clean main release to remain recorded as released.');
-}
+validateBootstrapBaseline();
 if (!dryRun) {
   await requireCleanMain(evidence.sourceCommit);
   await requireNpmOwner();
@@ -50,7 +48,7 @@ const registryState = new Map();
 for (const entry of evidence.packages) {
   const packument = await registryPackument(entry.name);
   if (packument?.versions?.[bootstrap.version]) {
-    const released = packument.versions?.[releasedVersion] !== undefined;
+    const released = packument.versions?.[baselineVersion] !== undefined;
     if (released) verifyReleasedPackageRecord(entry.name, packument);
     else verifyBootstrapMetadata(entry, packument);
     registryState.set(entry.name, released ? 'released' : 'bootstrap');
@@ -62,7 +60,7 @@ for (const entry of evidence.packages) {
 
 for (const entry of evidence.packages) {
   if (registryState.get(entry.name) === 'released') {
-    console.log(`verified existing released ${entry.name}@${releasedVersion} and bootstrap record; regenerated bootstrap archive skipped`);
+    console.log(`verified existing released ${entry.name}@${baselineVersion} and bootstrap record; regenerated bootstrap archive skipped`);
     continue;
   }
   if (registryState.get(entry.name) === 'bootstrap') {
@@ -95,6 +93,23 @@ function validateEvidence(evidenceValue) {
     || JSON.stringify(actualNames) !== JSON.stringify(expectedNames)) {
     throw new Error('Bootstrap evidence does not match the reviewed release and package contracts.');
   }
+}
+
+function validateBootstrapBaseline() {
+  if (!/^[1-9][0-9]*\.[0-9]+\.[0-9]+$/.test(baselineVersion ?? '')) {
+    throw new Error('Incremental bootstrap requires a stable recorded baselineVersion.');
+  }
+  if (releaseContract.targetVersion !== candidateVersion) {
+    throw new Error('Incremental bootstrap requires the release contract target to match the clean main candidate version.');
+  }
+  if (packageContract.registry.publicationState === 'released') {
+    if (baselineVersion !== candidateVersion) {
+      throw new Error('A released main train must use itself as the incremental bootstrap baseline.');
+    }
+    return;
+  }
+  if (packageContract.registry.publicationState === 'ready' && baselineVersion !== candidateVersion) return;
+  throw new Error('Incremental bootstrap requires either a released main train or a ready candidate with an earlier recorded supported baseline.');
 }
 
 async function requireCleanMain(sourceCommit) {
@@ -174,15 +189,15 @@ function verifyBootstrapMetadata(entry, packument) {
 }
 
 function verifyReleasedPackageRecord(name, packument) {
-  const metadata = packument.versions?.[releasedVersion];
-  if (metadata?.name !== name || metadata.version !== releasedVersion) {
-    throw new Error(`${name}@${releasedVersion} does not match the current released package record.`);
+  const metadata = packument.versions?.[baselineVersion];
+  if (metadata?.name !== name || metadata.version !== baselineVersion) {
+    throw new Error(`${name}@${baselineVersion} does not match the recorded supported baseline package record.`);
   }
-  if (packument['dist-tags']?.latest !== releasedVersion) {
-    throw new Error(`${name} latest is not the current released version ${releasedVersion}.`);
+  if (packument['dist-tags']?.latest !== baselineVersion) {
+    throw new Error(`${name} latest is not the recorded supported baseline version ${baselineVersion}.`);
   }
   if (!metadata.dist?.integrity || !metadata.dist?.attestations) {
-    throw new Error(`${name}@${releasedVersion} is missing registry integrity or provenance attestations.`);
+    throw new Error(`${name}@${baselineVersion} is missing registry integrity or provenance attestations.`);
   }
 }
 

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -208,10 +208,12 @@ function validateReleaseContract() {
   }
   if (!prereleaseVersion(releaseContract.bootstrap?.version)
     || releaseContract.bootstrap.version === releaseContract.targetVersion
+    || !stableVersion(releaseContract.bootstrap.baselineVersion)
+    || compareStableVersions(releaseContract.bootstrap.baselineVersion, releaseContract.targetVersion) >= 0
     || releaseContract.bootstrap.distTag === releaseContract.publication.distTag
     || releaseContract.bootstrap.latestPolicy !== 'absent-or-reviewed-bootstrap-until-first-supported-release'
     || releaseContract.bootstrap.identity !== 'owner-interactive-2fa') {
-    throw new Error('npm bootstrap must use a distinct prerelease, a non-latest reviewed dist-tag, the temporary bootstrap latest policy, and owner-controlled interactive 2FA.');
+    throw new Error('npm bootstrap must use a distinct prerelease, an earlier stable baseline, a non-latest reviewed dist-tag, the temporary bootstrap latest policy, and owner-controlled interactive 2FA.');
   }
   if (!releaseContract.bootstrap.supersededRecords.every((entry) => packageContract.packages.some(({ name }) => name === entry.name)
     && entry.version !== releaseContract.bootstrap.version
@@ -383,11 +385,12 @@ function validateReleasedState() {
   let releaseRef = tag;
   let releaseCommit = tagCommit;
   if (recovery) {
+    const recoveryPaths = expectedRecoveryPaths(version, recovery.failureCategory);
     if (recovery.releaseVersion !== version
       || recovery.canonicalTag !== tag
       || recovery.canonicalTagCommit !== tagCommit
       || recovery.recoveryTag !== `${tag}-recovery.1`
-      || JSON.stringify(recovery.allowedCanonicalDeltaPaths) !== JSON.stringify(expectedRecoveryPaths(version))) {
+      || JSON.stringify(recovery.allowedCanonicalDeltaPaths) !== JSON.stringify(recoveryPaths)) {
       throw new Error(`${recoveryPath} does not match the exact ${version} recovery boundary.`);
     }
     releaseRef = recovery.recoveryTag;
@@ -401,7 +404,7 @@ function validateReleasedState() {
       cwd: root,
       encoding: 'utf8',
     }).trim().split('\n').filter(Boolean);
-    const allowedRecoveryPaths = new Set(expectedRecoveryPaths(version));
+    const allowedRecoveryPaths = new Set(recoveryPaths);
     if (recoveryDelta.some((changed) => !allowedRecoveryPaths.has(changed))) {
       throw new Error(`${releaseRef} changes package or application inputs outside the exact recovery allowlist.`);
     }
@@ -680,6 +683,15 @@ function stableVersion(value) {
   return /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(value);
 }
 
+function compareStableVersions(left, right) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return leftParts[index] - rightParts[index];
+  }
+  return 0;
+}
+
 function prereleaseVersion(value) {
   return /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*$/.test(value ?? '');
 }
@@ -708,8 +720,8 @@ function readOptionalJsonAtRef(ref, path) {
   }
 }
 
-function expectedRecoveryPaths(version) {
-  return [
+function expectedRecoveryPaths(version, failureCategory = 'squash-merge-tested-commit-not-ancestor') {
+  const paths = [
     '.github/workflows/release.yml',
     `docs-site/content/${version}/guides/releasing/index.md`,
     'docs/releasing.md',
@@ -722,4 +734,12 @@ function expectedRecoveryPaths(version) {
     'scripts/validate-release-recovery.mjs',
     'scripts/verify-release-hosting.mjs',
   ];
+  if (failureCategory === 'missing-bootstrap-record') {
+    paths.push(
+      'release/release-contract.json',
+      'release/release-contract.schema.json',
+      'scripts/publish-npm-bootstrap.mjs',
+    );
+  }
+  return paths;
 }

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -738,6 +738,7 @@ function expectedRecoveryPaths(version, failureCategory = 'squash-merge-tested-c
     paths.push(
       'release/release-contract.json',
       'release/release-contract.schema.json',
+      'scripts/build-release-artifacts.mjs',
       'scripts/publish-npm-bootstrap.mjs',
     );
   }

--- a/scripts/validate-release-recovery.mjs
+++ b/scripts/validate-release-recovery.mjs
@@ -47,6 +47,13 @@ const expectedPaths = [
   'scripts/validate-release-recovery.mjs',
   'scripts/verify-release-hosting.mjs',
 ];
+if (manifest.failureCategory === 'missing-bootstrap-record') {
+  expectedPaths.push(
+    'release/release-contract.json',
+    'release/release-contract.schema.json',
+    'scripts/publish-npm-bootstrap.mjs',
+  );
+}
 if (manifest.releaseVersion !== version
   || manifest.canonicalTag !== canonicalTag
   || manifest.recoveryTag !== `${canonicalTag}-recovery.1`

--- a/scripts/validate-release-recovery.mjs
+++ b/scripts/validate-release-recovery.mjs
@@ -51,6 +51,7 @@ if (manifest.failureCategory === 'missing-bootstrap-record') {
   expectedPaths.push(
     'release/release-contract.json',
     'release/release-contract.schema.json',
+    'scripts/build-release-artifacts.mjs',
     'scripts/publish-npm-bootstrap.mjs',
   );
 }


### PR DESCRIPTION
## Summary

Recovers the immutable `v1.5.0` release after Trusted Publishing rejected the new `@gluonjs/graph` package because no reviewed bootstrap record existed.

- records `1.4.0` as the required prior supported baseline for incremental bootstrap
- verifies the 18 established package records at that baseline, including provenance, and leaves Graph as the only publishable bootstrap record
- adds a narrowly allowlisted `missing-bootstrap-record` recovery category for `v1.5.0-recovery.1`
- documents the recovery procedure and corrects the v1.5 registry statement

No package or application source changes are included; the recovery manifest permits only release-process paths.

## Validation

- `npm run check:release-contract`
- `npm run release:bootstrap:artifacts`
- `npm run release:bootstrap:publish -- --dry-run`
  - verified 18 existing `1.4.0` records and marked only `@gluonjs/graph@0.0.0-bootstrap.1` for publication

## Release sequence

After Quality Gates pass on this exact branch commit, this PR receives a final evidence-only commit (`release/evidence/1.5.0.json` and `release/compatibility/1.5.0.json`) before a merge commit preserves the tested ancestry. Then the owner-controlled Graph bootstrap, protected `v1.5.0-recovery.1` tag, and release workflow can run.

Closes #267; release completion closes #263.