### PR TITLE
fix(core): require a shared Reactivity runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Made `@gluonjs/reactivity` an exact peer of `@gluonjs/core` and verify that
+  packed consumers resolve the renderer and application state to one runtime.
+
 ## [1.6.0] - 2026-07-28
 
 ### Added

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -199,6 +199,11 @@ It typechecks every contracted package export with `skipLibCheck: false` before
 publication can start. This catches declaration-bundle defects in the exact
 package archives rather than relying only on source-tree typechecks.
 
+`npm run check:reactivity-singleton` additionally packs Core and Reactivity,
+installs them as a consumer's direct dependencies, rejects a nested Core copy,
+and requires both package-resolution paths to identify the same Reactivity
+module. It preserves the renderer/application runtime singleton boundary.
+
 ## Report-only Vue analyzer gate
 
 The preceding `npm run check:project-analysis` gate builds the public language

--- a/docs/reactive-elements.md
+++ b/docs/reactive-elements.md
@@ -2,9 +2,26 @@
 
 `GluonElement` integrates `@gluonjs/core` rendering with the shared
 `@gluonjs/reactivity` dependency graph, scheduler, and effect scopes. The Core
-package declares Reactivity as a runtime dependency and leaves that import
-external in its production ESM build so an application uses one reactivity
-identity.
+package declares Reactivity as an exact, required peer and leaves that import
+external in its production ESM build. An application that imports Reactivity
+therefore resolves the same package identity as the Core renderer.
+
+## One Reactivity runtime
+
+Install the lockstep packages together and import application state from the
+public Reactivity entry point:
+
+```sh
+npm install @gluonjs/core@1.6.0 @gluonjs/reactivity@1.6.0
+npm ls @gluonjs/reactivity
+```
+
+The second command should report one deduped `@gluonjs/reactivity@1.6.0` path.
+The repository's packed-consumer gate installs Core and direct application
+Reactivity from separate archives, rejects a nested Core copy, and verifies
+that Node resolves both imports to the same module file. This is a package
+topology contract; package-manager overrides that intentionally isolate peer
+dependencies are outside that verified boundary.
 
 ## Render dependencies and scheduling
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "@gluonjs/reactivity": "1.6.0"
-      },
       "bin": {
         "gluon-skill": "agent-skill/install.mjs"
       },
@@ -57,6 +54,9 @@
       },
       "engines": {
         "node": "^22.12.0 || ^24.0.0"
+      },
+      "peerDependencies": {
+        "@gluonjs/reactivity": "1.6.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "access": "public",
     "provenance": true
   },
