### PR TITLE
Reuse renderer-owned node arrays during stable recovery

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -24,6 +24,36 @@ The exact-reverse fast path reuses the direct element for each still-safe
 primitive row, avoiding per-row node-array materialization. Structural,
 mixed, or multi-node rows continue through generic keyed reconciliation.
 
+## Renderer-owned node-array reuse
+
+Issue #295 removed two redundant array copies before private DOM
+reconciliation. An unchanged `unsafeHTML()` value and an externally detached
+stable keyed row now pass the renderer's existing node array back to
+`replaceNodes()`. That method reads the array and retains the same reference; it
+does not mutate the input. DOM identity and external-mutation recovery remain
+covered by focused browser tests.
+
+The production Core build from clean `main` at `801611d` and the candidate
+build were loaded together in each browser with the same reactivity build.
+Separate DOM roots repeatedly rendered one stable three-node `unsafeHTML()`
+value through the same outer template. Build order alternated for 12 warm-up
+rounds and 100 measured samples. Batches were calibrated to at least 12 ms for
+the faster build: 65,536 renders in Chromium and Firefox, and 131,072 in
+WebKit.
+
+| Browser | Main median / p95 ms/op | Candidate median / p95 ms/op |
+| --- | ---: | ---: |
+| Chromium 149 | 0.0002274 / 0.0002319 | 0.0002182 / 0.0002228 |
+| Firefox 151 | 0.0002441 / 0.0002747 | 0.0002289 / 0.0002747 |
+| WebKit 26.5 | 0.0001450 / 0.0001450 | 0.0001373 / 0.0001373 |
+
+Candidate medians were 4.0%, 6.3%, and 5.3% lower respectively. An independent
+run measured 3.3%, 6.3%, and 5.6% lower medians. The reported minified Core
+runtime chunk changed from 79.20 kB to 79.19 kB while its rounded gzip size
+remained 20.86 kB. These figures describe stable raw-markup rerenders on the
+recorded Apple M4 environment. The rarer keyed external-recovery path is
+behaviorally covered but is not included in the throughput claim.
+
 Official production Vite builds also recognize a conservative component-level
 case: one fixed `GluonElement` template with one declared primitive property in
 a text Part and, optionally, one private readonly event handler. Property-only

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1004,7 +1004,7 @@ class NodePart implements Part {
     }
     this.textNode = undefined;
     this.lastPrimitive = unsetValue;
-    if (!nodesAreInPlace(this.marker, this.nodes)) this.replaceNodes([...this.nodes]);
+    if (!nodesAreInPlace(this.marker, this.nodes)) this.replaceNodes(this.nodes);
   }
 
   private updateKeyedChild(child: KeyedChild, value: TemplateValue, assumeInPlace: boolean): void {
@@ -1116,7 +1116,7 @@ class NodePart implements Part {
 
   private setUnsafeHTML(result: UnsafeHtmlResult): void {
     if (this.unsafeMarkup === result.markup) {
-      this.replaceNodes([...this.nodes]);
+      this.replaceNodes(this.nodes);
       return;
     }
 

--- a/tests/dom-runtime-contract.spec.ts
+++ b/tests/dom-runtime-contract.spec.ts
@@ -426,6 +426,9 @@ describe('DOM runtime contract', () => {
     const strong = root.querySelector('#trusted');
     render(content(trusted), root);
     expect(root.querySelector('#trusted')).toBe(strong);
+    strong!.remove();
+    render(content(trusted), root);
+    expect(root.querySelector('#trusted')).toBe(strong);
 
     const propertyRoot = document.createElement('div');
     expect(() => render(html`<div .innerHTML=${'<em>blocked</em>'}></div>`, propertyRoot)).toThrow(

--- a/tests/keyed-list-conformance.spec.ts
+++ b/tests/keyed-list-conformance.spec.ts
@@ -111,6 +111,18 @@ describe('keyed list renderer conformance', () => {
     expect(moved.textContent?.trim()).toBe('Bee');
   });
 
+  it('reinstalls externally detached lazy rows without replacing their DOM identities', () => {
+    const root = document.createElement('div');
+    const rows = [row('a'), row('b'), row('c')];
+    render(keyedView(rows), root);
+    const items = listItems(root);
+
+    items[1]!.remove();
+    render(keyedView(rows), root);
+
+    expect(listItems(root)).toEqual(items);
+  });
+
   it('updates lazy primitive rows in place and materializes structural bindings on demand', () => {
     const root = document.createElement('div');
     const view = (item: {


### PR DESCRIPTION
## Summary

- pass renderer-owned node arrays directly into private reconciliation for unchanged `unsafeHTML()` and stable keyed recovery
- preserve raw-markup and lazy-keyed DOM identities after external detachment
- document controlled production-build size and cross-browser latency evidence

## Performance evidence

Clean `main` at `801611d` and the candidate production build ran together with separate DOM roots, 12 warm-ups, and 100 interleaved samples. Stable three-node raw-markup medians changed by:

- Chromium 149: `0.0002274` -> `0.0002182` ms/op (-4.0%)
- Firefox 151: `0.0002441` -> `0.0002289` ms/op (-6.3%)
- WebKit 26.5: `0.0001450` -> `0.0001373` ms/op (-5.3%)

An independent run measured -3.3%, -6.3%, and -5.6%. The reported minified Core runtime chunk changed from 79.20 kB to 79.19 kB; rounded gzip remained 20.86 kB.

## Verification

- `npx vitest run tests/dom-runtime-contract.spec.ts tests/keyed-list-conformance.spec.ts tests/hydration.spec.ts` (57 tests)
- `npm run typecheck:core`
- `npm run build:core`
- `npm run check`
- two controlled Chromium/Firefox/WebKit production-build A/B runs

## GLUON GOODS

No shop change: this is a private reconciliation/allocation optimization with no honest user-visible shop surface. The complete gate rebuilt and validated the canonical shop, static output, previews, and quality budgets.

Closes #295