### PR TITLE
Fix GitHub Pages package metadata and link rewriting

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -47,7 +47,7 @@ and emits reviewed Markdown into `.tmp/docs-api`.
 `generate-api-examples.mjs` then derives every public function, class,
 interface, type-alias, and variable page, maps it back to an official package
 entry point, appends an `Example` section, and typechecks the complete generated
-snippet corpus. `api-examples.json` maps all 694 current symbol pages to reviewed
+snippet corpus. `api-examples.json` maps every generated current symbol page to reviewed
 task-oriented examples. Related symbols may share a maintained application
 recipe, but every page has its own purpose statement and the compiled recipe
 must use that documented symbol. Unknown pages, missing catalog entries, private
@@ -58,6 +58,10 @@ symbol coverage fail `npm run docs:api`.
 migration material, examples, and release archive. `validate-docs.mjs` verifies
 the version tree, public API entry-point count, one rendered example per public
 symbol page, required curated content, compiled examples, and internal links.
+The root redirect and the stable `/latest/` alias both resolve to the latest
+supported version. API landing pages derive their title, description, and
+breadcrumb from the package contract and package manifest rather than from the
+TypeDoc root label.
 The maintained component guide is the beginner entry point for properties,
 attributes, events, lifecycle ownership, and the complete public class map.
 TypeDoc excludes externally inherited DOM members so an API page keeps its

--- a/docs-site/content/1.8.1/guides/components/index.md
+++ b/docs-site/content/1.8.1/guides/components/index.md
@@ -63,7 +63,7 @@ receive exact canvas teardown without a Web Components adapter. The catalog
 uses the published exports for controls, interactions, accessibility checks,
 and visual baselines; it is developer evidence, not a replacement for the
 GLUON GOODS application acceptance flow. See the