-  "dependencies": {
+  "peerDependencies": {
     "@gluonjs/reactivity": "1.6.0"
   },
   "scripts": {
@@ -188,6 +188,7 @@
     "check:eleventy-clean-install": "npm run build:ssr && node scripts/validate-eleventy-clean-install.mjs",
     "check:example-previews": "npm run build:shop && npm run build:playground && npm run build:virtualizer-example && npm run build:signals-example && npm run build:component-library && node scripts/validate-example-previews.mjs",
     "check:packages": "node scripts/validate-package-contract.mjs",
+    "check:reactivity-singleton": "node scripts/validate-reactivity-singleton.mjs",
     "check:create-gluon-fixtures": "node scripts/validate-create-gluon-fixtures.mjs",
     "check:vue-analyzer-fixtures": "npm run build:vue-analyzer && node scripts/generate-vue-analyzer-fixtures.mjs --check",
     "check:vue-analyzer-clean-install": "npm run build:vue-analyzer && node scripts/validate-vue-analyzer-clean-install.mjs",
@@ -219,7 +220,7 @@
     "check:release-bootstrap": "node scripts/build-npm-bootstrap-artifacts.mjs --check",
     "check:release-contract": "node scripts/validate-release-contract.mjs",
     "check:release-artifacts": "node scripts/build-release-artifacts.mjs --check-state",
-    "check": "npm run typecheck && npm run build && npm run check:shop-boundaries && npm run check:shop-static && npm run check:eleventy-clean-install && npm run check:example-previews && npm run check:component-library-clean-install && npm run check:storybook:component-library && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run check:quality-budgets && npm run check:benchmark-builds && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:vscode-client && npm run check:language-server-cli && npm run check:project-analysis && npm run check:project-analysis-clean-install && npm run check:diagnostics && npm run check:template-composition && npm run check:stateful-control-comparison && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-bootstrap && npm run check:release-contract && npm run check:release-artifacts"
+    "check": "npm run typecheck && npm run build && npm run check:shop-boundaries && npm run check:shop-static && npm run check:eleventy-clean-install && npm run check:example-previews && npm run check:component-library-clean-install && npm run check:storybook:component-library && npm run test:coverage && npm run test:playground && npm run test:property-fuzz && npm run check:quality-budgets && npm run check:benchmark-builds && npm run check:security && npm run check:ui-contract && npm run typecheck:core-api && npm run typecheck:ui-api && npm run typecheck:reactivity-api && npm run typecheck:router-api && npm run typecheck:store-api && npm run typecheck:test-utils-api && npm run typecheck:tooling-api && npm run typecheck:ssr-api && npm run typecheck:devtools-api-contract && npm run typecheck:language-server-api && npm run typecheck:vue-analyzer-api && npm run typecheck:create-gluon-api && npm run check:router-lazy && npm run check:packages && npm run check:reactivity-singleton && npm run check:vscode-client && npm run check:language-server-cli && npm run check:project-analysis && npm run check:project-analysis-clean-install && npm run check:diagnostics && npm run check:template-composition && npm run check:stateful-control-comparison && npm run check:create-gluon-fixtures && npm run check:vue-analyzer-fixtures && npm run check:vue-analyzer-clean-install && npm run check:vue-codemod-decision && npm run check:dx-scorecard && npm run check:docs && npm run check:release-bootstrap && npm run check:release-contract && npm run check:release-artifacts"
   },
   "devDependencies": {
     "@11ty/eleventy": "3.1.6",

--- a/scripts/validate-reactivity-singleton.mjs
+++ b/scripts/validate-reactivity-singleton.mjs
@@ -1,0 +1,85 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCallback);
+const root = resolve(import.meta.dirname, '..');
+const coreManifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+const reactivityVersion = coreManifest.version;
+
+if (coreManifest.dependencies?.['@gluonjs/reactivity']) {
+  throw new Error('@gluonjs/core must not install a private @gluonjs/reactivity runtime dependency.');
+}
+if (coreManifest.peerDependencies?.['@gluonjs/reactivity'] !== reactivityVersion) {
+  throw new Error('@gluonjs/core must require the exact lockstep @gluonjs/reactivity peer.');
+}
+
+const fixture = await mkdtemp(join(tmpdir(), 'gluon-reactivity-singleton-'));
+try {
+  const coreArchive = await pack(root, fixture);
+  const reactivityArchive = await pack(resolve(root, 'packages/reactivity'), fixture);
+  const consumer = join(fixture, 'consumer');
+  await mkdir(consumer);
+  await writeFile(join(consumer, 'package.json'), JSON.stringify({
+    name: 'gluon-reactivity-singleton-consumer',
+    private: true,
+    type: 'module',
+    dependencies: {
+      '@gluonjs/core': `file:${coreArchive}`,
+      '@gluonjs/reactivity': `file:${reactivityArchive}`,
+    },
+  }, null, 2));
+  await execFile('npm', [
+    'install',
+    '--ignore-scripts',
+    '--package-lock=true',
+    '--audit=false',
+    '--fund=false',
+  ], { cwd: consumer });
+
+  const lockfile = JSON.parse(await readFile(join(consumer, 'package-lock.json'), 'utf8'));
+  const nestedReactivity = 'node_modules/@gluonjs/core/node_modules/@gluonjs/reactivity';
+  if (lockfile.packages[nestedReactivity]) {
+    throw new Error(`Consumer install created a duplicate Reactivity runtime at ${nestedReactivity}.`);
+  }
+  const installedCore = lockfile.packages['node_modules/@gluonjs/core'];
+  if (installedCore?.peerDependencies?.['@gluonjs/reactivity'] !== reactivityVersion) {
+    throw new Error('Packed @gluonjs/core must retain its exact Reactivity peer dependency.');
+  }
+
+  const consumerReactivity = await resolveEsmReactivity(consumer);
+  const coreReactivity = await resolveEsmReactivity(join(consumer, 'node_modules/@gluonjs/core'));
+  if (consumerReactivity !== coreReactivity) {
+    throw new Error(`Core resolves ${coreReactivity}; consumer resolves ${consumerReactivity}.`);
+  }
+
+  console.log(`validated one Reactivity runtime at ${consumerReactivity}`);
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}
+
+async function pack(directory, destination) {
+  const { stdout } = await execFile('npm', [
+    'pack',
+    '--json',
+    '--ignore-scripts',
+    '--pack-destination',
+    destination,
+  ], { cwd: directory });
+  const [result] = JSON.parse(stdout);
+  if (!result?.filename) throw new Error(`npm pack returned no archive for ${directory}.`);
+  return resolve(destination, result.filename);
+}
+
+async function resolveEsmReactivity(directory) {
+  const resolver = join(directory, '.gluon-reactivity-resolver.mjs');
+  await writeFile(resolver, "console.log(import.meta.resolve('@gluonjs/reactivity'));\n");
+  try {
+    const { stdout } = await execFile(process.execPath, [resolver], { cwd: directory });
+    return stdout.trim();
+  } finally {
+    await rm(resolver, { force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- make `@gluonjs/reactivity` an exact required peer of `@gluonjs/core`
- add a packed-consumer regression gate that rejects a nested Core copy and compares actual ESM resolution paths
- document installation, diagnosis, and the verified package-topology boundary

## Why

Core previously installed Reactivity as its own runtime dependency. A consumer with another physical copy could create state that the renderer effect never observed.

## Validation

- `node --check scripts/validate-reactivity-singleton.mjs`
- `npm run check:reactivity-singleton`
- `npm run check:packages`
- `npm run check:release-contract`
- `npm run check:docs`
- `git diff --check`

The package-boundary change has no truthful GLUON GOODS surface; the canonical shop remains unchanged.

Closes #277