### PR TITLE
Record completed v1.8.0 publication

### DIFF
--- a/docs-site/content/1.8.0/guides/releasing/index.md
+++ b/docs-site/content/1.8.0/guides/releasing/index.md
@@ -1,12 +1,13 @@
 # Release readiness
 
-The `1.8.0` documentation describes the next lockstep release candidate. All
-21 official manifests are at `1.8.0`. Registry preflight on 2026-08-10
-confirmed that every contracted package exposes `1.7.0` as `latest` and that
-`1.8.0` is absent. The completed `1.7.0` release remains the supported baseline
-until the protected workflow publishes and independently verifies all 21
-reviewed archives. The `@gluonjs` scope, package records, and Trusted Publisher
-bindings remain verified by the completed publication contract.
+The `1.8.0` documentation describes the completed lockstep release. All 21
+official manifests are at `1.8.0`. Release run `31404878372` published every
+contracted package under `latest` with npm provenance, confirmed matching
+reviewed archive integrity, clean-room installation, and public type
+declarations, and published immutable GitHub release `v1.8.0` with 101 retained
+assets on 2026-08-10. Canonical tag `v1.8.0` resolves to merge commit
+`1c57fa0c8497b0c6ddd7911f0feb91afc6deda49`, which preserves the tested
+candidate and evidence histories.
 
 Gluon's release group contains 21 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,28 +7,31 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.8.0` candidate. Every official
-manifest is public and lockstep at `1.8.0`. Registry preflight on 2026-08-10
-confirmed that all 21 package records expose `1.7.0` as `latest` and that
-`1.8.0` is absent. Immutable GitHub release `v1.7.0` remains the current
-finalized release; the `v1.0.9` GitHub release remains a draft after its
-public-type verification failure. This is enforced locally by:
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for the completed `1.8.0` release. Every official
+manifest is public and lockstep at `1.8.0`. Release run `31404878372` published
+all 21 reviewed packages with npm provenance under `latest`, verified matching
+archive integrity, clean-room installation, and public type declarations, and
+then published immutable GitHub release `v1.8.0` with 101 retained assets on
+2026-08-10. The `v1.0.9` GitHub release remains a draft after its public-type
+verification failure. This is enforced locally by:
 
 ```sh
 npm run check:release-contract
 ```
 
-## v1.8.0 train handoff
+## v1.8.0 train completion
 
-Issue [#361](https://github.com/marcmalerei/gluon/issues/361) tracks the
+Issue [#361](https://github.com/marcmalerei/gluon/issues/361) established the
 21-package `1.8.0` train. It promotes the accessible Atom and Molecule APIs
 delivered after `1.7.0`, including form controls, feedback, disclosure,
-selection, dialog, tab, empty-state, and table-region compositions. The train
-uses the two-commit release cut: a Quality-Gates-tested candidate followed only
-by its release-cut evidence and compatibility manifest. The immutable `v1.7.0`
-release remains the supported baseline until the protected `v1.8.0` workflow
-completes.
+selection, dialog, tab, empty-state, and table-region compositions. Protected
+canonical tag `v1.8.0` resolves to merge commit
+`1c57fa0c8497b0c6ddd7911f0feb91afc6deda49`, which retains tested candidate
+`c6f83c92921b461bcb69a8f2db0f4973becabbfb` and the evidence-only follow-up.
+Release run `31404878372` passed candidate, fixtures, browser, Node,
+performance, reproducibility, hosting, attestation, publication, and public
+registry verification before finalizing the immutable release.
 
 ## v1.7.0 train completion
 

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-08-10",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-08-10 confirmed that all 21 contracted package records expose 1.7.0 as latest and that version 1.8.0 is absent. Scope control and trusted publication remain verified by the completed 1.7.0 release contract."
+    "publicationState": "released",
+    "observation": "Release run 31404878372 published all 21 contracted packages at 1.8.0 under latest with npm provenance on 2026-08-10, verified matching reviewed archive integrity, clean-room installation, and public type declarations, then published immutable GitHub release v1.8.0 with 101 retained assets. Canonical tag v1.8.0 resolves to merge commit 1c57fa0c8497b0c6ddd7911f0feb91afc6deda49 and preserves the tested candidate and evidence histories."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary
- mark the 1.8.0 package contract as released
- record release workflow 31404878372 and immutable tag commit
- update maintained and versioned release documentation from candidate to completed state

## Live verification
- all 21 npm packages: version 1.8.0, latest 1.8.0, SHA-512 integrity, attestations present
- GitHub release v1.8.0: published, immutable, 101 assets
- release workflow 31404878372: success

## Checks
- npm run check:release-contract
- npm run check:docs
- npm run check:release-artifacts
- git diff --check

Closes #361