### PR TITLE
docs: define JSON Forms 1.6 scope

### DIFF
--- a/packages/json-forms/README.md
+++ b/packages/json-forms/README.md
@@ -69,3 +69,15 @@ JSON Forms rules, custom renderer registries, localization, async schemas, and
 file widgets are intentionally unsupported in this slice. An unsupported schema
 or UI schema renders an explicit configuration error rather than silently
 dropping fields.
+
+## 1.6 delivery decision
+
+The direct-property component above is the complete `1.6.0` delivery scope. It
+is the first usable package identified in issue #256 and was delivered in
+[#257](https://github.com/marcmalerei/gluon/issues/257). The listed nested,
+array, reference, composition, rule, registry, localization, and async
+capabilities are not compatibility promises for `1.6.0`; each needs a separate
+future slice that defines its public contract, accessibility behavior, and
+browser evidence before it can become supported. Until then, applications must
+treat the explicit configuration error as the package's only supported response
+to those inputs.


### PR DESCRIPTION
Closes #256\n\n## Decision\n- confirms that #257 / PR #258 delivered the first usable, optional form-associated JSON Forms package\n- treats the documented direct-property subset as the complete 1.6.0 contract\n- leaves arrays, nested layouts, references, composition, rules, registries, localization, and async schemas as future compatibility slices rather than claiming them as delivered\n\n## Verification\n- npm run check:docs\n- git diff --check\n\nNo application change is warranted: the existing docs reference is the maintained truthful acceptance surface, and GLUON GOODS intentionally retains its bespoke delivery form.