### PR TITLE
Add generated package documentation portal

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -62,6 +62,16 @@ The root redirect and the stable `/latest/` alias both resolve to the latest
 supported version. API landing pages derive their title, description, and
 breadcrumb from the package contract and package manifest rather than from the
 TypeDoc root label.
+The generated package portal lives at `/<version>/packages/` and creates one
+landing page for every current package declared by `package-contract.json`.
+Each landing page is derived from the package manifest and README, and exposes
+purpose, installation, runtime, version, license, public exports, dependencies,
+peer dependencies, starter code, API links, and maintained scope limits. The
+portal index includes a request-free client-side package search and keeps the
+same package navigation on desktop and mobile.
+The root package and every package manifest use the stable
+`https://marcmalerei.github.io/gluon/latest/packages/<slug>/` page as their
+homepage; source README links remain explicit inside the portal.
 The maintained component guide is the beginner entry point for properties,
 attributes, events, lifecycle ownership, and the complete public class map.
 TypeDoc excludes externally inherited DOM members so an API page keeps its

--- a/docs-site/assets/docs.css
+++ b/docs-site/assets/docs.css
@@ -82,6 +82,36 @@ button, select { font: inherit; }
 .site-footer > * { padding-left: 30px; }
 .site-footer a { color: var(--cobalt); }
 
