### PR TITLE
ci: bound Quality Gates runtimes

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   repository:
     runs-on: ubuntu-latest
+    # A successful full check normally completes in roughly 10–12 minutes.
+    # Keep enough headroom for a cold hosted runner while making a stuck runner visible.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v7
         with:
@@ -25,11 +28,15 @@ jobs:
           node-version: 22.12.0
           cache: npm
       - run: npm ci --ignore-scripts --legacy-peer-deps
+        timeout-minutes: 10
       - run: npx playwright install --with-deps chromium
+        timeout-minutes: 12
       - run: npm run check
+        timeout-minutes: 25
 
   browser-engines:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -41,8 +48,11 @@ jobs:
           node-version: 22.12.0
           cache: npm
       - run: npm ci --ignore-scripts --legacy-peer-deps
+        timeout-minutes: 10
       - run: npx playwright install --with-deps ${{ matrix.browser }}
+        timeout-minutes: 12
       - run: npm run test:browser-matrix
+        timeout-minutes: 15
         env:
           GLUON_BROWSER: ${{ matrix.browser }}
       - name: Retain browser screenshot differences
@@ -57,6 +67,7 @@ jobs:
 
   node-runtime:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -68,11 +79,15 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci --ignore-scripts --legacy-peer-deps
+        timeout-minutes: 10
       - run: npm run build
+        timeout-minutes: 10
       - run: npm run test:ssr
+        timeout-minutes: 10
 
   budgets:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -80,13 +95,19 @@ jobs:
           node-version: 22.12.0
           cache: npm
       - run: npm ci --ignore-scripts --legacy-peer-deps
+        timeout-minutes: 10
       - run: npm run build:core
+        timeout-minutes: 5
       - run: npm run build:compiler
+        timeout-minutes: 5
       - run: npm run build:vite
+        timeout-minutes: 5
       - run: npm run check:budgets
+        timeout-minutes: 5
 
   performance-evidence:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -94,14 +115,23 @@ jobs:
           node-version: 22.12.0
           cache: npm
       - run: npm ci --ignore-scripts --legacy-peer-deps
+        timeout-minutes: 10
       - run: npx playwright install --with-deps chromium firefox webkit
+        timeout-minutes: 20
       - run: npm run benchmark:bundle
+        timeout-minutes: 10
       - run: npm run check:component-library-loader-build
+        timeout-minutes: 10
       - run: npm run check:storybook:component-library
+        timeout-minutes: 15
       - run: npm run benchmark:rendering -- --samples=10 --warmup=4 --output=.tmp/quality-evidence/rendering.json
+        timeout-minutes: 15
       - run: npm run benchmark:components -- --samples=10 --warmup=4 --output=.tmp/quality-evidence/components.json
+        timeout-minutes: 15
       - run: npm run benchmark:runtime -- --samples=10 --warmup=3 --output=.tmp/quality-evidence/runtime-scorecard.json
+        timeout-minutes: 20
       - run: npm run check:shop-performance
+        timeout-minutes: 10
       - name: Retain quality evidence
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -20,6 +20,24 @@ security, accessibility, retention, performance-evidence, and shop-budget jobs.
 dispatch. It uses the current Node 24-based `actions/checkout@v7` and
 `actions/setup-node@v6` action majors:
 
+Every job has a bounded runtime so a stalled hosted runner is reported as a
+failed check instead of indefinitely blocking a pull request. The job limits
+include cold-runner headroom and are deliberately larger than their individually
+bounded expensive steps:
+
+| Job                    |                   Job limit | Individually bounded expensive work                                                   |
+| ---------------------- | --------------------------: | ------------------------------------------------------------------------------------- |
+| `repository`           |                  35 minutes | install 10, Chromium install 12, full check 25 minutes                                |
+| `browser-engines`      |       30 minutes per engine | install 10, browser install 12, browser matrix 15 minutes                             |
+| `node-runtime`         | 25 minutes per Node version | install 10, build 10, SSR suite 10 minutes                                            |
+| `budgets`              |                  20 minutes | install 10; each build/budget command 5 minutes                                       |
+| `performance-evidence` |                  45 minutes | install 10, all-browser install 20, individual benchmark/check commands 10–20 minutes |
+
+Browser screenshot differences remain uploadable after a failed or timed-out
+browser-test step, and performance evidence remains retained whenever its job
+has not been cancelled. GitHub Actions keeps the failed step logs with the run,
+including an explicit step-timeout message.
+
 - the full `npm run check` gate directly after a clean install on Node 22.12
   with Chromium, so source typechecks cannot depend on leftover or prebuilt
   workspace package exports; the check then builds those public exports before


### PR DESCRIPTION
## Summary

- add explicit job and expensive-step timeout limits to every Quality Gates lane
- retain screenshot and performance diagnostics after timed-out steps when the job can continue
- document the selected limits and their cold-runner headroom

## Why

A transient hosted-runner or browser-download stall could leave a pull request blocked indefinitely without producing an actionable failure.

## Validation

- `git diff --check`
- `npm exec -- prettier --check .github/workflows/quality-gates.yml docs/quality-gates.md`
- workflow YAML parse plus assertions that every job and `run` step has an integer timeout

Closes #279