### PR TITLE
perf(runtime): streamline component style comparisons

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -433,6 +433,33 @@ Run the focused benchmark with:
 npm run benchmark:allocations
 ```
 
+## Shared component-style comparison fast path
+
+Issue #292 removed redundant work from repeated component-style claims without
+changing the style metadata or ownership APIs. Unstyled `TemplateResult`
+instances already share one frozen empty dependency list, so identical list
+references now return immediately. Distinct lists use an indexed comparison
+instead of allocating an `Array.prototype.every()` callback.
+
+The production Core build from clean `main` at `28133ca` and the candidate build
+were loaded together in each browser with the same reactivity build. Separate
+DOM roots repeatedly updated one nested unstyled template. The build order
+alternated for eight warm-up rounds and 40 measured samples; every sample
+contained 50,000 updates. Both builds therefore experienced the same browser
+process, timer, and run-level load.
+
+| Browser | Main median / p95 ms/op | Candidate median / p95 ms/op |
+| --- | ---: | ---: |
+| Chromium 149 | 0.000138 / 0.000140 | 0.000124 / 0.000124 |
+| Firefox 151 | 0.000180 / 0.000220 | 0.000180 / 0.000200 |
+| WebKit 26.5 | 0.000120 / 0.000200 | 0.000120 / 0.000160 |
+
+The Chromium median and p95 were 10.1% and 11.4% lower. Firefox and WebKit
+medians stayed at the same timer resolution while their p95 values were one
+timer step lower. These figures describe this controlled nested-template path
+on the recorded Apple M4 environment; they are not a general rendering-speed
+claim.
+
 ## Reactivity debugger fast path
 
 Reactive effects may opt into `onTrack` and `onTrigger` debugger hooks. Normal

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -545,10 +545,14 @@ function sameComponentStyles(
   left: readonly ComponentStyleDependency[],
   right: readonly ComponentStyleDependency[],
 ): boolean {
+  if (left === right) return true;
   if (left.length !== right.length) return false;
-  return left.every((dependency, index) => (
-    dependency.id === right[index]?.id && dependency.sheet === right[index]?.sheet
-  ));
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index]!.id !== right[index]!.id || left[index]!.sheet !== right[index]!.sheet) {
+      return false;
+    }
+  }
+  return true;
 }
 
 class NodePart implements Part {

--- a/tests/component-styles.spec.ts
+++ b/tests/component-styles.spec.ts
@@ -65,6 +65,37 @@ describe('usage-driven component styles', () => {
     expect(document.adoptedStyleSheets).not.toContain(buttonStyles);
   });
 
+  it('keeps equivalent dependency lists stable and swaps unequal lists', () => {
+    const first = createComponentStyleDependency({
+      id: 'comparison-first',
+      sheet: css`.comparison-first { color: red; }`,
+      layer: 'atom',
+      order: 0,
+    });
+    const second = createComponentStyleDependency({
+      id: 'comparison-second',
+      sheet: css`.comparison-second { color: blue; }`,
+      layer: 'atom',
+      order: 1,
+    });
+    const view = (
+      label: string,
+      dependencies: readonly typeof first[],
+    ) => html`<p>${label}</p>`.withStyleDependencies(dependencies);
+
+    render(view('First', [first]), document.body);
+    const paragraph = document.body.querySelector('p');
+    render(view('Updated', [first]), document.body);
+
+    expect(document.body.querySelector('p')).toBe(paragraph);
+    expect(document.adoptedStyleSheets).toContain(first.sheet);
+    expect(document.adoptedStyleSheets).not.toContain(second.sheet);
+
+    render(view('Swapped', [second]), document.body);
+    expect(document.adoptedStyleSheets).not.toContain(first.sheet);
+    expect(document.adoptedStyleSheets).toContain(second.sheet);
+  });
+
   it('rejects deprecated aggregate coexistence instead of double-styling silently', () => {
     adoptStyles(document, atomStyles);
     expect(() => render(Button({ label: 'Conflicting path' }), document.body)).toThrowError(


### PR DESCRIPTION
## Summary

- return immediately when component-style dependency lists share identity
- compare distinct lists with an indexed loop instead of an `Array.prototype.every()` callback
- cover equivalent and unequal dependency-list updates through public rendering behavior
- document the controlled production-build benchmark evidence

## Why

Unstyled `TemplateResult` instances already share one frozen empty dependency list, but nested updates still performed length/every work and created a callback. The private equality helper is also used for non-identical dependency lists, where an indexed comparison preserves the exact id/sheet contract without that allocation.

## Performance evidence

Clean `main` at `28133ca` and candidate production Core builds ran together in each browser, with separate roots, alternating build order, 8 warm-up rounds, 40 measured samples, and 50,000 nested template updates per sample:

| Browser | Main median / p95 ms/op | Candidate median / p95 ms/op |
| --- | ---: | ---: |
| Chromium 149 | 0.000138 / 0.000140 | 0.000124 / 0.000124 |
| Firefox 151 | 0.000180 / 0.000220 | 0.000180 / 0.000200 |
| WebKit 26.5 | 0.000120 / 0.000200 | 0.000120 / 0.000160 |

Chromium median/p95 were 10.1%/11.4% lower. Firefox and WebKit medians stayed at timer resolution and p95 was lower. This is evidence for the recorded nested-template path, not a general rendering claim.

## Verification

- `npx vitest run tests/component-styles.spec.ts tests/runtime.spec.ts` — 21/21 passed
- `npm run check` — passed with exit 0
  - browser coverage: 48 files, 342 tests
  - full typecheck/build/package/public API/security/docs/release contract matrix
  - create-gluon clean-install matrix: 20 applications, 5 component kinds, 1 retained DX fixture
  - release artifacts: 20 packages and 42 schema-valid SBOMs
  - shop quality budget: 56,475 gzip bytes under the 56,500-byte limit

## Shop application

No visible shop change is warranted. This is a private equality fast path used by existing styled and unstyled component rendering; it adds no customer-facing capability or design change. The full shop build, static output, boundaries, coverage, and quality budgets passed in the same check run.

Closes #292