### PR TITLE
Stabilize React hydration cleanup evidence in WebKit

### DIFF
--- a/benchmarks/dx/stateful-form-control/react.tsx
+++ b/benchmarks/dx/stateful-form-control/react.tsx
@@ -5,7 +5,7 @@ import type { ProductInput, QuantityChange, QuantityControlPublic } from './shar
 import { adoptQuantityStyles } from './shared.js';
 
 export const reactQuantityTag = 'dx-react-quantity';
-export const reactLifecycleEvidence = { cleanups: 0 };
+export const reactLifecycleEvidence = { cleanups: 0, mounts: 0 };
 
 export interface ReactQuantityViewProps {
   readonly product: ProductInput;
@@ -18,7 +18,7 @@ export function ReactQuantityView(props: ReactQuantityViewProps): ReactElement {
   const [draft, setDraft] = useState(props.value);
   const total = useMemo(() => draft * props.product.price, [draft, props.product.price]);
   useEffect(() => { setDraft(props.value); }, [props.value]);
-  useEffect(() => () => { reactLifecycleEvidence.cleanups += 1; }, []);
+  useEffect(() => { reactLifecycleEvidence.mounts += 1; return () => { reactLifecycleEvidence.cleanups += 1; }; }, []);
   const change = (quantity: number): void => {
     const next = Math.max(0, quantity);
     if (props.requestChange(next)) setDraft(next);

--- a/docs/quality-gates.md
+++ b/docs/quality-gates.md
@@ -191,6 +191,10 @@ before and after observer registration and uses the deadline only to fail a
 missing commit. The retained synchronous event assertion remains separate, and
 a focused 25-update React case exercises the event/render boundary in every
 configured Playwright engine.
+The retained-hydration case separately waits for React's recorded passive-effect
+mount before teardown and for its paired cleanup afterward. Matching server
+text alone is not treated as a hydration-commit signal, so WebKit cannot remove
+the bridge while React still considers the root unhydrated.
 
 ## Generated API example gate
 

--- a/docs/stateful-form-control-comparison.md
+++ b/docs/stateful-form-control-comparison.md
@@ -37,6 +37,13 @@ only a failure boundary; it is not a settlement delay. A focused React case
 repeats 25 accepted changes while preserving separate event, quantity, and
 computed-total assertions.
 
+SSR-identical text is not sufficient evidence that React hydration committed:
+WebKit can retain that text before React installs the component's passive
+lifecycle effect. The retained-hydration case therefore waits for the React
+mount counter before removing the autonomous element, then waits for the exact
+matching cleanup counter. This observable lifecycle boundary prevents teardown
+from becoming an early update while retaining the original server section.
+
 The raw record is
 `benchmarks/dx/stateful-form-control/evidence.json`; its parent-contract record
 is `benchmarks/dx/evidence/stateful-form-control-2026-07-12.json`. These records

--- a/tests/dx-stateful-form-control.spec.ts
+++ b/tests/dx-stateful-form-control.spec.ts
@@ -1,5 +1,5 @@
 import { createApp, defineComponent, h, nextTick } from 'vue';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { GluonElement, renderGluonElementForServer } from '@gluonjs/core';
 import { prepareForHydration } from '@gluonjs/ssr';
 import { hydrateElement } from '@gluonjs/ssr/hydration';
@@ -138,6 +138,7 @@ test('Vue and React hydrate retained server markup and every lane disposes its c
   const functionalBefore = gluonFunctionalLifecycleEvidence.cleanups;
   const vueBefore = vueLifecycleEvidence.cleanups;
   const reactBefore = reactLifecycleEvidence.cleanups;
+  const reactMountsBefore = reactLifecycleEvidence.mounts;
   const cases = [
     [vueQuantityTag, await renderVueQuantityShadow(product, 2)],
     [reactQuantityTag, renderReactQuantityShadow(product, 2)],
@@ -152,10 +153,16 @@ test('Vue and React hydrate retained server markup and every lane disposes its c
     control.value = 2;
     document.body.append(control);
     await settled(control);
+    if (tagName === reactQuantityTag) {
+      await vi.waitFor(() => expect(reactLifecycleEvidence.mounts).toBe(reactMountsBefore + 1));
+    }
     expect(control.shadowRoot?.querySelector('section')).toBe(retainedSection);
     expect(control.shadowRoot?.querySelector('strong')?.textContent).toBe('Total €498.00');
     control.remove();
     await settled(control);
+    if (tagName === reactQuantityTag) {
+      await vi.waitFor(() => expect(reactLifecycleEvidence.cleanups).toBe(reactBefore + 1));
+    }
   }
 
   for (const tagName of [gluonClassTag, gluonFunctionalTag]) {


### PR DESCRIPTION
## Summary
- expose the React passive-effect mount boundary in the stateful form-control benchmark
- wait for the committed mount before removing the hydrated custom element
- wait for cleanup evidence without fixed sleeps and document the lifecycle contract

## Root cause
SSR-identical text allowed the generic settled helper to return before React committed its passive effect. Removing the element in that window could trigger React early-update fallback in WebKit, so the cleanup assertion observed 2 instead of 3.

## Verification
- original failed Quality Gates run rerun with the same matrix: green
- 10 sequential focused WebKit repeats: green
- focused Chromium and Firefox: green
- npm run check:stateful-control-comparison
- npm run typecheck:core
- npm run test:browser:coverage (392/392)
- npm run test:ssr (32/32)
- npm run check:docs
- npm run check:release-artifacts

Closes #359