+.package-page .sidebar nav { max-height: calc(100vh - var(--header-height) - 32px); overflow: auto; }
+.package-page .sidebar a { font-size: 13px; }
+.package-page .content article { max-width: 940px; }
+.package-page .eyebrow, .package-kicker { margin: 0 0 16px; color: var(--cobalt); font: 12px/1.3 "SFMono-Regular", Consolas, monospace; letter-spacing: .06em; text-transform: uppercase; }
+.package-page .package-lede { max-width: 720px; font-size: clamp(19px, 2.2vw, 25px); }
+.package-search { display: grid; gap: 8px; max-width: 560px; margin: 44px 0 8px; color: var(--muted); font-size: 13px; font-weight: 700; }
+.package-search input { min-height: 48px; border: 1px solid var(--ink); padding: 0 14px; color: var(--ink); background: var(--paper); font: inherit; }
+.package-search-status { color: var(--muted); font-size: 13px; }
+.package-cards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; margin-top: 26px; }
+.package-card { display: flex; min-height: 230px; flex-direction: column; padding: 24px; border: 1px solid var(--rule); background: var(--paper); }
+.package-card[hidden] { display: none; }
+.package-card h2 { margin: 0 0 12px; padding: 0; border: 0; font-size: clamp(24px, 3vw, 34px); }
+.package-card p { margin-top: 0; }
+.package-card-meta { display: flex; justify-content: space-between; align-items: center; gap: 14px; margin-top: auto !important; padding-top: 22px; color: var(--muted); font-size: 12px; }
+.package-card-meta a { white-space: nowrap; }
+.package-actions { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin: 30px 0 36px; }
+.package-primary-action { display: inline-grid; min-height: 48px; place-items: center; padding: 0 22px; background: var(--chartreuse); color: var(--ink); }
+.package-facts { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border-top: 1px solid var(--ink); border-bottom: 1px solid var(--ink); }
+.package-facts div { display: grid; gap: 4px; min-height: 86px; padding: 16px 14px 14px 0; border-right: 1px solid var(--rule); }
+.package-facts div + div { padding-left: 14px; }
+.package-facts div:last-child { border-right: 0; }
+.package-facts strong { color: var(--muted); font: 11px/1.2 "SFMono-Regular", Consolas, monospace; text-transform: uppercase; }
+.package-facts span { overflow-wrap: anywhere; }
+.package-list { padding-left: 22px; }
+.package-list li { margin: 8px 0; }
+.package-columns { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; }
+.package-columns h3 { margin-top: 0; }
+.package-readme-link { margin-top: 44px; padding-top: 20px; border-top: 1px solid var(--rule); }
+.package-toc p { color: var(--muted); font-size: 13px; }
+
 @media (max-width: 1050px) {
   .site-grid { grid-template-columns: var(--sidebar-width) minmax(0, 1fr); }
   .toc { display: none; }
@@ -116,6 +146,12 @@ button, select { font: inherit; }
   .doc-home .content .home-row p:last-child { margin-bottom: 0; text-align: left; }
   .site-footer { grid-template-columns: 1fr 1fr; gap: 12px; min-height: 132px; padding: 18px; font-size: 12px; }
   .site-footer > * { padding-left: 0; }
+  .package-cards, .package-columns { grid-template-columns: 1fr; }
+  .package-facts { grid-template-columns: 1fr 1fr; }
+  .package-facts div:nth-child(2) { border-right: 0; }
+  .package-facts div:nth-child(n + 3) { border-top: 1px solid var(--rule); }
+  .package-facts div:nth-child(3) { padding-left: 0; }
+  .package-facts div:nth-child(4) { padding-left: 14px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs-site/assets/docs.js
+++ b/docs-site/assets/docs.js
@@ -54,3 +54,18 @@ const syncSidebar = () => {
 };
 mobile.addEventListener('change', syncSidebar);
 syncSidebar();
+
+const packageSearch = document.querySelector('[data-package-search]');
+const packageCards = [...document.querySelectorAll('[data-package-card]')];
+const packageSearchStatus = document.querySelector('[data-package-search-status]');
+packageSearch?.addEventListener('input', () => {
+  if (!(packageSearch instanceof HTMLInputElement)) return;
+  const query = packageSearch.value.trim().toLocaleLowerCase();
+  let visible = 0;
+  for (const card of packageCards) {
+    const match = !query || (card.getAttribute('data-package-search-text') ?? '').toLocaleLowerCase().includes(query);
+    card.hidden = !match;
+    if (match) visible += 1;
+  }
+  if (packageSearchStatus) packageSearchStatus.textContent = `${visible} package${visible === 1 ? '' : 's'}`;
+});

--- a/docs-site/content/1.8.1/api/index.md
+++ b/docs-site/content/1.8.1/api/index.md
@@ -9,6 +9,10 @@ New to Gluon? Start with [Components: properties, events, and lifecycle](../guid
 before using the signature reference. Its class map explains which public class
 to construct, subclass, receive as an error, or reserve for tooling.
 
+Use the [package portal](/gluon/1.8.1/packages/) to compare every current
+package's purpose, runtime, installation command, peers, public exports, and
+supported scope before opening generated symbol documentation.
+
 ## Runtime
 
 - [`@gluonjs/core`](generated/src/)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/marcmalerei/gluon.git"
   },
-  "homepage": "https://github.com/marcmalerei/gluon#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/core/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/atoms/package.json
+++ b/packages/atoms/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/atoms"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/atoms#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/atoms/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/compiler"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/compiler#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/compiler/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/create-gluon/package.json
+++ b/packages/create-gluon/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/create-gluon"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/create-gluon#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/create-gluon/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/devtools-api/package.json
+++ b/packages/devtools-api/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/devtools-api"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/devtools-api#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/devtools-api/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/devtools"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/devtools#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/devtools/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/gluon-components-vite/package.json
+++ b/packages/gluon-components-vite/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/gluon-components-vite"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/gluon-components-vite#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/gluon-components-vite/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/graph"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/graph#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/graph/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/i18n"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/i18n#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/i18n/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/json-forms/package.json
+++ b/packages/json-forms/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/json-forms"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/json-forms#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/json-forms/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/language-server"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/language-server#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/language-server/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/molecules/package.json
+++ b/packages/molecules/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/molecules"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/molecules#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/molecules/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/organisms/package.json
+++ b/packages/organisms/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/organisms"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/organisms#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/organisms/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/quarks/package.json
+++ b/packages/quarks/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/quarks"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/quarks#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/quarks/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/reactivity/package.json
+++ b/packages/reactivity/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/reactivity"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/reactivity#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/reactivity/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/router"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/router#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/router/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/ssr/package.json
+++ b/packages/ssr/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/ssr"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/ssr#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/ssr/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/store"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/store#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/store/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/test-utils"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/test-utils#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/test-utils/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/vite"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/vite#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/vite/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/packages/vue-migration-analyzer/package.json
+++ b/packages/vue-migration-analyzer/package.json
@@ -10,7 +10,7 @@
     "url": "git+https://github.com/marcmalerei/gluon.git",
     "directory": "packages/vue-migration-analyzer"
   },
-  "homepage": "https://github.com/marcmalerei/gluon/tree/main/packages/vue-migration-analyzer#readme",
+  "homepage": "https://marcmalerei.github.io/gluon/latest/packages/vue-migration-analyzer/",
   "bugs": {
     "url": "https://github.com/marcmalerei/gluon/issues"
   },

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -15,7 +15,14 @@ const packageMetadata = new Map(await Promise.all(
     .filter((entry) => entry.state === 'current')
     .map(async (entry) => {
       const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
-      return [entry.name, { name: entry.name, entry, description: packageJson.description }];
+      const readme = await readFile(resolve(root, entry.directory, 'README.md'), 'utf8');
+      return [entry.name, {
+        name: entry.name,
+        entry,
+        packageJson,
+        readme,
+        description: packageJson.description,
+      }];
     }),
 ));
 
@@ -39,6 +46,7 @@ const apiPages = (await markdownFiles(apiRoot)).map((source) => ({
 const pages = [...maintainedPages, ...apiPages];
 
 for (const page of pages) await renderPage(page);
+for (const version of versions.supported) await renderPackagePortal(version);
 await writeRedirect(resolve(outputRoot, 'index.html'), `${base}${versions.latest}/`);
 await mkdir(resolve(outputRoot, 'latest'), { recursive: true });
 await writeRedirect(resolve(outputRoot, 'latest', 'index.html'), `${base}${versions.latest}/`);
@@ -254,6 +262,128 @@ function rewriteApiBreadcrumb(markdown, packageName) {
     .replace(/^\[@gluonjs\/core\]/m, `[${packageName}]`);
 }
 
+async function renderPackagePortal(version) {
+  const packages = [...packageMetadata.values()].sort((left, right) => left.name.localeCompare(right.name));
+  await writePackagePage(version, undefined, packages);
+  for (const packageInfo of packages) await writePackagePage(version, packageInfo, packages);
+}
+
+async function writePackagePage(version, packageInfo, packages) {
+  const destination = packageInfo
+    ? resolve(outputRoot, version, 'packages', packageSlug(packageInfo.name), 'index.html')
+    : resolve(outputRoot, version, 'packages', 'index.html');
+  await mkdir(dirname(destination), { recursive: true });
+  const title = packageInfo ? packageInfo.name : 'Gluon packages';
+  const description = packageInfo?.description ?? 'Choose a Gluon package by purpose, runtime, and public entry point.';
+  const content = packageInfo
+    ? packageDetailContent(version, packageInfo)
+    : packageIndexContent(version, packages);
+  await writeFile(destination, packagePageShell({ version, title, description, content, packageInfo, packages }), 'utf8');
+}
+
+function packagePageShell({ version, title, description, content, packageInfo, packages }) {
+  const currentUrl = packageInfo
+    ? `${base}${version}/packages/${packageSlug(packageInfo.name)}/`
+    : `${base}${version}/packages/`;
+  const packageNavigation = [
+    `<a href="${base}${version}/packages/"${packageInfo ? '' : ' aria-current="page"'}>All packages</a>`,
+    ...packages.map((entry) => `<a href="${base}${version}/packages/${packageSlug(entry.name)}/"${entry.name === packageInfo?.name ? ' aria-current="page"' : ''}>${escapeHtml(entry.name)}</a>`),
+  ].join('');
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="description" content="${escapeHtml(description)}">
+    <title>${escapeHtml(title)} · Gluon ${version}</title>
+    <link rel="stylesheet" href="${base}assets/docs.css">
+    <link rel="canonical" href="https://marcmalerei.github.io${currentUrl}">
+  </head>
+  <body class="package-page${packageInfo ? '' : ' package-home'}">
+    <a class="skip-link" href="#content">Skip to content</a>
+    <header class="site-header">
+      <button class="menu-button" type="button" aria-label="Open package navigation" aria-expanded="false" data-menu-button><span></span><span></span></button>
+      <a class="brand" href="${base}${version}/">GLUON / PACKAGES</a>
+      <nav class="header-nav" aria-label="Documentation"><a href="${base}${version}/guides/">Guides</a><a href="${base}${version}/api/">API</a><a href="${base}${version}/cookbook/">Cookbook</a><a href="${base}${version}/packages/" aria-current="page">Packages</a></nav>
+      <label class="version-control"><span>Docs version</span><select data-version-select>${versions.supported.map((entry) => `<option value="${entry}"${entry === version ? ' selected' : ''}>${entry}</option>`).join('')}</select></label>
+      <a class="playground-action" href="${base}playground/">Playground</a>
+    </header>
+    <div class="site-grid package-grid">
+      <aside class="sidebar" aria-label="Gluon packages" data-sidebar><nav>${packageNavigation}</nav></aside>
+      <main id="content" class="content"><article>${content}</article></main>
+      <aside class="toc package-toc" aria-label="Package context"><strong>${packageInfo ? 'Package context' : 'Package map'}</strong><p>${packageInfo ? 'Public package boundary and release metadata.' : `${packages.length} current packages in the lockstep train.`}</p></aside>
+    </div>
+    <footer class="site-footer"><span>Gluon ${version}</span><a href="${base}${version}/">Documentation</a><a href="https://github.com/marcmalerei/gluon">GitHub</a><a href="${base}archive/">Release archive</a></footer>
+    <script type="module" src="${base}assets/docs.js"></script>
+  </body>
+</html>`;
+}
+
+function packageIndexContent(version, packages) {
+  const cards = packages.map((entry) => `<article class="package-card" data-package-card data-package-search-text="${escapeAttribute(`${entry.name} ${entry.description} ${entry.entry.environment}`)}">
+  <p class="package-kicker">${escapeHtml(entry.entry.environment)} package</p>
+  <h2><a href="${base}${version}/packages/${packageSlug(entry.name)}/">${escapeHtml(entry.name)}</a></h2>
+  <p>${escapeHtml(entry.description)}</p>
+  <p class="package-card-meta"><code>${escapeHtml(entry.entry.exports.length)} public export${entry.entry.exports.length === 1 ? '' : 's'}</code><a href="${base}${version}/packages/${packageSlug(entry.name)}/">Open package →</a></p>
+</article>`).join('');
+  return `<p class="eyebrow">${packages.length} packages · lockstep release train</p>
+<h1>Build with the package that owns the boundary.</h1>
+<p class="package-lede">Gluon is split into small public entry points. Find a package by capability, verify its runtime and peers, then open its API reference and runnable starter.</p>
+<label class="package-search"><span>Search packages</span><input type="search" placeholder="Search by name or capability" data-package-search></label>
+<p class="package-search-status" data-package-search-status aria-live="polite">${packages.length} packages</p>
+<section class="package-cards" aria-label="Gluon packages">${cards}</section>`;
+}
+
+function packageDetailContent(version, packageInfo) {
+  const { entry, packageJson, readme } = packageInfo;
+  const sourceReadmeUrl = entry.directory === '.'
+    ? 'https://github.com/marcmalerei/gluon#readme'
+    : `https://github.com/marcmalerei/gluon/tree/main/${entry.directory}#readme`;
+  const apiLinks = entry.exports.map((exportName) => {
+    const subpath = exportName === '.' ? '' : `/${exportName.slice(2)}`;
+    const sourceRoot = entry.directory === '.' ? 'src' : `${entry.directory}/src`;
+    return `<li><a href="${base}${version}/api/generated/${sourceRoot}${subpath}/">${escapeHtml(exportName === '.' ? entry.name : `${entry.name}${subpath}`)}</a></li>`;
+  }).join('');
+  const dependencies = [...new Set([
+    ...(entry.dependencies ?? []).map((name) => `${name} · runtime dependency`),
+    ...Object.keys(packageJson.dependencies ?? {}).filter((name) => !name.startsWith('@gluonjs/')).map((name) => `${name} · runtime dependency`),
+  ])];
+  const peers = Object.entries(packageJson.peerDependencies ?? {}).map(([name, range]) => {
+    const optional = packageJson.peerDependenciesMeta?.[name]?.optional ? ' · optional' : '';
+    return `${name}@${range}${optional}`;
+  });
+  const readmeCode = readme.match(/```(?:ts|tsx|js|sh|bash|html)\n([\s\S]+?)```/)?.[1]?.trim() ?? `import '${entry.name}';`;
+  const limits = readme.match(/(?:^|\n)## (?:[^\n]*(?:Limit|Support|Boundary|Compatibility|Scope)[^\n]*)\n([\s\S]*?)(?=\n## |$)/i)?.[1]
+    ?.trim()
+    .split(/\n\s*\n/)
+    .slice(0, 2)
+    .map((paragraph) => `<li>${escapeHtml(paragraph.replace(/\s+/g, ' '))}</li>`)
+    .join('')
+    ?? `<li>See the package README for the maintained scope and unsupported boundaries.</li>`;
+  const dependencyList = dependencies.length > 0 ? dependencies.map((dependency) => `<li>${escapeHtml(dependency)}</li>`).join('') : '<li>None</li>';
+  const peerList = peers.length > 0 ? peers.map((peer) => `<li>${escapeHtml(peer)}</li>`).join('') : '<li>None</li>';
+  return `<p class="eyebrow">Gluon ${escapeHtml(entry.environment)} package · ${escapeHtml(packageJson.version)}</p>
+<h1>${escapeHtml(packageInfo.name)}</h1>
+<p class="package-lede">${escapeHtml(packageInfo.description)}</p>
+<div class="package-actions"><a class="package-primary-action" href="https://www.npmjs.com/package/${encodeURIComponent(entry.name)}">npm package</a><a href="${sourceReadmeUrl}">Source README</a></div>
+<section class="package-facts" aria-label="Package facts"><div><strong>Runtime</strong><span>${escapeHtml(entry.environment)}</span></div><div><strong>Version</strong><span>${escapeHtml(packageJson.version)}</span></div><div><strong>License</strong><span>${escapeHtml(packageJson.license ?? 'MIT')}</span></div><div><strong>Exports</strong><span>${escapeHtml(String(entry.exports.length))}</span></div></section>
+<h2 id="install">Install and start</h2>
+<p>${entry.name === 'create-gluon' ? 'Scaffold a project with the maintained CLI:' : 'Install the public package at the same version as the rest of the Gluon train:'}</p>
+<figure class="code-frame"><figcaption><span>shell</span><button type="button" data-copy-code>Copy</button></figcaption><pre><code class="language-sh">${escapeHtml(entry.name === 'create-gluon' ? 'npm create gluon@latest my-app' : `npm install ${entry.name}`)}</code></pre></figure>
+<figure class="code-frame"><figcaption><span>starter</span><button type="button" data-copy-code>Copy</button></figcaption><pre><code class="language-ts">${escapeHtml(readmeCode)}</code></pre></figure>
+<h2 id="entry-points">Public entry points</h2>
+<p>Only these package exports are part of the supported public boundary.</p><ul class="package-list">${apiLinks}</ul>
+<h2 id="dependencies">Dependencies and peers</h2>
+<div class="package-columns"><div><h3>Installed dependencies</h3><ul class="package-list">${dependencyList}</ul></div><div><h3>Peer dependencies</h3><ul class="package-list">${peerList}</ul></div></div>
+<h2 id="api">API reference</h2>
+<p>Open an entry point above for generated symbol documentation and a reviewed example for every public symbol. Application code must import from this package entry point, never from repository source paths.</p>
+<h2 id="limits">Scope and limits</h2>
+<ul class="package-list">${limits}</ul>
+<p class="package-readme-link"><a href="${sourceReadmeUrl}">Read the complete ${escapeHtml(packageInfo.name)} README →</a></p>`;
+}
+
+function packageSlug(name) { return name === '@gluonjs/core' ? 'core' : name.replace(/^@gluonjs\//, ''); }
+
 function firstHeading(markdown) {
   return /^#\s+(.+)$/m.exec(markdown)?.[1].replace(/[`*_]/g, '').trim();
 }
@@ -274,6 +404,7 @@ function normalizeBase(value) {
 
 function slash(value) { return value.split(sep).join('/'); }
 function escapeHtml(value) { return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }
+function escapeAttribute(value) { return escapeHtml(value).replaceAll("'", '&#39;'); }
 
 async function writeRedirect(path, target) {
   await writeFile(path, `<!doctype html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0;url=${target}"><link rel="canonical" href="${target}"><title>Gluon documentation</title></head><body><a href="${target}">Open Gluon documentation</a></body></html>`, 'utf8');

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -32,6 +32,41 @@ for (const version of versions.supported) {
 }
 await access(resolve(outputRoot, 'archive/index.html'));
 await access(resolve(outputRoot, 'latest/index.html'));
+await access(resolve(outputRoot, versions.latest, 'packages/index.html'));
+
+const currentPackages = packageContract.packages.filter((entry) => entry.state === 'current');
+const packageIndexHtml = await readFile(resolve(outputRoot, versions.latest, 'packages/index.html'), 'utf8');
+if ((packageIndexHtml.match(/data-package-card/g) ?? []).length !== currentPackages.length) {
+  throw new Error(`package portal lists ${(packageIndexHtml.match(/data-package-card/g) ?? []).length} packages; contract requires ${currentPackages.length}`);
+}
+for (const entry of currentPackages) {
+  const packageSlug = entry.name === '@gluonjs/core' ? 'core' : entry.name.replace(/^@gluonjs\//, '');
+  const packageHtml = await readFile(resolve(outputRoot, versions.latest, 'packages', packageSlug, 'index.html'), 'utf8');
+  const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
+  for (const required of [
+    `<title>${entry.name} · Gluon ${versions.latest}</title>`,
+    `<meta name="description" content="${escapeHtml(packageJson.description)}">`,
+    'Install and start',
+    'Public entry points',
+    'Dependencies and peers',
+    'Scope and limits',
+  ]) if (!packageHtml.includes(required)) throw new Error(`${entry.name} package portal is missing: ${required}`);
+}
+
+for (const entry of currentPackages) {
+  const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
+  const sourceRoot = entry.directory === '.' ? 'src' : `${entry.directory}/src`;
+  const html = await readFile(resolve(outputRoot, versions.latest, 'api/generated', sourceRoot, 'index.html'), 'utf8');
+  if (!html.includes(`<title>${escapeHtml(entry.name)} · Gluon ${versions.latest}</title>`)) {
+    throw new Error(`${entry.name} API landing page has no package-specific title`);
+  }
+  if (!html.includes(`<meta name="description" content="${escapeHtml(packageJson.description)}">`)) {
+    throw new Error(`${entry.name} API landing page has no package-specific description`);
+  }
+  if (!html.includes(`>${escapeHtml(entry.name)}</a>`)) {
+    throw new Error(`${entry.name} API landing page has no package-specific breadcrumb`);
+  }
+}
 await access(resolve(outputRoot, 'assets/docs.css'));
 await access(resolve(outputRoot, 'assets/docs.js'));
 const docsStyles = await readFile(resolve(outputRoot, 'assets/docs.css'), 'utf8');
@@ -46,22 +81,6 @@ const apiIndex = await readFile(resolve(root, '.tmp/docs-api/README.md'), 'utf8'
 const documentedEntryPoints = (apiIndex.match(/^- \[[^\]]+\]\([^\)]+README\.md\)$/gm) ?? []).length;
 if (documentedEntryPoints !== expectedEntryPoints) {
   throw new Error(`API reference documents ${documentedEntryPoints} entry points; package contract requires ${expectedEntryPoints}`);
-}
-
-for (const entry of packageContract.packages.filter((candidate) => candidate.state === 'current')) {
-  const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
-  const sourceRoot = entry.directory === '.' ? 'src' : `${entry.directory}/src`;
-  const htmlPath = resolve(outputRoot, versions.latest, 'api/generated', sourceRoot, 'index.html');
-  const html = await readFile(htmlPath, 'utf8');
-  if (!html.includes(`<title>${escapeHtml(entry.name)} · Gluon ${versions.latest}</title>`)) {
-    throw new Error(`${entry.name} API landing page has no package-specific title`);
-  }
-  if (!html.includes(`<meta name="description" content="${escapeHtml(packageJson.description)}">`)) {
-    throw new Error(`${entry.name} API landing page has no package-specific description`);
-  }
-  if (!html.includes(`>${escapeHtml(entry.name)}</a>`)) {
-    throw new Error(`${entry.name} API landing page has no package-specific breadcrumb`);
-  }
 }
 
 const apiExampleManifest = JSON.parse(await readFile(resolve(root, '.tmp/api-examples/manifest.json'), 'utf8'));

--- a/scripts/validate-package-contract.mjs
+++ b/scripts/validate-package-contract.mjs
@@ -90,6 +90,11 @@ async function validateCurrentPackage(entry) {
   if (packageJson.name !== entry.name) {
     throw new Error(`${entry.name} does not match ${packageJson.name} in package.json.`);
   }
+  const packageSlug = entry.name === '@gluonjs/core' ? 'core' : entry.name.replace(/^@gluonjs\//, '');
+  const expectedHomepage = `https://marcmalerei.github.io/gluon/latest/packages/${packageSlug}/`;
+  if (packageJson.homepage !== expectedHomepage) {
+    throw new Error(`${entry.name} homepage must point to its version-independent package portal page.`);
+  }
   if (packageJson.license !== 'MIT') {
     throw new Error(`${entry.name} must declare the authorized MIT license.`);
   }


### PR DESCRIPTION
Closes #376

## What changed

- generate a versioned package portal at `/<version>/packages/` from `package-contract.json` and real package manifests/READMEs
- publish all 21 current package landing pages with purpose, install command, runtime, version, license, exports, dependencies, peers, starter code, API links, and scope limits
- add a request-free package search and shared package navigation with mobile layout
- link the API overview to the package portal
- make package npm homepages resolve through the stable `/latest/packages/<slug>/` URLs while keeping source README links explicit
- validate package page count, metadata, content sections, stable aliases, and all generated links

## Verification

- `npm run check:docs`
- `npm run check:packages`
- real-browser desktop/mobile smoke check for package search and `@gluonjs/reactivity` detail navigation
- 917 generated documentation pages
- 21/21 package contracts