### PR TITLE
docs: finalize v1.9.0 release state

### DIFF
--- a/docs-site/content/1.9.0/guides/releasing/index.md
+++ b/docs-site/content/1.9.0/guides/releasing/index.md
@@ -2,15 +2,17 @@
 
 The `1.9.0` documentation describes the completed lockstep release. All 21
 official manifests are at `1.9.0`, and the protected release workflow published
-`1.9.0` as the latest package train with npm provenance. Issue
-[#367](https://github.com/marcmalerei/gluon/issues/367) delivered retained
-nested SSR hydration and request-local abort propagation. The release cut
-retains a Quality-Gates-tested candidate followed only by its release-cut
-evidence and compatibility manifest.
+`1.9.0` as the latest package train with npm provenance. Issues
+[#375-#384](https://github.com/marcmalerei/gluon/issues/375) delivered the
+platform-hardening, package-documentation, accessibility, tooling, routing,
+forms, i18n, JSON Forms, and SSR work tracked by epic
+[#374](https://github.com/marcmalerei/gluon/issues/374). The release cut retains
+a Quality-Gates-tested candidate followed only by its release-cut evidence and
+compatibility manifest.
 
 The immutable GitHub release is [`v1.9.0`](https://github.com/marcmalerei/gluon/releases/tag/v1.9.0),
-published from `b1c2feeeffd5e1ac6bba2607cf1fae95642e60ab`. Protected workflow
-run [31580641519](https://github.com/marcmalerei/gluon/actions/runs/31580641519)
+published from `06dc45457bbf9a109ae67f5048db8be63f0fda39`. Protected workflow
+run [31890472642](https://github.com/marcmalerei/gluon/actions/runs/31890472642)
 passed browser, Node, reproducibility, clean-room registry, and publication
 verification for all 21 packages.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -7,14 +7,17 @@ and `.github/workflows/release.yml` is the only supported publication path.
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.9.0` candidate. Every official
-manifest is public and lockstep at `1.9.0`. Registry preflight on 2026-08-15
-confirmed that all 21 package records expose `1.8.1` as `latest` and that
-`1.9.0` is absent. The immutable GitHub release `v1.8.1` remains the current
-finalized release until the protected `1.9.0` workflow completes. The
-`v1.0.9` GitHub release remains a draft after its public-type verification
-failure. This is enforced locally by:
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for `1.9.0`. Every official manifest is public and
+lockstep at `1.9.0`. Protected release workflow
+[31890472642](https://github.com/marcmalerei/gluon/actions/runs/31890472642)
+published all 21 package records to `latest` with provenance and verified the
+train from a clean directory. The immutable GitHub release
+[`v1.9.0`](https://github.com/marcmalerei/gluon/releases/tag/v1.9.0) was
+published on 2026-08-15 from tag commit
+`06dc45457bbf9a109ae67f5048db8be63f0fda39` with 101 reviewed assets. The
+`v1.0.9` GitHub release remains a historical draft after its public-type
+verification failure. This is enforced locally by:
 
 ```sh
 npm run check:release-contract
@@ -22,12 +25,14 @@ npm run check:release-contract
 
 ## v1.9.0 train handoff
 
-Issue [#374](https://github.com/marcmalerei/gluon/issues/374) establishes the
+Issue [#374](https://github.com/marcmalerei/gluon/issues/374) established the
 21-package `1.9.0` train for the platform-hardening and application-primitive
-work delivered by issues #375-#384. The train uses the two-commit release cut:
-a Quality-Gates-tested candidate followed only by its release-cut evidence and
-compatibility manifest. The immutable `v1.8.1` release remains the supported
-baseline until the protected `1.9.0` workflow completes.
+work delivered by issues #375-#384. PR
+[#388](https://github.com/marcmalerei/gluon/pull/388) merged the tested
+candidate and its release-cut evidence as a preserved merge commit. The
+protected tag workflow completed candidate, reproducibility, browser-engine,
+Node-runtime, performance, fixture, registry, provenance, and publication
+checks. `v1.9.0` is now the supported `latest` baseline.
 
 ## v1.8.1 train completion
 

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-08-15",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-08-15 confirmed that all 21 contracted package records expose 1.8.1 as latest and that version 1.9.0 is absent. Scope control and trusted publication remain verified by the completed 1.8.1 release contract."
+    "publicationState": "released",
+    "observation": "Protected release workflow 31890472642 completed successfully on 2026-08-15: all 21 contracted package records were published to latest at 1.9.0 with provenance and verified from a clean directory. Immutable GitHub release v1.9.0 was published from tag commit 06dc45457bbf9a109ae67f5048db8be63f0fda39 with 101 reviewed assets."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary
- mark the 21-package contract as released after protected workflow 31890472642
- record the immutable v1.9.0 release and npm latest verification
- correct the root and versioned release handoff documentation

Related to #374