### PR TITLE
docs: record the bounded DX decision

### DIFF
--- a/docs/dx-benchmark.md
+++ b/docs/dx-benchmark.md
@@ -7,12 +7,18 @@ contract is
 and completed evidence must conform to
 [`benchmarks/dx/schema/run-v1.schema.json`](../benchmarks/dx/schema/run-v1.schema.json).
 
-This repository does not currently contain a completed human-plus-automation
-DX benchmark run. A schema-valid automated-only run retains all 21 framework-
-task records while its `humanPasses` array is deliberately empty. One retained
-record selects the comparator lanes and captures the environment and package
-versions observed on 12 July 2026. A second, explicitly partial record
-captures issue #111's nested checkout/dialog syntax measurements for the
+This repository does not contain a completed human-plus-automation DX benchmark
+run. A schema-valid automated-only run retains all 21 framework-task records
+while its `humanPasses` array is deliberately empty. The 1.6 decision for
+issue #107 therefore uses only the bounded per-dimension conclusion in
+[`dx-scorecard-report.md`](dx-scorecard-report.md): named automated wins, ties,
+losses, and mixed results, but no general DX-superiority claim. A human pass is
+not a release gate for closing that historical issue; it remains required for
+any future human-plus-automation comparison or general claim.
+
+One retained record selects the comparator lanes and captures the environment
+and package versions observed on 12 July 2026. A second, explicitly partial
+record captures issue #111's nested checkout/dialog syntax measurements for the
 T3-local-layers implementation slice. A third partial record captures issue
 #112's retained stateful form-control comparison for T4. Those partial records
 support no win, tie, loss, usability, readability, or general DX-superiority

--- a/docs/dx-scorecard-report.md
+++ b/docs/dx-scorecard-report.md
@@ -1,11 +1,10 @@
-# Automated DX scorecard report
+# Automated DX scorecard and issue #107 decision
 
-This report interprets only
+This report is the final per-dimension decision record for issue #107. It interprets only
 [`automation-8a02472.json`](../benchmarks/dx/runs/automation-8a02472.json),
 captured on 12 July 2026 from commit
-`8a024721fd484dacb79397a0bf257e49c1f4664b`. It is not the final issue #107
-report: the required human usability pass has not occurred, so no general DX
-superiority claim is supported.
+`8a024721fd484dacb79397a0bf257e49c1f4664b`. No human usability pass occurred,
+so the record supports no general DX-superiority claim.
 
 ## Retained lanes
 
@@ -56,10 +55,27 @@ lists remain separate in every raw task record.
   and T6 explicitly measures request state, hydration, and style ownership.
   Removing those concepts solely to reduce a count is an accepted non-goal.
 
-## Remaining blocker
+## Final decision for issue #107
 
-Run the unchanged
-[`human-usability-brief-v1.md`](../benchmarks/dx/human-usability-brief-v1.md)
-with at least one real participant and retain reviewed observations under the
-completed-run schema. Until then issue #107 stays open and this report cannot be
-promoted to a final human-plus-automation comparison.
+Gluon is better only in the named automated dimensions above: retained
+author-created source and configuration for T1–T6, its generated stateful
+control, direct plain-HTML use for T7, and the retained missing-cleanup
+diagnostic. It ties the comparators on the six shared observable flows and on
+invalid prop/event diagnostics. It loses on direct production and development
+dependency counts, and the required-concepts dimension remains mixed. No total
+score or general ranking follows from those facts.
+
+The 1.6 release accepts the missing human pass as a non-goal for closing this
+historical issue; it does **not** treat its absence as favorable evidence or as
+a substitute for participant research. A fresh check on 30 July 2026 confirmed
+that the official [Vue Quick Start](https://vuejs.org/guide/quick-start.html)
+still selects `create-vue`, while the official [React application guide](https://react.dev/learn/creating-a-react-app)
+still recommends framework lanes including React Router. That check does not
+refresh this 12 July version-pinned comparison or turn it into a claim about
+current framework versions.
+
+A future claim that Gluon is generally better than Vue or React requires a new
+version-pinned run of all seven tasks, a real participant study using the
+unchanged [human-usability brief](../benchmarks/dx/human-usability-brief-v1.md),
+and a new per-dimension report. Until then, documentation must use the bounded
+automated conclusion above.

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -305,8 +305,9 @@ fixture mappings, the automated-only schema and committed raw run, and still
 reports zero completed human-plus-automation runs. The DX Scorecard workflow
 executes the full clean-install/HMR/SSR/hydration/diagnostic scorecard every
 Monday and on manual dispatch, retaining raw artifacts for 90 days. Human
-evidence remains required before issue #107 can close. The full contract and
-current boundary are documented in
+evidence remains required for a future human-plus-automation comparison or a
+general DX claim; it is not a release gate for the bounded issue #107 decision.
+The full contract and current boundary are documented in
 [`dx-benchmark.md`](dx-benchmark.md).
 
 The comparator projects have independent pinned TypeScript graphs and are

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -257,8 +257,10 @@ The versioned issue #107 benchmark contract is documented in
 [`dx-benchmark.md`](dx-benchmark.md). Its retained automated run contains all 21
 framework-task results with exact versions, clean installs, diagnostics,
 three-engine flows, HMR, SSR, and hydration. It deliberately contains no human
-pass. Issue #107 remains open until at least one real participant executes the
-unchanged brief and a maintainer reviews the combined evidence.
+pass. The 1.6 decision closes #107 with its bounded automated win/tie/loss
+report, not a general superiority claim. A real participant using the unchanged
+brief and a fresh version-pinned rerun remain necessary before any future
+human-plus-automation or general-DX conclusion.
 
 ## M4 — Universal Rendering
 


### PR DESCRIPTION
Closes #107\n\n## Decision\n- recognizes Gluon wins only in the retained, named automated dimensions: authored source/configuration, generated stateful control, direct plain-HTML use, and cleanup diagnostics\n- retains observable-flow and prop/event diagnostic ties, direct-dependency losses, and mixed required concepts\n- makes no general claim that Gluon DX is better than Vue or React\n- records the absent human usability pass as a 1.6 non-goal for this historical issue, not as positive evidence\n\n## Currency boundary\nA 30 July check of official Vue and React guidance confirms the selected scaffold/framework-lane categories remain recognizable, but does not refresh the 12 July version-pinned comparison.\n\n## Verification\n- npm run check:dx-scorecard\n- npm run check:docs\n- git diff --check\n\nNo application or GLUON GOODS change is warranted: this PR documents an evidence decision and does not change a public framework capability.