-[complete Storybook guide](../../../../../docs/storybook.md).
+[complete Storybook guide](https://github.com/marcmalerei/gluon/blob/main/docs/storybook.md).
 
 ## Declare properties
 

--- a/docs-site/content/1.8.1/guides/tooling/index.md
+++ b/docs-site/content/1.8.1/guides/tooling/index.md
@@ -28,7 +28,7 @@ npm run storybook:component-library
 npm run check:storybook:component-library
 ```
 
-The [Storybook guide](../../../../../docs/storybook.md) explains installation,
+The [Storybook guide](https://github.com/marcmalerei/gluon/blob/main/docs/storybook.md) explains installation,
 typed stories, component style dependencies, controls, and cleanup.
 
 The production consumer and clean-install package checks remain the authority

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -8,7 +8,16 @@ const contentRoot = resolve(siteRoot, 'content');
 const apiRoot = resolve(root, '.tmp/docs-api');
 const outputRoot = resolve(siteRoot, 'dist');
 const versions = JSON.parse(await readFile(resolve(siteRoot, 'versions.json'), 'utf8'));
+const packageContract = JSON.parse(await readFile(resolve(root, 'package-contract.json'), 'utf8'));
 const base = normalizeBase(process.env.DOCS_BASE ?? '/gluon/');
+const packageMetadata = new Map(await Promise.all(
+  packageContract.packages
+    .filter((entry) => entry.state === 'current')
+    .map(async (entry) => {
+      const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
+      return [entry.name, { name: entry.name, entry, description: packageJson.description }];
+    }),
+));
 
 for (const version of versions.supported) {
   const entries = await readdir(resolve(contentRoot, version));
@@ -31,6 +40,8 @@ const pages = [...maintainedPages, ...apiPages];
 
 for (const page of pages) await renderPage(page);
 await writeRedirect(resolve(outputRoot, 'index.html'), `${base}${versions.latest}/`);
+await mkdir(resolve(outputRoot, 'latest'), { recursive: true });
+await writeRedirect(resolve(outputRoot, 'latest', 'index.html'), `${base}${versions.latest}/`);
 await writeFile(resolve(outputRoot, '404.html'), pageShell({
   title: 'Documentation page not found',
   description: 'The requested Gluon documentation page does not exist.',
@@ -44,12 +55,18 @@ console.log(`built ${pages.length} documentation pages for ${versions.supported.
 async function renderPage(page) {
   let markdown = await readFile(page.source, 'utf8');
   markdown = await expandIncludes(markdown, dirname(page.source));
+  const apiPackage = packageForApiPage(page.relative);
+  if (apiPackage) markdown = rewriteApiBreadcrumb(markdown, apiPackage.name);
   const headings = [];
   const environment = { headings, slugs: new Map() };
   const markdownRenderer = createMarkdownRenderer();
   let content = markdownRenderer.render(markdown, environment);
-  const title = firstHeading(markdown) ?? 'Gluon documentation';
-  const description = firstParagraph(markdown) ?? 'Versioned Gluon framework documentation.';
+  const title = apiPackage && isApiPackageLanding(page.relative)
+    ? apiPackage.name
+    : firstHeading(markdown) ?? 'Gluon documentation';
+  const description = apiPackage?.description
+    ?? firstParagraph(markdown)
+    ?? 'Versioned Gluon framework documentation.';
   if (slash(page.relative) === `${versions.latest}/index.md`) {
     content = content.replace(
       /<h2([^>]*)>(.*?)<\/h2>\n<p>(.*?)<\/p>\n<p>(.*?)<\/p>/gs,
@@ -204,11 +221,37 @@ function pageUrl(relativePath) {
 
 function rewriteMarkdownLink(href) {
   const [path, hash = ''] = href.split('#');
+  if (/^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(path)) return href;
   if (!path.endsWith('.md')) return href;
   const rewritten = path.endsWith('README.md')
     ? `${path.slice(0, -'README.md'.length)}index.html`
     : path.replace(/\.md$/, '.html');
   return `${rewritten}${hash ? `#${hash}` : ''}`;
+}
+
+function packageForApiPage(relativePath) {
+  const normalized = slash(relativePath);
+  const marker = `${versions.latest}/api/generated/`;
+  if (!normalized.startsWith(marker)) return undefined;
+  const generatedPath = normalized.slice(marker.length).replace(/\/[^/]+$/, '');
+  const entry = packageContract.packages
+    .filter((candidate) => candidate.state === 'current')
+    .sort((left, right) => right.directory.length - left.directory.length)
+    .find((candidate) => {
+      const sourceRoot = candidate.directory === '.' ? 'src' : `${candidate.directory}/src`;
+      return generatedPath === sourceRoot || generatedPath.startsWith(`${sourceRoot}/`);
+    });
+  return entry ? packageMetadata.get(entry.name) : undefined;
+}
+
+function isApiPackageLanding(relativePath) {
+  return slash(relativePath).endsWith('/README.md');
+}
+
+function rewriteApiBreadcrumb(markdown, packageName) {
+  return markdown
+    .replace(/^\[\*\*@gluonjs\/core\*\*\]/m, `[**${packageName}**]`)
+    .replace(/^\[@gluonjs\/core\]/m, `[${packageName}]`);
 }
 
 function firstHeading(markdown) {

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -31,6 +31,7 @@ for (const version of versions.supported) {
   ]) await access(resolve(outputRoot, version, page));
 }
 await access(resolve(outputRoot, 'archive/index.html'));
+await access(resolve(outputRoot, 'latest/index.html'));
 await access(resolve(outputRoot, 'assets/docs.css'));
 await access(resolve(outputRoot, 'assets/docs.js'));
 const docsStyles = await readFile(resolve(outputRoot, 'assets/docs.css'), 'utf8');
@@ -45,6 +46,22 @@ const apiIndex = await readFile(resolve(root, '.tmp/docs-api/README.md'), 'utf8'
 const documentedEntryPoints = (apiIndex.match(/^- \[[^\]]+\]\([^\)]+README\.md\)$/gm) ?? []).length;
 if (documentedEntryPoints !== expectedEntryPoints) {
   throw new Error(`API reference documents ${documentedEntryPoints} entry points; package contract requires ${expectedEntryPoints}`);
+}
+
+for (const entry of packageContract.packages.filter((candidate) => candidate.state === 'current')) {
+  const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
+  const sourceRoot = entry.directory === '.' ? 'src' : `${entry.directory}/src`;
+  const htmlPath = resolve(outputRoot, versions.latest, 'api/generated', sourceRoot, 'index.html');
+  const html = await readFile(htmlPath, 'utf8');
+  if (!html.includes(`<title>${escapeHtml(entry.name)} · Gluon ${versions.latest}</title>`)) {
+    throw new Error(`${entry.name} API landing page has no package-specific title`);
+  }
+  if (!html.includes(`<meta name="description" content="${escapeHtml(packageJson.description)}">`)) {
+    throw new Error(`${entry.name} API landing page has no package-specific description`);
+  }
+  if (!html.includes(`>${escapeHtml(entry.name)}</a>`)) {
+    throw new Error(`${entry.name} API landing page has no package-specific breadcrumb`);
+  }
 }
 
 const apiExampleManifest = JSON.parse(await readFile(resolve(root, '.tmp/api-examples/manifest.json'), 'utf8'));
@@ -272,11 +289,21 @@ for (const required of [
 
 const htmlFiles = await filesWithExtension(outputRoot, '.html');
 const missingLinks = [];
+const invalidExternalLinks = [];
 for (const file of htmlFiles) {
   const html = await readFile(file, 'utf8');
   for (const match of html.matchAll(/\shref="([^"]+)"/g)) {
     const href = match[1];
-    if (/^(?:https?:|mailto:|#)/.test(href)) continue;
+    if (/^(?:https?:|mailto:)/.test(href)) {
+      const external = href.startsWith('http') ? new URL(href) : undefined;
+      if (external?.hostname === 'github.com'
+        && external.pathname.startsWith('/marcmalerei/gluon/blob/')
+        && external.pathname.endsWith('.html')) {
+        invalidExternalLinks.push(`${slash(relative(outputRoot, file))} -> ${href}`);
+      }
+      continue;
+    }
+    if (href.startsWith('#')) continue;
     const currentRelative = slash(relative(outputRoot, file));
     const currentPath = currentRelative.endsWith('/index.html')
       ? `${base}${currentRelative.slice(0, -'index.html'.length)}`
@@ -292,6 +319,9 @@ for (const file of htmlFiles) {
   }
 }
 if (missingLinks.length > 0) throw new Error(`documentation has broken internal links:\n- ${missingLinks.join('\n- ')}`);
+if (invalidExternalLinks.length > 0) {
+  throw new Error(`documentation rewrote curated GitHub links to generated HTML:\n- ${invalidExternalLinks.join('\n- ')}`);
+}
 
 const exampleSources = (await filesWithExtension(resolve(siteRoot, 'examples'), '.ts'))
   .filter((file) => !file.endsWith('vite.config.ts'));
@@ -310,3 +340,4 @@ async function filesWithExtension(directory, extension) {
 }
 
 function slash(value) { return value.split(sep).join('/'); }
+function escapeHtml(value) { return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }


### PR DESCRIPTION
Closes #375

## What changed

- preserve absolute and protocol-relative Markdown links during static rendering
- rewrite repository-local Storybook references to canonical GitHub Markdown URLs
- derive API package titles, descriptions, and breadcrumbs from the package contract and package manifests
- publish and validate the stable `/latest/` documentation redirect
- validate that curated GitHub links never point to generated `.html` paths
- update the documentation build contract to describe the derived metadata and current symbol coverage

## Verification

- `npm run check:docs`
- 895 generated documentation pages
- 36 public entry points
- 828 curated API examples
- 16 compiled documentation examples