### PR TITLE
Stabilize TransitionGroup leaving snapshot test

### DIFF
--- a/tests/builtins.spec.ts
+++ b/tests/builtins.spec.ts
@@ -501,8 +501,10 @@ describe('Transition and TransitionGroup', () => {
     render(view(['a', 'b']), root);
     render(view(['b', 'c']), root);
     expect(root.textContent).toBe('bc');
-    await new Promise((resolve) => setTimeout(resolve, 80));
-    expect(document.body.textContent).not.toContain('a');
+    await vi.waitFor(
+      () => expect(document.body.querySelector('[data-item="a"]')).toBeNull(),
+      { timeout: 500 },
+    );
     unmount(root);
     root.remove();
   });


### PR DESCRIPTION
Closes #274.

Replaces the fixed delay and broad body-text assertion with a bounded wait for the leaving keyed element to be removed.

Checks:
- focused test repeated three times
- CI=1 NODE_ENV= PLAYWRIGHT_BROWSERS_PATH=0 npx vitest run --coverage --no-file-parallelism (48 files, 339 tests, branch coverage 90.07%)