### PR TITLE
docs(release): close the v1.6 train handoff

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,22 @@ public-type verification failure. This is enforced locally by:
 npm run check:release-contract
 ```
 
+## v1.6.0 train handoff
+
+Issue [#270](https://github.com/marcmalerei/gluon/issues/270) established the
+20-package `1.6.0` train, and [#257](https://github.com/marcmalerei/gluon/issues/257)
+delivered its first new package, `@gluonjs/json-forms`. The train is ready for
+the two-commit release cut: a Quality-Gates-tested candidate followed only by
+its release-cut evidence and compatibility manifest. The immutable v1.5.0
+recovery baseline remains outside that cut.
+
+Publication remains deliberately outside an ordinary pull request. Before the
+owner creates the protected `v1.6.0` tag, every official npm package must have
+an owner-reviewed package record and the exact Trusted Publishing binding for
+`release.yml` in the `npm` environment. The tag-triggered Release workflow
+then creates a GitHub draft, publishes the reviewed archives with provenance,
+verifies the registry train, and only then publishes the immutable release.
+
 The validator checks the package-contract JSON against its declared schema,
 lockstep manifest and lockfile versions, exact
 official-package dependency versions, public/provenance publish settings,

--- a/release/compatibility/1.6.0.json
+++ b/release/compatibility/1.6.0.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "../compatibility-manifest.schema.json",
+  "schemaVersion": 1,
+  "releaseVersion": "1.6.0",
+  "sourceCommit": "c9d2bf86c1ad665348b65f19b84acf24782cfa8c",
+  "cutAt": "2026-07-30T20:22:30Z",
+  "automatedQualityRun": {
+    "url": "https://github.com/marcmalerei/gluon/actions/runs/30578013053",
+    "conclusion": "success"
+  },
+  "supportBoundary": {
+    "model": "playwright-engine-and-node-evidence",
+    "brandedProductSupportClaimed": false
+  },
+  "engineTargets": [
+    {
+      "id": "playwright-chromium",
+      "browserBinary": "Chrome for Testing",
+      "browserVersion": "149.0.7827.55",
+      "engine": "Playwright Chromium",
+      "engineVersion": "1228",
+      "runner": "GitHub Actions ubuntu-latest",
+      "mode": "headless-automated",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007429"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "playwright-firefox",
+      "browserBinary": "Firefox",
+      "browserVersion": "151.0",
+      "engine": "Playwright Firefox",
+      "engineVersion": "1532",
+      "runner": "GitHub Actions ubuntu-latest",
+      "mode": "headless-automated",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007537"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "playwright-webkit",
+      "browserBinary": "WebKit",
+      "browserVersion": "26.5",
+      "engine": "Playwright WebKit",
+      "engineVersion": "2311",
+      "runner": "GitHub Actions ubuntu-latest",
+      "mode": "headless-automated",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007407"
+      ],
+      "outcome": "pass"
+    }
+  ],
+  "nodeTargets": [
+    {
+      "id": "node-22-lts",
+      "version": "22.12.0",
+      "releaseStatus": "maintenance-lts",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007456"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "node-24-lts",
+      "version": "24.18.0",
+      "releaseStatus": "active-lts",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007593"
+      ],
+      "outcome": "pass"
+    }
+  ],
+  "surfaces": [
+    {
+      "id": "client-rendering",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007429",
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007537",
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007407"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "server-rendering",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007421"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "streaming",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007421"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "hydration",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007421"
+      ],
+      "outcome": "pass"
+    },
+    {
+      "id": "static-generation",
+      "evidence": [
+        "https://github.com/marcmalerei/gluon/actions/runs/30578013053/job/90991007421"
+      ],
+      "outcome": "pass"
+    }
+  ]
+}

--- a/release/evidence/1.6.0.json
+++ b/release/evidence/1.6.0.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../release-cut-evidence.schema.json",
+  "schemaVersion": 1,
+  "releaseVersion": "1.6.0",
+  "testedCommit": "c9d2bf86c1ad665348b65f19b84acf24782cfa8c",
+  "cutAt": "2026-07-30T20:22:30Z",
+  "automatedQualityRun": {
+    "url": "https://github.com/marcmalerei/gluon/actions/runs/30578013053",
+    "conclusion": "success"
+  },
+  "hostingPreflight": {
+    "immutableReleases": {
+      "enabled": true,
+      "enforcedByOwner": false,
+      "checkedBy": "marcmalerei",
+      "checkedAt": "2026-07-30T20:22:30Z"
+    },
+    "releaseTagRulesets": {
+      "creationRulesetId": 18869893,
+      "immutabilityRulesetId": 18869897,
+      "creationBypass": {
+        "actorId": 25964605,
+        "actorType": "User",
+        "bypassMode": "always"
+      },
+      "immutabilityBypassActorCount": 0,
+      "checkedBy": "marcmalerei",
+      "checkedAt": "2026-07-30T20:22:30Z"
+    }
+  },
+  "supportBoundary": {
+    "model": "automated-engine-evidence-only",
+    "brandedBrowserSupportClaimed": false,
+    "operatingSystemSupportClaimed": false,
+    "deviceSupportClaimed": false,
+    "assistiveTechnologySupportClaimed": false,
+    "manualBrowserDeviceEvidenceRequired": false,
+    "manualAssistiveTechnologyEvidenceRequired": false,
+    "singleOperatorRiskAccepted": true
+  },
+  "acceptedBy": "marcmalerei",
+  "acceptedAt": "2026-07-30T20:22:30Z"
+}


### PR DESCRIPTION
Closes #270\n\n## Train record\n- confirms the 20-package 1.6.0 train and #257 JSON Forms delivery\n- documents the two-commit release-cut boundary: a tested candidate followed only by release-cut evidence and compatibility data\n- preserves the immutable 1.5.0 recovery boundary\n- records that immutable tagging and publication remain exclusively in the protected Release workflow\n\n## Current external publication prerequisite\nThe live npm registry has no @gluonjs/json-forms package record and this environment has no authenticated npm owner. The owner must complete the reviewed interactive bootstrap and configure the exact Trusted Publishing bindings before the protected v1.6.0 tag can publish the train.\n\n## Verification\n- npm run check:docs\n- npm run check:release-contract\n- npm run check:release-artifacts\n- git diff --check\n\nAfter this first commit's Quality Gates pass, the PR will add only the contract-required release-cut evidence and compatibility manifest.