### PR TITLE
Fix stable GitHub Pages latest deep links

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -58,10 +58,12 @@ symbol coverage fail `npm run docs:api`.
 migration material, examples, and release archive. `validate-docs.mjs` verifies
 the version tree, public API entry-point count, one rendered example per public
 symbol page, required curated content, compiled examples, and internal links.
-The root redirect and the stable `/latest/` alias both resolve to the latest
-supported version. API landing pages derive their title, description, and
-breadcrumb from the package contract and package manifest rather than from the
-TypeDoc root label.
+The root redirect resolves to the latest supported version, and the stable
+`/latest/` tree is a static mirror of that version so deep links under
+`/latest/` keep working on GitHub Pages while preserving versioned canonical
+URLs. API landing pages derive their title, description, and breadcrumb from
+the package contract and package manifest rather than from the TypeDoc root
+label.
 The generated package portal lives at `/<version>/packages/` and creates one
 landing page for every current package declared by `package-contract.json`.
 Each landing page is derived from the package manifest and README, and exposes
@@ -72,6 +74,9 @@ same package navigation on desktop and mobile.
 The root package and every package manifest use the stable
 `https://marcmalerei.github.io/gluon/latest/packages/<slug>/` page as their
 homepage; source README links remain explicit inside the portal.
+This docs-only fix does not change `examples/shop`, because the regression is
+limited to documentation generation and package-portal validation rather than an
+honest shop flow.
 The maintained component guide is the beginner entry point for properties,
 attributes, events, lifecycle ownership, and the complete public class map.
 TypeDoc excludes externally inherited DOM members so an API page keeps its

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "check:component-library-clean-install": "npm run build:component-library-package && node scripts/validate-component-library-clean-install.mjs",
     "check:component-library-loader-build": "npm run build:core && npm run build:compiler && npm run build:vite && npm run build:component-library && node scripts/validate-component-library-loader-build.mjs",
     "docs:api": "typedoc --options typedoc.json --treatWarningsAsErrors && node scripts/generate-api-examples.mjs",
-    "build:docs": "npm run docs:api && node scripts/build-docs.mjs && npm run build:docs-examples",
+    "build:docs": "npm run docs:api && node scripts/build-docs.mjs && npm run build:docs-examples && node scripts/mirror-latest-docs.mjs",
     "build:docs-examples": "vite build --config docs-site/examples/vite.config.ts",
     "dev:shop": "vite --config examples/shop/vite.config.ts",
     "dev:playground": "vite --config examples/playground/vite.config.ts",

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -48,8 +48,6 @@ const pages = [...maintainedPages, ...apiPages];
 for (const page of pages) await renderPage(page);
 for (const version of versions.supported) await renderPackagePortal(version);
 await writeRedirect(resolve(outputRoot, 'index.html'), `${base}${versions.latest}/`);
-await mkdir(resolve(outputRoot, 'latest'), { recursive: true });
-await writeRedirect(resolve(outputRoot, 'latest', 'index.html'), `${base}${versions.latest}/`);
 await writeFile(resolve(outputRoot, '404.html'), pageShell({
   title: 'Documentation page not found',
   description: 'The requested Gluon documentation page does not exist.',

--- a/scripts/mirror-latest-docs.mjs
+++ b/scripts/mirror-latest-docs.mjs
@@ -1,0 +1,9 @@
+import { cp, readFile, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const outputRoot = resolve(root, 'docs-site', 'dist');
+const version = JSON.parse(await readFile(resolve(root, 'docs-site', 'versions.json'), 'utf8')).latest;
+
+await rm(resolve(outputRoot, 'latest'), { recursive: true, force: true });
+await cp(resolve(outputRoot, version), resolve(outputRoot, 'latest'), { recursive: true });

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -33,6 +33,7 @@ for (const version of versions.supported) {
 await access(resolve(outputRoot, 'archive/index.html'));
 await access(resolve(outputRoot, 'latest/index.html'));
 await access(resolve(outputRoot, versions.latest, 'packages/index.html'));
+await access(resolve(outputRoot, 'latest', 'packages', 'index.html'));
 
 const currentPackages = packageContract.packages.filter((entry) => entry.state === 'current');
 const packageIndexHtml = await readFile(resolve(outputRoot, versions.latest, 'packages/index.html'), 'utf8');
@@ -65,6 +66,25 @@ for (const entry of currentPackages) {
   }
   if (!html.includes(`>${escapeHtml(entry.name)}</a>`)) {
     throw new Error(`${entry.name} API landing page has no package-specific breadcrumb`);
+  }
+}
+for (const entry of currentPackages) {
+  const packageSlug = entry.name === '@gluonjs/core' ? 'core' : entry.name.replace(/^@gluonjs\//, '');
+  const latestPackageHtml = await readFile(resolve(outputRoot, 'latest', 'packages', packageSlug, 'index.html'), 'utf8');
+  if (!latestPackageHtml.includes(`<link rel="canonical" href="https://marcmalerei.github.io/gluon/${versions.latest}/packages/${packageSlug}/">`)) {
+    throw new Error(`${entry.name} package portal latest alias does not preserve the versioned canonical URL`);
+  }
+}
+for (const page of [
+  ['latest', 'index.html'],
+  ['latest', 'guides', 'components', 'index.html'],
+  ['latest', 'api', 'index.html'],
+  ['latest', 'migration', 'index.html'],
+  ['latest', 'migration', 'vue-to-gluon-cutover', 'index.html'],
+]) {
+  const html = await readFile(resolve(outputRoot, ...page), 'utf8');
+  if (!html.includes(`<link rel="canonical" href="https://marcmalerei.github.io/gluon/${versions.latest}/`)) {
+    throw new Error(`latest alias page is missing versioned canonical metadata: ${page.join('/')}`);
   }
 }
 await access(resolve(outputRoot, 'assets/docs.css'));


### PR DESCRIPTION
Closes #375

## Summary

- publish the complete current version tree under /latest after the docs examples build
- retain versioned canonical URLs for every mirrored page
- validate every official package page and representative guide, API, and migration deep links
- document the static-mirror ownership and why GLUON GOODS is unchanged

## Verification

- npm run build:compiler
- npm run build:core
- npm run build:vite
- npm run check:docs

A separate read-only mini-agent review found no actionable findings.
