### PR TITLE
perf(runtime): streamline keyed reverse reconciliation

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -20,6 +20,10 @@ contiguous run, and move only the surrounding groups. These shortcuts retain
 the external-DOM recovery, cleanup, style, hydration, and keyed-identity
 contracts covered by the browser suite.
 
+The exact-reverse fast path reuses the direct element for each still-safe
+primitive row, avoiding per-row node-array materialization. Structural,
+mixed, or multi-node rows continue through generic keyed reconciliation.
+
 Official production Vite builds also recognize a conservative component-level
 case: one fixed `GluonElement` template with one declared primitive property in
 a text Part and, optionally, one private readonly event handler. Property-only

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -847,8 +847,8 @@ class NodePart implements Part {
     for (let index = 0; reverseOrder && index < keys.length; index += 1) {
       reverseOrder = this.keyedChildren[index]!.key === keys[keys.length - index - 1];
     }
-    if (reverseOrder && this.marker.parentNode) {
-      const parent = this.marker.parentNode;
+    const parent = this.marker.parentNode;
+    if (reverseOrder && parent) {
       const reference = this.marker.nextSibling;
       const nextChildren: KeyedChild[] = [];
       const nextNodes: Node[] = [];
@@ -857,10 +857,15 @@ class NodePart implements Part {
         const child = this.keyedChildren[keys.length - index - 1]!;
         const value = values[index]!;
         this.updateKeyedChild(child, value, true);
-        const childNodes = keyedChildNodes(child);
-        if (childNodes[0] !== reference) moveNodesBefore(parent, childNodes, reference);
+        if (isLazyPrimitiveKeyedChild(child) && !child.part) {
+          if (child.element !== reference) parent.insertBefore(child.element, reference);
+          nextNodes.push(child.element);
+        } else {
+          const childNodes = keyedChildNodes(child);
+          if (childNodes[0] !== reference) moveNodesBefore(parent, childNodes, reference);
+          nextNodes.push(...childNodes);
+        }
         nextChildren.push(child);
-        nextNodes.push(...childNodes);
       }
 
       this.keyedChildren = nextChildren;
@@ -892,7 +897,6 @@ class NodePart implements Part {
 
     const previousChildren = this.keyedChildren;
     const previousNodes = this.nodes;
-    const parent = this.marker.parentNode;
     const nodesInPlace = Boolean(parent && nodesAreInPlace(this.marker, previousNodes));
     const boundary = nodesInPlace && previousNodes.length > 0
       ? previousNodes[previousNodes.length - 1]!.nextSibling

--- a/tests/keyed-list-conformance.spec.ts
+++ b/tests/keyed-list-conformance.spec.ts
@@ -170,6 +170,57 @@ describe('keyed list renderer conformance', () => {
     expect(item.textContent).toBe('');
   });
 
+  it('reverses anchor-free lazy primitive rows without materializing them', () => {
+    const root = document.createElement('div');
+    const rows = [row('a', 'Alpha'), row('b', 'Beta'), row('c', 'Gamma')];
+    const view = (items: readonly Row[]) => html`<ul>${repeat(
+      items,
+      (item) => item.id,
+      (item) => html`<li data-id=${item.id}>${item.label}</li>`,
+    )}</ul>`;
+
+    render(view(rows), root);
+    const list = root.querySelector('ul')!;
+    const identities = [...list.childNodes];
+
+    render(view([
+      rows[2]!,
+      { ...rows[1]!, label: 'Updated Beta' },
+      rows[0]!,
+    ]), root);
+
+    expect([...list.childNodes]).toEqual([identities[0]!, ...identities.slice(1).reverse()]);
+    expect([...list.childNodes].slice(1).every((node) => node instanceof HTMLLIElement)).toBe(true);
+    expect(list.querySelector('[data-id="b"]')?.textContent).toBe('Updated Beta');
+  });
+
+  it('falls back to generic reconciliation when a reversed lazy row becomes structural', () => {
+    const root = document.createElement('div');
+    type Item = { readonly id: string; readonly content: TemplateValue };
+    const view = (items: readonly Item[]) => html`<ul>${repeat(
+      items,
+      (item) => item.id,
+      (item) => html`<li data-id=${item.id}>${item.content}</li>`,
+    )}</ul>`;
+    const initial: readonly Item[] = [
+      { id: 'a', content: 'Alpha' },
+      { id: 'b', content: 'Beta' },
+    ];
+
+    render(view(initial), root);
+    const list = root.querySelector('ul')!;
+    const first = list.querySelector('[data-id="a"]')!;
+    const second = list.querySelector('[data-id="b"]')!;
+
+    render(view([
+      { id: 'b', content: html`<strong>Beta</strong>` },
+      { id: 'a', content: 'Alpha' },
+    ]), root);
+
+    expect([...list.querySelectorAll('li')]).toEqual([second, first]);
+    expect(second.querySelector('strong')?.textContent).toBe('Beta');
+  });
+
   it('clones pristine primitive prototypes without sharing mounted DOM mutations', () => {
     const firstRoot = document.createElement('div');
     const secondRoot = document.createElement('div');


### PR DESCRIPTION
## Summary

- Avoid per-row node-array materialization when a keyed repeat is reversed and a row remains a safe lazy primitive.
- Keep structural, multi-node, and mixed rows on the existing generic reconciliation path.
- Add direct and fallback regression coverage, plus document the optimization boundary.

## Performance

The repeated Chromium production comparison (30 samples, 6 warm-ups) improved the 1,000-row reverse median from 0.1371 ms/op on `main` to 0.1271 ms/op on this branch (7.3% lower). The local shop entry is 56,483 gzip bytes, 17 bytes below the enforced budget.

## Validation

- `npm run build:core`
- `npm run typecheck:core-api`
- `npm run test:browser` (341 tests)
- `npx vitest run tests/keyed-list-conformance.spec.ts tests/hydration.spec.ts tests/dom-runtime-contract.spec.ts` (56 tests)
- `npm run check:docs`
- `npm run check:budgets`
- `npm run benchmark:rendering -- --browsers=chromium --samples=30 --warmup=6 --output=.tmp/rendering-budget-candidate-v3.json`

Closes #287