### PR TITLE
docs: finalize v1.8.1 publication

### DIFF
--- a/docs-site/content/1.8.1/guides/releasing/index.md
+++ b/docs-site/content/1.8.1/guides/releasing/index.md
@@ -1,12 +1,18 @@
 # Release readiness
 
-The `1.8.1` documentation describes the prepared lockstep release candidate.
-All 21 official manifests are at `1.8.1`, with `1.8.0` remaining the latest
-published package train until the protected release workflow completes. Issue
-[#367](https://github.com/marcmalerei/gluon/issues/367) tracks retained nested
-SSR hydration and request-local abort propagation. The release cut retains a
-Quality-Gates-tested candidate followed only by its release-cut evidence and
-compatibility manifest.
+The `1.8.1` documentation describes the completed lockstep release. All 21
+official manifests are at `1.8.1`, and the protected release workflow published
+`1.8.1` as the latest package train with npm provenance. Issue
+[#367](https://github.com/marcmalerei/gluon/issues/367) delivered retained
+nested SSR hydration and request-local abort propagation. The release cut
+retains a Quality-Gates-tested candidate followed only by its release-cut
+evidence and compatibility manifest.
+
+The immutable GitHub release is [`v1.8.1`](https://github.com/marcmalerei/gluon/releases/tag/v1.8.1),
+published from `b1c2feeeffd5e1ac6bba2607cf1fae95642e60ab`. Protected workflow
+run [31580641519](https://github.com/marcmalerei/gluon/actions/runs/31580641519)
+passed browser, Node, reproducibility, clean-room registry, and publication
+verification for all 21 packages.
 
 Gluon's release group contains 21 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,26 +7,32 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.8.1` candidate. Every official
-manifest is public and lockstep at `1.8.1`. Registry preflight on 2026-08-12
-confirmed that all 21 package records expose `1.8.0` as `latest` and that
-`1.8.1` is absent. Immutable GitHub release `v1.8.0` remains the current
-finalized release; the `v1.0.9` GitHub release remains a draft after its
-public-type verification failure. This is enforced locally by:
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for `1.8.1`. Every official manifest is public and
+lockstep at `1.8.1`. Protected release run
+[#31580641519](https://github.com/marcmalerei/gluon/actions/runs/31580641519)
+published immutable GitHub release [`v1.8.1`](https://github.com/marcmalerei/gluon/releases/tag/v1.8.1)
+from commit `b1c2feeeffd5e1ac6bba2607cf1fae95642e60ab` on 2026-08-12. Its
+clean-room registry verification confirmed all 21 package records at `1.8.1`
+as `latest`, with npm provenance attestations and archive/registry integrity
+matches. The `v1.0.9` GitHub release remains a draft after its public-type
+verification failure. This is enforced locally by:
 
 ```sh
 npm run check:release-contract
 ```
 
-## v1.8.1 train handoff
+## v1.8.1 train completion
 
-Issue [#367](https://github.com/marcmalerei/gluon/issues/367) establishes the
+Issue [#367](https://github.com/marcmalerei/gluon/issues/367) established the
 21-package `1.8.1` patch train for retained nested SSR hydration and
 request-local abort propagation. The train uses the two-commit release cut: a
 Quality-Gates-tested candidate followed only by its release-cut evidence and
-compatibility manifest. The immutable `v1.8.0` release remains the supported
-baseline until the protected `v1.8.1` workflow completes.
+compatibility manifest. PR [#369](https://github.com/marcmalerei/gluon/pull/369)
+merged that cut, and the tag-triggered workflow completed candidate,
+reproducibility, browser-engine, Node-runtime, performance, fixture, registry,
+and publication checks. The immutable release contains 101 reviewed assets;
+the package train is now the supported `latest` baseline.
 
 ## v1.7.0 train completion
 

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-08-12",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-08-12 confirmed that all 21 contracted package records expose 1.8.0 as latest and that version 1.8.1 is absent. Scope control and trusted publication remain verified by the completed 1.8.0 release contract."
+    "publicationState": "released",
+    "observation": "Protected release run 31580641519 published immutable GitHub release v1.8.1 from b1c2feeeffd5e1ac6bba2607cf1fae95642e60ab on 2026-08-12. Clean-room registry verification confirmed all 21 contracted package records at 1.8.1 as latest with npm provenance attestations; the published archives and registry integrities match the release evidence."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary
- mark the completed 21-package v1.8.1 train as released
- record the immutable tag, successful protected workflow, and clean-room registry verification
- update the versioned release guide from candidate handoff to completed publication

## Verification
- `npm run check:release-contract`
- `npm run check:docs`
- `npm run check:repository`
- release workflow `31580641519` passed all gates and published 21 packages
