### PR TITLE
Improve raw-text interpolation diagnostics

### DIFF
--- a/docs/dom-runtime.md
+++ b/docs/dom-runtime.md
@@ -16,7 +16,7 @@ unchanged, Gluon does not reset a dirty live property.
 | Control | Controlled binding | Uncontrolled binding | Contract |
 | --- | --- | --- | --- |
 | Text-like `input` | `.value=${value}` | `value=${initial}` | A render restores the controlled value; a user edit survives an unchanged uncontrolled render. |
-| `textarea` | `.value=${value}` | `.defaultValue=${initial}` | Dynamic textarea child interpolation is unsupported because the HTML parser treats its contents as raw text. `q.textarea({ children: initial })` maps primitive text to `.defaultValue`. |
+| `textarea` | `.value=${value}` | `.defaultValue=${initial}` | Dynamic textarea child interpolation is unsupported because the HTML parser treats its contents as raw text. `q.textarea({ children: initial })` maps primitive text to `.defaultValue`. Direct template child bindings inside `textarea`, `title`, `script`, and `style` throw a runtime error that points authors to a complete `.value` or text-safe binding instead. |
 | Checkbox | `.checked=${boolean}` | `?checked=${initial}` | Controlled state is restored; uncontrolled dirty state is preserved. |
 | Radio group | `.checked=${boolean}` on every member | `?checked=${initial}` | Native name/group exclusivity remains browser behavior. |
 | Single select | `.value=${string}` | `?selected=${initial}` on options | Controlled selection is restored; dirty uncontrolled selection is preserved. |

--- a/packages/quarks/README.md
+++ b/packages/quarks/README.md
@@ -18,6 +18,9 @@ requirement of the native element it selects. Void elements reject children.
 `q.textarea()` maps primitive `children` to the native `defaultValue` property
 because HTML parses textarea contents as raw text; use `.value` for controlled
 content. Template, Node, directive, and collection children are rejected.
