### PR TITLE
fix(vite): ship client source-map targets

### DIFF
--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ship the HMR client source referenced by the published JavaScript and
+  declaration source maps.
+
 ## [1.6.0] - 2026-07-28
 
 ### Changed

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -65,6 +65,10 @@ inject the virtual HMR client, `import.meta.hot` handlers, stable proxies, or
 module identity strings. The plugin defines `__GLUON_DEV__` as `false`, which
 allows Rollup to remove Core render-debug branches from application bundles.
 
+The packaged HMR client maps reference `src/client.ts`. That exact source file
+ships with `@gluonjs/vite`, so Vite and browser-test diagnostics can resolve
+`dist/client.js` and its declarations without a missing-source warning.
+
 Set `universal: true` for a production client build. The plugin emits
 `gluon-assets.json` with the hashed entry chunk, modulepreload imports, CSS, and
 referenced assets consumed by `@gluonjs/ssr` and static generation. Pass

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "dist",
+    "src/client.ts",
     "README.md",
     "LICENSE",
     "CHANGELOG.md"

--- a/scripts/build-release-artifacts.mjs
+++ b/scripts/build-release-artifacts.mjs
@@ -1,7 +1,7 @@
 import { execFile as execFileCallback } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { access, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
-import { basename, resolve } from 'node:path';
+import { basename, posix, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import process from 'node:process';
 import Ajv from 'ajv';
@@ -96,6 +96,7 @@ for (const entry of packageContract.packages) {
   if (firstDigest.digest !== secondDigest.digest || JSON.stringify(firstDigest.files) !== JSON.stringify(secondDigest.files)) {
     throw new Error(`${entry.name} canonical package contents are not reproducible.`);
   }
+  await verifyViteClientSourceMaps(resolve(packageOutput, first.filename), first.files, entry.name);
 
   packageResults.push({
     name: entry.name,
@@ -250,6 +251,29 @@ async function canonicalPackageDigest(archive, files) {
   }
   const digest = sha256(Buffer.from(entries.map((entry) => `${entry.path}\0${entry.sha256}\n`).join('')));
   return { digest, files: entries };
+}
+
+async function verifyViteClientSourceMaps(archive, files, packageName) {
+  if (packageName !== '@gluonjs/vite') return;
+  const included = new Set(files.map(({ path }) => path));
+  for (const mapPath of ['dist/client.js.map', 'dist/client.d.ts.map']) {
+    if (!included.has(mapPath)) throw new Error(`${packageName} package is missing ${mapPath}.`);
+    const { stdout } = await execFile('tar', ['-xOf', archive, `package/${mapPath}`], {
+      cwd: root,
+      encoding: null,
+    });
+    const map = JSON.parse(stdout.toString('utf8'));
+    if (!Array.isArray(map.sources) || map.sources.length === 0) {
+      throw new Error(`${packageName} ${mapPath} must declare at least one source.`);
+    }
+    for (const source of map.sources) {
+      if (typeof source !== 'string') throw new Error(`${packageName} ${mapPath} has an invalid source entry.`);
+      const sourcePath = posix.normalize(posix.join(posix.dirname(mapPath), map.sourceRoot ?? '', source));
+      if (sourcePath === '..' || sourcePath.startsWith('../') || !included.has(sourcePath)) {
+        throw new Error(`${packageName} ${mapPath} references unpublished source ${source}.`);
+      }
+    }
+  }
 }
 
 async function verifyPackedPackageTypes(packages) {


### PR DESCRIPTION
## Summary

- ship `src/client.ts` alongside the published Vite client maps
- check both client JavaScript and declaration source maps against the packed archive during release-artifact creation
- document the debuggable package contract and changelog entry

## Why

The published client maps referenced `../src/client.ts`, but the npm archive contained only `dist`, producing missing-source warnings in Vite and Vitest Browser diagnostics.

## Validation

- `git diff --check`
- `node --check scripts/build-release-artifacts.mjs`
- `npm run check:release-contract`
- packed `@gluonjs/vite` archive check confirming both client maps resolve to shipped files

Closes #276