### PR TITLE
Evaluate: [Bug]: Property does not reflect its value

### DIFF
--- a/examples/component-library/README.md
+++ b/examples/component-library/README.md
@@ -8,8 +8,9 @@ The library uses only `@gluonjs/core` and `@gluonjs/quarks` public entry points:
 Custom Element. Its ShadowRoot owns a constructable stylesheet, native buttons
 remain keyboard-operable, and its typed `change` event reports the exact new
 quantity. The picker treats its public `value` property as the current quantity:
-button interactions update that property, and its `reflect: true` declaration
-keeps the `value` attribute synchronized for HTML and DOM consumers.
+rendering reads that property directly, button interactions update it, and its
+`reflect: true` declaration keeps the `value` attribute synchronized for HTML
+and DOM consumers without a second local quantity state.
 
 Run `npm run build:component-library` to build the consumer. It imports only
 the serializable manifest initially, requests the badge and picker through

--- a/examples/component-library/library/src/product-picker.ts
+++ b/examples/component-library/library/src/product-picker.ts
@@ -21,17 +21,15 @@ export const ProductPicker: CustomElementConstructor & { new(): ProductPickerEle
   events: { change: elementEvent<ProductPickerChange>() },
   styles: productPickerStyles,
   setup(context) {
-    const quantity = context.state('quantity', () => context.props.value);
-    context.watch(() => context.props.value, (value) => { quantity.value = value ?? 1; });
     const change = (next: number): void => {
       const value = Math.max(1, next);
       context.host.value = value;
       context.emit('change', { quantity: value });
     };
     return { render: () => html`
-      <button type="button" aria-label="Decrease quantity" @click=${() => change(quantity.value - 1)}>−</button>
-      <output aria-live="polite">${quantity.value}</output>
-      <button type="button" aria-label="Increase quantity" @click=${() => change(quantity.value + 1)}>+</button>
+      <button type="button" aria-label="Decrease quantity" @click=${() => change(context.props.value - 1)}>−</button>
+      <output aria-live="polite">${context.props.value}</output>
+      <button type="button" aria-label="Increase quantity" @click=${() => change(context.props.value + 1)}>+</button>
     ` };
   },
 }) as CustomElementConstructor & { new(): ProductPickerElement; };

--- a/tests/component-library-example.spec.ts
+++ b/tests/component-library-example.spec.ts
@@ -21,6 +21,9 @@ describe('component-library consumer example', () => {
     expect(document.adoptedStyleSheets).toHaveLength(documentSheetCount);
     expect(customElements.get('example-product-picker')).toBe(ProductPicker);
     expect((await import('@gluonjs/example-component-library')).ProductPicker).toBe(ProductPicker);
+    expect(picker.value).toBe(2);
+    expect(picker.getAttribute('value')).toBe('2');
+    expect(picker.shadowRoot?.querySelector('output')?.textContent).toBe('2');
     const event = new Promise<CustomEvent<{ quantity: number }>>((resolve) => picker.addEventListener('change', resolve as EventListener, { once: true }));
     (picker.shadowRoot?.querySelector('[aria-label="Increase quantity"]') as HTMLButtonElement).click();
     expect((await event).detail).toEqual({ quantity: 3 });
@@ -28,6 +31,15 @@ describe('component-library consumer example', () => {
     expect(picker.getAttribute('value')).toBe('3');
     await picker.updateComplete;
     expect(picker.shadowRoot?.querySelector('output')?.textContent).toBe('3');
+
+    const reboundEvent = new Promise<CustomEvent<{ quantity: number }>>((resolve) => picker.addEventListener('change', resolve as EventListener, { once: true }));
+    picker.value = 7;
+    (picker.shadowRoot?.querySelector('[aria-label="Decrease quantity"]') as HTMLButtonElement).click();
+    expect((await reboundEvent).detail).toEqual({ quantity: 6 });
+    expect(picker.value).toBe(6);
+    expect(picker.getAttribute('value')).toBe('6');
+    await picker.updateComplete;
+    expect(picker.shadowRoot?.querySelector('output')?.textContent).toBe('6');
 
     app.unmount();
     expect(host.querySelector('example-product-picker')).toBeNull();


### PR DESCRIPTION
Improve the managed product through one small, well-scoped, independently verified change.
Research signal: Open issue: [Bug]: Property does not reflect its value
Source: https://github.com/marcmalerei/gluon/issues/235
Observed summary: ### Playground reproduction URL https://marcmalerei.github.io/gluon/playground/#p=eyJhcHAiOiJpbXBvcnQgeyBkZWZpbmVHbHVvbkVsZW1lbnQsIGVsZW1lbnRFdmVudCwgaHRtbCB9IGZyb20gJ0BnbHVvbmpzL2NvcmUnO1xuXG5pZiAoIWN1c3RvbUVsZW1lbnRzLmdldCgnZ2x1b24tcGxheWdyb3VuZC1jb3VudGVyJykpIHtcbiAgZGVmaW5lR2x1b25FbGVtZW50KHtcbiAgICB0YWdOYW1lOiAnZ2x1b24tcGxheWdyb3VuZC1jb3VudGVyJyxcbiAgICBwcm9wZXJ0aWVzOiB7IHZhbHVlOiB7IHR5cGU6IE51bWJlciwgZGVmYXVsdDogMCwgcmVmbGVjdDogdHJ1ZSB9IH0sXG4gICAgZXZlbnRzOiB7IGluY3JlbWVudDogZWxlbWVudEV2ZW
Use the product charter as the boundary; do not change permissions, secrets, or communicate outside GitHub.

Closes #235

<!-- mission-control:idempotency=repository-delivery:a5488385-4de2-4739-b4a4-155264baea4c:pull-request -->