+Direct template child interpolation inside raw-text and RCDATA elements
+(`textarea`, `title`, `script`, and `style`) is rejected with a runtime error
+that points to the supported complete binding form.
 
 `QuarkProps<ElementType>` has no general string index signature. It derives
 native scalar values and explicit property/boolean bindings from the target DOM

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1915,6 +1915,8 @@ function getCompiledTemplate(result: TemplateResult): CompiledTemplate {
   const element = document.createElement('template');
   const attributeNames = new Map<number, string>();
   const state = { inTag: false, quote: '' };
+  let markerPrefix = 'gluon:';
+  while (result.strings.some((chunk) => chunk.includes(`<!--${markerPrefix}`))) markerPrefix += '_';
   let markup = '';
 
   for (let index = 0; index < result.strings.length - 1; index += 1) {
@@ -1934,7 +1936,7 @@ function getCompiledTemplate(result: TemplateResult): CompiledTemplate {
       attributeNames.set(index, match[1]);
       markup += `__gluon_${index}__`;
     } else {
-      markup += `<!--gluon:${index}-->`;
+      markup += `<!--${markerPrefix}${index}-->`;
     }
   }
 
@@ -1946,13 +1948,17 @@ function getCompiledTemplate(result: TemplateResult): CompiledTemplate {
   } else {
     element.innerHTML = markup;
   }
-  const descriptors = buildDescriptors(element.content, attributeNames);
+  const descriptors = buildDescriptors(element.content, attributeNames, markerPrefix);
   const traversalDescriptors = [...descriptors].sort(
     (left, right) => left.traversalIndex - right.traversalIndex || left.index - right.index,
   );
   const expressionCount = result.strings.length - 1;
 
   if (descriptors.length !== expressionCount) {
+    const rawTextDiagnostic = getRawTextInterpolationDiagnostic(element.content, markerPrefix);
+    if (rawTextDiagnostic) {
+      throw new Error(rawTextDiagnostic);
+    }
     throw new Error(
       'Every Gluon expression must occupy a complete child or attribute value. '
       + 'Mixed attribute strings such as class="prefix ${value}" are not supported; '
@@ -1999,9 +2005,21 @@ function getCompiledTemplate(result: TemplateResult): CompiledTemplate {
   return compiled;
 }
 
+function getRawTextInterpolationDiagnostic(content: DocumentFragment, markerPrefix: string): string | undefined {
+  for (const element of content.querySelectorAll('script, style, textarea, title')) {
+    if (!(element.textContent ?? '').includes(`<!--${markerPrefix}`)) continue;
+    const tagName = element.localName;
+    return tagName === 'textarea'
+      ? 'Interpolation inside <textarea> is unsupported raw text; use .value=${value} for controlled content.'
+      : `Interpolation inside <${tagName}> is unsupported raw text; move the binding outside the element.`;
+  }
+  return undefined;
+}
+
 function buildDescriptors(
   content: DocumentFragment,
   attributeNames: ReadonlyMap<number, string>,
+  markerPrefix: string,
 ): PartDescriptor[] {
   const descriptors: PartDescriptor[] = [];
   const walker = document.createTreeWalker(
@@ -2015,13 +2033,13 @@ function buildDescriptors(
     const node = walker.currentNode;
 
     if (node.nodeType === Node.COMMENT_NODE) {
-      const match = (node as Comment).data.match(/^gluon:(\d+)$/);
-      if (match?.[1]) {
+      const marker = (node as Comment).data;
+      if (marker.startsWith(markerPrefix)) {
         const seededText = document.createTextNode('');
         node.parentNode!.insertBefore(seededText, node.nextSibling);
         descriptors.push({
           kind: 'node',
-          index: Number(match[1]),
+          index: Number(marker.slice(markerPrefix.length)),
           path: pathFromRoot(content, node),
           traversalIndex,
           seededText: true,

--- a/tests/runtime-edge-cases.spec.ts
+++ b/tests/runtime-edge-cases.spec.ts
@@ -150,10 +150,65 @@ describe('template runtime edge cases', () => {
     expect(button.value).toBe('undefined');
   });
 
-  it('rejects expressions that the HTML parser cannot represent as parts', () => {
+  it('rejects raw-text and RCDATA child expressions with targeted diagnostics', () => {
     const root = document.createElement('div');
-    const invalid = (value: string) => html`<textarea>${value}</textarea>`;
 
-    expect(() => render(invalid('content'), root)).toThrow(/complete child or attribute value/i);
+    const cases = [
+      { label: 'textarea', view: (value: string) => html`<textarea>${value}</textarea>`, pattern: /textarea/i },
+      { label: 'title', view: (value: string) => html`<title>${value}</title>`, pattern: /title/i },
+      { label: 'script', view: (value: string) => html`<script>${value}</script>`, pattern: /script/i },
+      { label: 'style', view: (value: string) => html`<style>${value}</style>`, pattern: /style/i },
+    ] as const;
+
+    for (const { view, pattern } of cases) {
+      expect(() => render(view('content'), root)).toThrow(pattern);
+    }
+  });
+
+  it('keeps mixed attribute diagnostics for partial attribute strings', () => {
+    const root = document.createElement('div');
+
+    expect(() => render(html`<p class="prefix ${'value'}"></p>`, root)).toThrow(/complete child or attribute value/i);
+    expect(() => render(html`<template>${'value'}</template>`, root)).toThrow(/complete child or attribute value/i);
+  });
+
+  it('ignores markup-like text and only exits raw-text content on the matching close tag', () => {
+    const root = document.createElement('div');
+
+    expect(() => render(html`<textarea>${'<div>'}${"'script'"}${'<!-- comment -->'}${'<TITLE>'}${'</not-the-tag>'}</textarea><p>${'after'}</p>`, root)).toThrow(
+      /textarea/i,
+    );
+    expect(() => render(html`<textarea>Before ${'<div>'}${'</textarea>'}</textarea><p>${'after'}</p>`, root)).toThrow(/textarea/i);
+  });
+
+  it('treats malformed closing fragments as inert raw-text content', () => {
+    const root = document.createElement('div');
+
+    expect(() => render(html`<textarea>${'</text'}${'area'}${'>'}</textarea>`, root)).toThrow(/textarea/i);
+    expect(() => render(html`<script>${'</scr'}${'ipt'}${'>'}</script>`, root)).toThrow(/script/i);
+  });
+
+  it('preserves state across template literal chunks before the diagnostic fires', () => {
+    const root = document.createElement('div');
+    const value = 'content';
+
+    expect(() => render(html`<textarea>${'first'}${'<div>'}${value}</textarea>`, root)).toThrow(/textarea/i);
+    expect(() => render(html`<style>${'a'}${'/* comment */'}${value}</style>`, root)).toThrow(/style/i);
+  });
+
+  it('allows a valid expression after the matching close tag', () => {
+    const root = document.createElement('div');
+
+    expect(() => render(html`<textarea>Static</textarea><p>${'after'}</p>`, root)).not.toThrow();
+    expect(root.querySelector('p')?.textContent).toBe('after');
+  });
+
+  it('keeps literal renderer-like markers distinct from generated expression markers', () => {
+    const root = document.createElement('div');
+
+    expect(() => render(html`<textarea>Literal <!--gluon:0--></textarea><p>${'after'}</p>`, root)).not.toThrow();
+    expect(root.querySelector('textarea')?.value).toContain('<!--gluon:0-->');
+    expect(root.querySelector('p')?.textContent).toBe('after');
+    expect(() => render(html`<textarea>Literal <!--gluon:0--> ${'dynamic'}</textarea>`, root)).toThrow(/textarea/i);
   });
 });


### PR DESCRIPTION
Closes #364

## Outcome
- detects unsupported interpolation inside textarea, title, script, and style raw-text/RCDATA content
- reports a targeted runtime error with a supported binding direction
- preserves the generic mixed-attribute diagnostic and metadata-free callers
- documents the runtime-only contract without claiming compiler or language-server support

## Evidence
- npx vitest run tests/runtime-edge-cases.spec.ts (10 passed)
- independent no-edit review: mergeable
- git diff --check

## Shop application
No honest customer-facing shop integration exists for this runtime diagnostic. The canonical shop remains unchanged.
