### PR TITLE
Add explicit package documentation metadata (#397)

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -66,11 +66,17 @@ the package contract and package manifest rather than from the TypeDoc root
 label.
 The generated package portal lives at `/<version>/packages/` and creates one
 landing page for every current package declared by `package-contract.json`.
-Each landing page is derived from the package manifest and README, and exposes
-purpose, installation, runtime, version, license, public exports, dependencies,
-peer dependencies, starter code, API links, and maintained scope limits. The
-portal index includes a request-free client-side package search and keeps the
-same package navigation on desktop and mobile.
+Each landing page is derived from the package manifest, `package-contract.json`,
+and the version-controlled `docs-site/package-docs.json` metadata contract.
+That metadata owns purpose, starter code and language, use cases, limits and
+non-goals, related guides, and verified integration notes. The package manifest
+and package contract continue to own installation, runtime, version, license,
+public entry points, dependencies, peer dependencies, npm links, source README
+links, and API links. The portal index includes a request-free client-side
+package search and keeps the same package navigation on desktop and mobile.
+This docs-only metadata change does not alter `examples/shop`; the regression is
+limited to documentation generation and docs validation, so the shop remains
+unchanged.
 The root package and every package manifest use the stable
 `https://marcmalerei.github.io/gluon/latest/packages/<slug>/` page as their
 homepage; source README links remain explicit inside the portal.

--- a/docs-site/package-docs.json
+++ b/docs-site/package-docs.json
@@ -1,0 +1,530 @@
+{
+  "version": 1,
+  "packages": [
+    {
+      "name": "@gluonjs/reactivity",
+      "purpose": "DOM-free reactive state primitives for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { computed, effect, reactive, ref } from '@gluonjs/reactivity';\n\nconst count = ref(1);\nconst state = reactive({ multiplier: 2 });\nconst total = computed(() => count.value * state.multiplier);\n\neffect(() => {\n  console.log(total.value);\n});"
+      },
+      "useCases": [
+        "Shared reactive state in browser, Node, and SSR code.",
+        "Signals-style derived state and side effects.",
+        "Core runtime ownership for packages that depend on reactive state."
+      ],
+      "limits": [
+        "Does not provide DOM, component, router, or store APIs.",
+        "Applications that need object lifetime, templating, or elements must use the owning package."
+      ],
+      "relatedGuides": [
+        { "label": "API reference", "href": "/gluon/latest/api/" },
+        { "label": "Application runtime", "href": "/gluon/latest/guides/application/" }
+      ],
+      "integrationNotes": [
+        "Peer dependencies include `@preact/signals-core` and `signal-polyfill`.",
+        "Package manifest exports `.` plus `./signals` and `./preact-signals`."
+      ]
+    },
+    {
+      "name": "@gluonjs/compiler",
+      "purpose": "Source transforms and template location tracking for Gluon tooling.",
+      "starter": {
+        "language": "ts",
+        "code": "import {\n  transformGluonModule,\n  type GluonTransformResult,\n} from '@gluonjs/compiler';\n\nconst source = `\n  import { html } from '@gluonjs/core';\n  export const ProductName = (name: string) => html\\`<h1>\\${name}</h1>\\`;\n`;\n\nconst result: GluonTransformResult = transformGluonModule(\n  source,\n  '/src/product-name.ts',\n  { development: true },\n);\n\nconsole.log(result.templates[0]?.tag); // \"html\"\nconsole.log(result.diagnostics); // source-located compiler diagnostics"
+      },
+      "useCases": [
+        "Track `html`, `svg`, `css`, and aliased `compose()` tagged templates.",
+        "Produce source maps and decorator transforms for tooling.",
+        "Support downstream Vite and language tooling packages."
+      ],
+      "limits": [
+        "Does not render templates or own runtime application state.",
+        "Does not replace the public component model with a private renderer format."
+      ],
+      "relatedGuides": [
+        { "label": "Tooling", "href": "/gluon/latest/guides/tooling/" },
+        { "label": "Diagnostics", "href": "/gluon/latest/reference/diagnostics/" }
+      ],
+      "integrationNotes": [
+        "Used by `@gluonjs/vite` and `@gluonjs/language-server`.",
+        "Public export surface includes `.` and `./diagnostics`."
+      ]
+    },
+    {
+      "name": "@gluonjs/core",
+      "purpose": "Browser runtime and component ownership boundary for Gluon applications.",
+      "starter": {
+        "language": "ts",
+        "code": "import { createApp, html } from '@gluonjs/core';\n\ncreateApp(() => html`<main>Hello Gluon</main>`).mount(document.body);"
+      },
+      "useCases": [
+        "Functional components and stateful custom elements.",
+        "Application mounting, rendering, and event ownership.",
+        "Style transport and public component helpers."
+      ],
+      "limits": [
+        "Does not bundle application features such as routing or storage.",
+        "Applications should import only public entry points, not repository source paths."
+      ],
+      "relatedGuides": [
+        { "label": "Getting started", "href": "/gluon/latest/guides/getting-started/" },
+        { "label": "Components", "href": "/gluon/latest/guides/components/" }
+      ],
+      "integrationNotes": [
+        "Exports `.` plus `./decorators` and `./styles`.",
+        "Owns the browser-only runtime boundary consumed by multiple packages."
+      ]
+    },
+    {
+      "name": "@gluonjs/router",
+      "purpose": "Official Gluon router with browser, hash, and memory histories.",
+      "starter": {
+        "language": "ts",
+        "code": "import { createRouter } from '@gluonjs/router';\n\nconst router = createRouter({\n  routes: [{ path: '/', component: () => import('./home.js') }],\n});"
+      },
+      "useCases": [
+        "Named routes, guards, lazy routes, and scroll restoration.",
+        "Browser, hash, and memory history strategies.",
+        "Application bindings that share the Gluon runtime context."
+      ],
+      "limits": [
+        "Does not own component rendering or application state storage.",
+        "History selection and guards live at the router boundary."
+      ],
+      "relatedGuides": [
+        { "label": "Application runtime", "href": "/gluon/latest/guides/application/" },
+        { "label": "Universal rendering", "href": "/gluon/latest/guides/universal-rendering/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core` and `@gluonjs/reactivity`.",
+        "Package exports `.` and `./memory`."
+      ]
+    },
+    {
+      "name": "@gluonjs/store",
+      "purpose": "Typed, application-scoped state management without a DOM dependency.",
+      "starter": {
+        "language": "ts",
+        "code": "import { createStoreManager, defineStore } from '@gluonjs/store';\n\nconst counter = defineStore('counter', () => ({ count: 0 }), {\n  increment(state) { state.count += 1; },\n});"
+      },
+      "useCases": [
+        "Shared state, getters, and actions for browser or server code.",
+        "Application-scoped store instances with typed inference.",
+        "Structured state ownership in larger Gluon apps."
+      ],
+      "limits": [
+        "Does not provide DOM access or component templating.",
+        "Applications needing reactive presentation still depend on Core and Reactivity."
+      ],
+      "relatedGuides": [
+        { "label": "Application", "href": "/gluon/latest/guides/application/" },
+        { "label": "Store", "href": "/gluon/latest/reference/support-matrix/" }
+      ],
+      "integrationNotes": [
+        "Peers on `@gluonjs/reactivity`.",
+        "Used by SSR and test utilities for application state scenarios."
+      ]
+    },
+    {
+      "name": "@gluonjs/i18n",
+      "purpose": "Locale-aware messages and lazy namespace loading for Gluon applications.",
+      "starter": {
+        "language": "ts",
+        "code": "import { createI18n, useI18n } from '@gluonjs/i18n';\n\nconst i18n = createI18n({ locale: 'en', fallbackLocale: 'en' });"
+      },
+      "useCases": [
+        "Translated messages for application UI.",
+        "Lazy-loaded locale namespaces and ready-state tracking.",
+        "Reactive language switching in browser apps."
+      ],
+      "limits": [
+        "Does not own routing, storage, or component rendering.",
+        "Applications without translated strings do not need this package."
+      ],
+      "relatedGuides": [
+        { "label": "Application runtime", "href": "/gluon/latest/guides/application/" },
+        { "label": "Components", "href": "/gluon/latest/guides/components/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core` and `@gluonjs/reactivity`.",
+        "Browser package with a single public export."
+      ]
+    },
+    {
+      "name": "@gluonjs/ssr",
+      "purpose": "DOM-independent server rendering and request isolation for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { renderToString } from '@gluonjs/ssr';\nimport { html } from '@gluonjs/core';\n\nconst markup = await renderToString(html`<main>Hello</main>`);"
+      },
+      "useCases": [
+        "Server rendering, streaming, static generation, and hydration handoff.",
+        "Request-local effect scopes and declarative ShadowRoot output.",
+        "Shared public component definitions between browser and server."
+      ],
+      "limits": [
+        "Does not replace browser ownership or client hydration logic.",
+        "Rendered output still depends on public component definitions."
+      ],
+      "relatedGuides": [
+        { "label": "Universal rendering", "href": "/gluon/latest/guides/universal-rendering/" },
+        { "label": "Hydration", "href": "/gluon/latest/reference/hydration/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core`, `@gluonjs/reactivity`, `@gluonjs/router`, and `@gluonjs/store`.",
+        "Exports `.` plus `./eleventy`, `./hydration`, `./static`, and `./streaming`."
+      ]
+    },
+    {
+      "name": "@gluonjs/vite",
+      "purpose": "Official Vite integration and state-preserving HMR for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { defineConfig } from 'vite';\nimport gluon from '@gluonjs/vite';\n\nexport default defineConfig({ plugins: [gluon()] });"
+      },
+      "useCases": [
+        "Template source maps, development diagnostics, and HMR.",
+        "Build-time integration for Gluon applications.",
+        "Tooling support for browser-oriented packages."
+      ],
+      "limits": [
+        "Does not own application runtime state or rendering semantics.",
+        "Requires Vite and the public Core package."
+      ],
+      "relatedGuides": [
+        { "label": "Tooling", "href": "/gluon/latest/guides/tooling/" },
+        { "label": "Deployment", "href": "/gluon/latest/guides/deployment/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/compiler` and peers on `@gluonjs/core` plus `vite`.",
+        "Public export surface is `.`."
+      ]
+    },
+    {
+      "name": "@gluonjs/gluon-components-vite",
+      "purpose": "Official Storybook renderer and Vite framework for Gluon components.",
+      "starter": {
+        "language": "ts",
+        "code": "import type { StorybookConfig } from '@gluonjs/gluon-components-vite';\n\nconst config = {\n  stories: ['../src/**/*.stories.ts'],\n  framework: '@gluonjs/gluon-components-vite',\n} satisfies StorybookConfig;\n\nexport default config;"
+      },
+      "useCases": [
+        "Storybook rendering for Gluon component libraries.",
+        "Renderer-owned DOM and stylesheet cleanup when stories change.",
+        "Preview, preset, and renderer-preset integration."
+      ],
+      "limits": [
+        "Does not replace the component library or application runtime.",
+        "Requires Storybook and Vite in the host project."
+      ],
+      "relatedGuides": [
+        { "label": "Components", "href": "/gluon/latest/guides/components/" },
+        { "label": "Tooling", "href": "/gluon/latest/guides/tooling/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core` and peers on Storybook plus Vite.",
+        "Exports `.` plus `./entry-preview`, `./preset`, and `./renderer-preset`."
+      ]
+    },
+    {
+      "name": "@gluonjs/test-utils",
+      "purpose": "Black-box component and application test helpers for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { afterEach, expect, it } from 'vitest';\nimport { html } from '@gluonjs/core';\nimport { cleanupFixtures, mountComponent } from '@gluonjs/test-utils';"
+      },
+      "useCases": [
+        "Browser-based mounting of public components and applications.",
+        "Test cleanup helpers and SSR-specific test helpers.",
+        "User-facing behavior checks without private runtime imports."
+      ],
+      "limits": [
+        "Targets the supported browser matrix rather than Node-only unit tests.",
+        "Does not expose private framework internals."
+      ],
+      "relatedGuides": [
+        { "label": "Quality", "href": "/gluon/latest/guides/quality/" },
+        { "label": "Components", "href": "/gluon/latest/guides/components/" }
+      ],
+      "integrationNotes": [
+        "Depends on Core, Reactivity, Router, SSR, and Store.",
+        "Exports `.` and `./ssr`."
+      ]
+    },
+    {
+      "name": "@gluonjs/devtools-api",
+      "purpose": "Versioned, environment-neutral Gluon Devtools protocol.",
+      "starter": {
+        "language": "ts",
+        "code": "import { DevtoolsProtocol } from '@gluonjs/devtools-api';\n\nconst protocol = new DevtoolsProtocol();\nprotocol.handshake();"
+      },
+      "useCases": [
+        "Inspector, overlay, and editor integrations that exchange structured records.",
+        "Protocol handshakes and capability gating across environments.",
+        "Independent application timelines and snapshots."
+      ],
+      "limits": [
+        "Does not render UI or own a browser bridge by itself.",
+        "Protocol consumers must validate capability compatibility."
+      ],
+      "relatedGuides": [
+        { "label": "Devtools", "href": "/gluon/latest/guides/tooling/" },
+        { "label": "Diagnostics", "href": "/gluon/latest/reference/diagnostics/" }
+      ],
+      "integrationNotes": [
+        "Single public export `.`.",
+        "Used by `@gluonjs/devtools`."
+      ]
+    },
+    {
+      "name": "@gluonjs/devtools",
+      "purpose": "Opt-in Gluon development bridge, browser inspector, and Vite integration.",
+      "starter": {
+        "language": "ts",
+        "code": "import { createDevtoolsBridge, mountGluonDevtools } from '@gluonjs/devtools';\n\nconst bridge = createDevtoolsBridge({ enabled: true });"
+      },
+      "useCases": [
+        "Development-only inspection of application, component, render, Router, and Store state.",
+        "Explicit opt-in bridges and app-root registration.",
+        "Browser inspector integration with optional Vite support."
+      ],
+      "limits": [
+        "Disabled by default and never exposes a global automatically.",
+        "Development tooling only; not part of production app behavior."
+      ],
+      "relatedGuides": [
+        { "label": "Tooling", "href": "/gluon/latest/guides/tooling/" },
+        { "label": "Quality", "href": "/gluon/latest/guides/quality/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core` and `@gluonjs/devtools-api`.",
+        "Peers on `vite`."
+      ]
+    },
+    {
+      "name": "@gluonjs/graph",
+      "purpose": "Interactive, dependency-free network graph Custom Element for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import '@gluonjs/graph';\n\nconst graph = document.querySelector('gluon-graph');"
+      },
+      "useCases": [
+        "Canvas-backed graph visualization with deterministic layouts.",
+        "Pan, zoom, selection, and link rendering owned by the element.",
+        "Optional knowledge-map and dependency-map views."
+      ],
+      "limits": [
+        "Does not own graph data modeling or filtering controls.",
+        "Consumers must provide their own labels and persistence."
+      ],
+      "relatedGuides": [
+        { "label": "Components", "href": "/gluon/latest/guides/components/" },
+        { "label": "Application", "href": "/gluon/latest/guides/application/" }
+      ],
+      "integrationNotes": [
+        "Peers on `@gluonjs/core`.",
+        "Browser package with a single public export."
+      ]
+    },
+    {
+      "name": "@gluonjs/language-server",
+      "purpose": "Gluon template language service, LSP server, and CI checker.",
+      "starter": {
+        "language": "sh",
+        "code": "gluon-language-server\n# or\n gluon-project-analyze ."
+      },
+      "useCases": [
+        "Static analysis for imported templates and alias-aware tagged templates.",
+        "Language server, project analyzer, and CI template checks.",
+        "Diagnostics without evaluating application code."
+      ],
+      "limits": [
+        "Does not execute project code or modify source files.",
+        "Reports evidence records rather than browser behavior."
+      ],
+      "relatedGuides": [
+        { "label": "Tooling", "href": "/gluon/latest/guides/tooling/" },
+        { "label": "Quality", "href": "/gluon/latest/guides/quality/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/compiler`.",
+        "Exports `.` and ships `gluon-language-server`, `gluon-project-analyze`, and `gluon-template-check` binaries."
+      ]
+    },
+    {
+      "name": "@gluonjs/vue-migration-analyzer",
+      "purpose": "Static, report-only Vue 3.5 migration inventory for Gluon.",
+      "starter": {
+        "language": "sh",
+        "code": "gluon-vue-analyze .\ngluon-vue-analyze . --format json"
+      },
+      "useCases": [
+        "Inventory Vue source surfaces without executing project code.",
+        "Report-only migration evidence for the Gluon Vue cutover path.",
+        "Schema-backed CLI analysis for repository reviews."
+      ],
+      "limits": [
+        "Does not generate Gluon source or modify files.",
+        "Does not establish behavioral equivalence."
+      ],
+      "relatedGuides": [
+        { "label": "Vue migration analyzer", "href": "/gluon/latest/migration/vue-analyzer/" },
+        { "label": "Vue cutover", "href": "/gluon/latest/migration/vue-to-gluon-cutover/" }
+      ],
+      "integrationNotes": [
+        "Exports `.` and `./schema`.",
+        "Ships the `gluon-vue-analyze` binary."
+      ]
+    },
+    {
+      "name": "@gluonjs/quarks",
+      "purpose": "Typed native-element factories and headless interaction primitives for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { Dialog, Listbox, createFocusScope, q } from '@gluonjs/quarks';"
+      },
+      "useCases": [
+        "Factory helpers for native elements and headless behavior primitives.",
+        "Semantic building blocks without inventing roles or names.",
+        "Low-level interaction helpers for higher UI packages."
+      ],
+      "limits": [
+        "Does not create accessibility semantics on behalf of callers.",
+        "Callers remain responsible for roles, names, and labels."
+      ],
+      "relatedGuides": [
+        { "label": "Components", "href": "/gluon/latest/guides/components/" },
+        { "label": "Accessibility", "href": "/gluon/latest/reference/support-matrix/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core`.",
+        "Browser package with one public export."
+      ]
+    },
+    {
+      "name": "@gluonjs/atoms",
+      "purpose": "Accessible focused UI primitives and reusable Gluon theme styles.",
+      "starter": {
+        "language": "ts",
+        "code": "import { Button, Checkbox, Input, Select, Textarea, installUi } from '@gluonjs/atoms';\n\nconst ui = installUi(document, { theme: 'light' });"
+      },
+      "useCases": [
+        "Focused UI primitives and shared theming boundaries.",
+        "Accessible form controls and theme installation.",
+        "Shared styles for browser-facing Gluon interfaces."
+      ],
+      "limits": [
+        "Does not own larger compositions or app shell layout.",
+        "Depends on Quarks for native primitives and Core for runtime ownership."
+      ],
+      "relatedGuides": [
+        { "label": "Components", "href": "/gluon/latest/guides/components/" },
+        { "label": "Accessibility", "href": "/gluon/latest/reference/support-matrix/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core` and `@gluonjs/quarks`.",
+        "Browser package with a single public export."
+      ]
+    },
+    {
+      "name": "@gluonjs/molecules",
+      "purpose": "Accessible reusable UI compositions for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { Accordion, ButtonGroup, Card, ChoiceGroup } from '@gluonjs/molecules';"
+      },
+      "useCases": [
+        "Reusable mid-level compositions built from Core, Quarks, and Atoms.",
+        "Form fields, control groups, notice surfaces, and dialog patterns.",
+        "Composition helpers that preserve native ownership."
+      ],
+      "limits": [
+        "Does not replace application-specific structure or business logic.",
+        "Some components rely on caller-provided heading and labeling hierarchy."
+      ],
+      "relatedGuides": [
+        { "label": "Components", "href": "/gluon/latest/guides/components/" },
+        { "label": "Component decisions", "href": "/gluon/latest/guides/component-decisions/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core`, `@gluonjs/quarks`, and `@gluonjs/atoms`.",
+        "Browser package with one public export."
+      ]
+    },
+    {
+      "name": "@gluonjs/organisms",
+      "purpose": "Accessible larger interface structures for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { AppShell } from '@gluonjs/organisms';"
+      },
+      "useCases": [
+        "App shell and larger layout structures built from lower-level packages.",
+        "Landmarks, navigation, and responsive composition.",
+        "Structured interface regions for browser apps."
+      ],
+      "limits": [
+        "Does not generate content that the caller has not supplied.",
+        "Layout remains dependent on consumer-owned content and semantics."
+      ],
+      "relatedGuides": [
+        { "label": "Application", "href": "/gluon/latest/guides/application/" },
+        { "label": "Components", "href": "/gluon/latest/guides/components/" }
+      ],
+      "integrationNotes": [
+        "Depends on `@gluonjs/core`, `@gluonjs/quarks`, `@gluonjs/atoms`, and `@gluonjs/molecules`.",
+        "Browser package with one public export."
+      ]
+    },
+    {
+      "name": "@gluonjs/json-forms",
+      "purpose": "Schema-driven, form-associated Custom Elements for Gluon.",
+      "starter": {
+        "language": "ts",
+        "code": "import { registerJsonForms } from '@gluonjs/json-forms';\n\nregisterJsonForms();"
+      },
+      "useCases": [
+        "Accessible form rendering from a documented JSON Schema subset.",
+        "AJV-backed validation and form-associated custom elements.",
+        "Optional schema-driven UI inside browser applications."
+      ],
+      "limits": [
+        "Does not enter the core package runtime.",
+        "Schema rendering is intentionally limited to the documented subset."
+      ],
+      "relatedGuides": [
+        { "label": "Forms", "href": "/gluon/latest/reference/forms/" },
+        { "label": "Application", "href": "/gluon/latest/guides/application/" }
+      ],
+      "integrationNotes": [
+        "Depends on AJV and `ajv-formats` plus `@gluonjs/core`.",
+        "Browser package with one public export."
+      ]
+    },
+    {
+      "name": "create-gluon",
+      "purpose": "Scaffold Gluon TypeScript applications and verified app-local components.",
+      "starter": {
+        "language": "sh",
+        "code": "npm create gluon@latest my-app"
+      },
+      "useCases": [
+        "Project scaffolding with public Gluon package entry points.",
+        "Adding verified app-local component boundaries to an existing project.",
+        "CLI-driven local project setup."
+      ],
+      "limits": [
+        "Does not provide a runtime package or browser component API.",
+        "Scaffolded projects must still follow the public-boundary rules."
+      ],
+      "relatedGuides": [
+        { "label": "Getting started", "href": "/gluon/latest/guides/getting-started/" },
+        { "label": "Tooling", "href": "/gluon/latest/guides/tooling/" }
+      ],
+      "integrationNotes": [
+        "Ships the `create-gluon` binary.",
+        "Package manifest has a single public export."
+      ]
+    }
+  ]
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -583,6 +583,12 @@ the complete implemented release-group graph, including the analyzer.
 validates every declared package independently and additionally verifies built
 exports, types, license, changelog, README, and `npm pack` contents for
 implemented packages.
+The docs portal keeps its package-specific usage metadata in
+[`docs-site/package-docs.json`](../docs-site/package-docs.json) instead of
+parsing README prose. That file owns purpose, starter code and language, use
+cases, limits, related guides, and verified integration notes for the current
+packages recorded in `package-contract.json`, while the package manifest and package contract continue to
+own public entry points and packaging links.
 Reactivity behavior runs in a Node Vitest configuration; the public generated
 Core and Reactivity declarations are compiled again through
 `tests-node/core.types.ts` and `tests-node/reactivity.types.ts`.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -99,6 +99,10 @@ artwork rather than a separate HTML heading. Each README uses an absolute
 not ship the repository `docs/` tree. `npm run check:packages` derives the asset
 name from `package-contract.json` and rejects missing, duplicated, stale,
 wrongly sized, or wrongly referenced package headers.
+The docs portal no longer infers package semantics from README structure. Its
+package-purpose, starter, use-case, limits, guide, and integration metadata live
+in version control under `docs-site/package-docs.json`, and `npm run check:docs`
+validates that every current package in `package-contract.json` is covered.
 
 The immutable `v1.0.0` tag points to commit
 `8f52b4b98fe9e9f5182973cbf5a0655c879df7ea`. Its Release run

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -9,18 +9,20 @@ const apiRoot = resolve(root, '.tmp/docs-api');
 const outputRoot = resolve(siteRoot, 'dist');
 const versions = JSON.parse(await readFile(resolve(siteRoot, 'versions.json'), 'utf8'));
 const packageContract = JSON.parse(await readFile(resolve(root, 'package-contract.json'), 'utf8'));
+const packageDocs = JSON.parse(await readFile(resolve(siteRoot, 'package-docs.json'), 'utf8'));
 const base = normalizeBase(process.env.DOCS_BASE ?? '/gluon/');
+validatePackageDocs(packageDocs, packageContract);
 const packageMetadata = new Map(await Promise.all(
   packageContract.packages
     .filter((entry) => entry.state === 'current')
     .map(async (entry) => {
       const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
-      const readme = await readFile(resolve(root, entry.directory, 'README.md'), 'utf8');
+      const docs = packageDocs.packages.find((candidate) => candidate.name === entry.name);
       return [entry.name, {
         name: entry.name,
         entry,
         packageJson,
-        readme,
+        docs,
         description: packageJson.description,
       }];
     }),
@@ -309,7 +311,7 @@ function packagePageShell({ version, title, description, content, packageInfo, p
     <div class="site-grid package-grid">
       <aside class="sidebar" aria-label="Gluon packages" data-sidebar><nav>${packageNavigation}</nav></aside>
       <main id="content" class="content"><article>${content}</article></main>
-      <aside class="toc package-toc" aria-label="Package context"><strong>${packageInfo ? 'Package context' : 'Package map'}</strong><p>${packageInfo ? 'Public package boundary and release metadata.' : `${packages.length} current packages in the lockstep train.`}</p></aside>
+      <aside class="toc package-toc" aria-label="Package context"><strong>${packageInfo ? 'Package context' : 'Package map'}</strong><p>${packageInfo ? 'Public package boundary and release metadata.' : `${packages.length} packages in the lockstep train.`}</p></aside>
     </div>
     <footer class="site-footer"><span>Gluon ${version}</span><a href="${base}${version}/">Documentation</a><a href="https://github.com/marcmalerei/gluon">GitHub</a><a href="${base}archive/">Release archive</a></footer>
     <script type="module" src="${base}assets/docs.js"></script>
@@ -322,7 +324,7 @@ function packageIndexContent(version, packages) {
   <p class="package-kicker">${escapeHtml(entry.entry.environment)} package</p>
   <h2><a href="${base}${version}/packages/${packageSlug(entry.name)}/">${escapeHtml(entry.name)}</a></h2>
   <p>${escapeHtml(entry.description)}</p>
-  <p class="package-card-meta"><code>${escapeHtml(entry.entry.exports.length)} public export${entry.entry.exports.length === 1 ? '' : 's'}</code><a href="${base}${version}/packages/${packageSlug(entry.name)}/">Open package →</a></p>
+  <p class="package-card-meta"><code>${escapeHtml(entry.entry.exports.length)} public entry point${entry.entry.exports.length === 1 ? '' : 's'}</code><a href="${base}${version}/packages/${packageSlug(entry.name)}/">Open package →</a></p>
 </article>`).join('');
   return `<p class="eyebrow">${packages.length} packages · lockstep release train</p>
 <h1>Build with the package that owns the boundary.</h1>
@@ -333,7 +335,7 @@ function packageIndexContent(version, packages) {
 }
 
 function packageDetailContent(version, packageInfo) {
-  const { entry, packageJson, readme } = packageInfo;
+  const { entry, packageJson, docs } = packageInfo;
   const sourceReadmeUrl = entry.directory === '.'
     ? 'https://github.com/marcmalerei/gluon#readme'
     : `https://github.com/marcmalerei/gluon/tree/main/${entry.directory}#readme`;
@@ -350,25 +352,28 @@ function packageDetailContent(version, packageInfo) {
     const optional = packageJson.peerDependenciesMeta?.[name]?.optional ? ' · optional' : '';
     return `${name}@${range}${optional}`;
   });
-  const readmeCode = readme.match(/```(?:ts|tsx|js|sh|bash|html)\n([\s\S]+?)```/)?.[1]?.trim() ?? `import '${entry.name}';`;
-  const limits = readme.match(/(?:^|\n)## (?:[^\n]*(?:Limit|Support|Boundary|Compatibility|Scope)[^\n]*)\n([\s\S]*?)(?=\n## |$)/i)?.[1]
-    ?.trim()
-    .split(/\n\s*\n/)
-    .slice(0, 2)
-    .map((paragraph) => `<li>${escapeHtml(paragraph.replace(/\s+/g, ' '))}</li>`)
-    .join('')
-    ?? `<li>See the package README for the maintained scope and unsupported boundaries.</li>`;
+  if (!docs) throw new Error(`missing package docs for ${entry.name}`);
+  const starterCode = docs.starter.code;
+  const starterLanguage = docs.starter.language;
+  const useCases = docs.useCases.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+  const limits = docs.limits.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+  const relatedGuides = docs.relatedGuides.map((guide) => `<li><a href="${escapeHtml(guide.href)}">${escapeHtml(guide.label)}</a></li>`).join('');
+  const integrationNotes = docs.integrationNotes.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
   const dependencyList = dependencies.length > 0 ? dependencies.map((dependency) => `<li>${escapeHtml(dependency)}</li>`).join('') : '<li>None</li>';
   const peerList = peers.length > 0 ? peers.map((peer) => `<li>${escapeHtml(peer)}</li>`).join('') : '<li>None</li>';
   return `<p class="eyebrow">Gluon ${escapeHtml(entry.environment)} package · ${escapeHtml(packageJson.version)}</p>
 <h1>${escapeHtml(packageInfo.name)}</h1>
 <p class="package-lede">${escapeHtml(packageInfo.description)}</p>
 <div class="package-actions"><a class="package-primary-action" href="https://www.npmjs.com/package/${encodeURIComponent(entry.name)}">npm package</a><a href="${sourceReadmeUrl}">Source README</a></div>
-<section class="package-facts" aria-label="Package facts"><div><strong>Runtime</strong><span>${escapeHtml(entry.environment)}</span></div><div><strong>Version</strong><span>${escapeHtml(packageJson.version)}</span></div><div><strong>License</strong><span>${escapeHtml(packageJson.license ?? 'MIT')}</span></div><div><strong>Exports</strong><span>${escapeHtml(String(entry.exports.length))}</span></div></section>
+<section class="package-facts" aria-label="Package facts"><div><strong>Runtime</strong><span>${escapeHtml(entry.environment)}</span></div><div><strong>Version</strong><span>${escapeHtml(packageJson.version)}</span></div><div><strong>License</strong><span>${escapeHtml(packageJson.license ?? 'MIT')}</span></div><div><strong>Public entry points</strong><span>${escapeHtml(String(entry.exports.length))}</span></div></section>
 <h2 id="install">Install and start</h2>
 <p>${entry.name === 'create-gluon' ? 'Scaffold a project with the maintained CLI:' : 'Install the public package at the same version as the rest of the Gluon train:'}</p>
 <figure class="code-frame"><figcaption><span>shell</span><button type="button" data-copy-code>Copy</button></figcaption><pre><code class="language-sh">${escapeHtml(entry.name === 'create-gluon' ? 'npm create gluon@latest my-app' : `npm install ${entry.name}`)}</code></pre></figure>
-<figure class="code-frame"><figcaption><span>starter</span><button type="button" data-copy-code>Copy</button></figcaption><pre><code class="language-ts">${escapeHtml(readmeCode)}</code></pre></figure>
+<figure class="code-frame"><figcaption><span>${escapeHtml(starterLanguage)}</span><button type="button" data-copy-code>Copy</button></figcaption><pre><code class="language-${escapeHtml(starterLanguage)}">${escapeHtml(starterCode)}</code></pre></figure>
+<h2 id="purpose">Purpose</h2>
+  <p>${escapeHtml(docs.purpose)}</p>
+<h2 id="use-cases">Use cases</h2>
+<ul class="package-list">${useCases}</ul>
 <h2 id="entry-points">Public entry points</h2>
 <p>Only these package exports are part of the supported public boundary.</p><ul class="package-list">${apiLinks}</ul>
 <h2 id="dependencies">Dependencies and peers</h2>
@@ -377,6 +382,10 @@ function packageDetailContent(version, packageInfo) {
 <p>Open an entry point above for generated symbol documentation and a reviewed example for every public symbol. Application code must import from this package entry point, never from repository source paths.</p>
 <h2 id="limits">Scope and limits</h2>
 <ul class="package-list">${limits}</ul>
+<h2 id="guides">Related guides</h2>
+<ul class="package-list">${relatedGuides}</ul>
+<h2 id="integration-notes">Verified integration notes</h2>
+<ul class="package-list">${integrationNotes}</ul>
 <p class="package-readme-link"><a href="${sourceReadmeUrl}">Read the complete ${escapeHtml(packageInfo.name)} README →</a></p>`;
 }
 
@@ -406,4 +415,67 @@ function escapeAttribute(value) { return escapeHtml(value).replaceAll("'", '&#39
 
 async function writeRedirect(path, target) {
   await writeFile(path, `<!doctype html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta http-equiv="refresh" content="0;url=${target}"><link rel="canonical" href="${target}"><title>Gluon documentation</title></head><body><a href="${target}">Open Gluon documentation</a></body></html>`, 'utf8');
+}
+
+function validatePackageDocs(packageDocs, packageContract) {
+  if (!packageDocs || packageDocs.version !== 1 || !Array.isArray(packageDocs.packages)) {
+    throw new Error('docs-site/package-docs.json must contain version 1 and a packages array.');
+  }
+  const currentPackages = packageContract.packages.filter((entry) => entry.state === 'current');
+  if (packageDocs.packages.length !== currentPackages.length) {
+    throw new Error(`docs-site/package-docs.json must describe ${currentPackages.length} current packages.`);
+  }
+  const names = new Set();
+  for (const entry of packageDocs.packages) {
+    if (names.has(entry.name)) throw new Error(`docs-site/package-docs.json contains duplicate package metadata for ${entry.name}.`);
+    names.add(entry.name);
+    const requiredFields = ['name', 'purpose', 'starter', 'useCases', 'limits', 'relatedGuides', 'integrationNotes'];
+    for (const field of requiredFields) {
+      if (!(field in entry)) throw new Error(`docs-site/package-docs.json is missing ${field} for ${entry.name}.`);
+    }
+    if (!currentPackages.some((pkg) => pkg.name === entry.name)) {
+      throw new Error(`docs-site/package-docs.json contains unknown package ${entry.name}.`);
+    }
+    if (!isTrimmedNonEmptyString(entry.purpose)) {
+      throw new Error(`docs-site/package-docs.json purpose must be a non-empty trimmed string for ${entry.name}.`);
+    }
+    if (!isTrimmedNonEmptyString(entry.starter?.language) || !isTrimmedNonEmptyString(entry.starter?.code)) {
+      throw new Error(`docs-site/package-docs.json starter metadata must include non-empty trimmed language and code for ${entry.name}.`);
+    }
+    for (const listName of ['useCases', 'limits', 'integrationNotes']) {
+      if (!Array.isArray(entry[listName]) || entry[listName].length === 0 || entry[listName].some((value) => !isTrimmedNonEmptyString(value))) {
+        throw new Error(`docs-site/package-docs.json ${listName} must be a non-empty array of non-empty trimmed strings for ${entry.name}.`);
+      }
+    }
+    if (!Array.isArray(entry.relatedGuides) || entry.relatedGuides.length === 0) {
+      throw new Error(`docs-site/package-docs.json relatedGuides must be a non-empty list of {label, href} objects for ${entry.name}.`);
+    }
+    const relatedLabels = new Set();
+    const relatedHrefs = new Set();
+    for (const guide of entry.relatedGuides) {
+      if (!isTrimmedNonEmptyString(guide?.label) || !isTrimmedNonEmptyString(guide?.href)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides entries must include trimmed label and href strings for ${entry.name}.`);
+      }
+      if (!isSupportedGuideHref(guide.href)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides href must use a versioned Gluon docs path for ${entry.name}: ${guide.href}`);
+      }
+      if (relatedLabels.has(guide.label)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides contains duplicate label ${guide.label} for ${entry.name}.`);
+      }
+      if (relatedHrefs.has(guide.href)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides contains duplicate href ${guide.href} for ${entry.name}.`);
+      }
+      relatedLabels.add(guide.label);
+      relatedHrefs.add(guide.href);
+    }
+  }
+}
+
+function isTrimmedNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0 && value === value.trim();
+}
+
+function isSupportedGuideHref(href) {
+  return /^\/gluon\/(?:latest|\d+\.\d+\.\d+)\/(?:api|cookbook|guides|migration|reference|examples)(?:\/[A-Za-z0-9._~!$&'()*+,;=:@/-]*)?\/?$/.test(href)
+    || /^\/gluon\/(?:latest|\d+\.\d+\.\d+)\/(?:api|cookbook|guides|migration|reference|examples)\/(?:[A-Za-z0-9._~!$&'()*+,;=:@/-]+\/)?(?:index\.html|index\.md)?$/.test(href);
 }

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -6,7 +6,9 @@ const siteRoot = resolve(root, 'docs-site');
 const outputRoot = resolve(siteRoot, 'dist');
 const versions = JSON.parse(await readFile(resolve(siteRoot, 'versions.json'), 'utf8'));
 const packageContract = JSON.parse(await readFile(resolve(root, 'package-contract.json'), 'utf8'));
+const packageDocs = JSON.parse(await readFile(resolve(siteRoot, 'package-docs.json'), 'utf8'));
 const base = '/gluon/';
+validatePackageDocs(packageDocs, packageContract);
 
 if (!versions.supported.includes(versions.latest)) {
   throw new Error(`documentation latest ${versions.latest} is not a supported version`);
@@ -40,18 +42,56 @@ const packageIndexHtml = await readFile(resolve(outputRoot, versions.latest, 'pa
 if ((packageIndexHtml.match(/data-package-card/g) ?? []).length !== currentPackages.length) {
   throw new Error(`package portal lists ${(packageIndexHtml.match(/data-package-card/g) ?? []).length} packages; contract requires ${currentPackages.length}`);
 }
+if (!packageIndexHtml.includes('public entry points')) {
+  throw new Error('package portal index must name the displayed metric as public entry points.');
+}
 for (const entry of currentPackages) {
   const packageSlug = entry.name === '@gluonjs/core' ? 'core' : entry.name.replace(/^@gluonjs\//, '');
   const packageHtml = await readFile(resolve(outputRoot, versions.latest, 'packages', packageSlug, 'index.html'), 'utf8');
   const packageJson = JSON.parse(await readFile(resolve(root, entry.directory, 'package.json'), 'utf8'));
+  const docsEntry = packageDocs.packages.find((candidate) => candidate.name === entry.name);
   for (const required of [
     `<title>${entry.name} · Gluon ${versions.latest}</title>`,
     `<meta name="description" content="${escapeHtml(packageJson.description)}">`,
     'Install and start',
+    'Purpose',
+    'Use cases',
     'Public entry points',
     'Dependencies and peers',
     'Scope and limits',
+    'Related guides',
+    'Verified integration notes',
   ]) if (!packageHtml.includes(required)) throw new Error(`${entry.name} package portal is missing: ${required}`);
+  if (!docsEntry) throw new Error(`package docs are missing for ${entry.name}`);
+  if (!packageHtml.includes(escapeHtml(docsEntry.starter.code))) {
+    throw new Error(`${entry.name} package portal does not render the documented starter code.`);
+  }
+  if (!packageHtml.includes(`>${escapeHtml(docsEntry.starter.language)}<`)) {
+    throw new Error(`${entry.name} package portal does not render the documented starter language.`);
+  }
+  if (!packageHtml.includes(escapeHtml(docsEntry.purpose))) {
+    throw new Error(`${entry.name} package portal does not render the documented purpose.`);
+  }
+  for (const item of docsEntry.useCases) {
+    if (!packageHtml.includes(`<li>${escapeHtml(item)}</li>`)) {
+      throw new Error(`${entry.name} package portal does not render use case ${item}.`);
+    }
+  }
+  for (const item of docsEntry.limits) {
+    if (!packageHtml.includes(`<li>${escapeHtml(item)}</li>`)) {
+      throw new Error(`${entry.name} package portal does not render scope limit ${item}.`);
+    }
+  }
+  for (const item of docsEntry.integrationNotes) {
+    if (!packageHtml.includes(`<li>${escapeHtml(item)}</li>`)) {
+      throw new Error(`${entry.name} package portal does not render integration note ${item}.`);
+    }
+  }
+  for (const guide of docsEntry.relatedGuides) {
+    if (!packageHtml.includes(`href="${guide.href}"`) || !packageHtml.includes(`>${escapeHtml(guide.label)}<`)) {
+      throw new Error(`${entry.name} package portal does not render related guide ${guide.label} -> ${guide.href}.`);
+    }
+  }
 }
 
 for (const entry of currentPackages) {
@@ -380,3 +420,65 @@ async function filesWithExtension(directory, extension) {
 
 function slash(value) { return value.split(sep).join('/'); }
 function escapeHtml(value) { return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }
+
+function validatePackageDocs(packageDocs, packageContract) {
+  if (!packageDocs || packageDocs.version !== 1 || !Array.isArray(packageDocs.packages)) {
+    throw new Error('docs-site/package-docs.json must contain version 1 and a packages array.');
+  }
+  const currentPackages = packageContract.packages.filter((entry) => entry.state === 'current');
+  if (packageDocs.packages.length !== currentPackages.length) {
+    throw new Error(`docs-site/package-docs.json must describe ${currentPackages.length} current packages.`);
+  }
+  const names = new Set();
+  for (const entry of packageDocs.packages) {
+    if (names.has(entry.name)) throw new Error(`docs-site/package-docs.json contains duplicate package metadata for ${entry.name}.`);
+    names.add(entry.name);
+    if (!currentPackages.some((pkg) => pkg.name === entry.name)) {
+      throw new Error(`docs-site/package-docs.json contains unknown package ${entry.name}.`);
+    }
+    for (const field of ['name', 'purpose', 'starter', 'useCases', 'limits', 'relatedGuides', 'integrationNotes']) {
+      if (!(field in entry)) throw new Error(`docs-site/package-docs.json is missing ${field} for ${entry.name}.`);
+    }
+    if (!isTrimmedNonEmptyString(entry.purpose)) {
+      throw new Error(`docs-site/package-docs.json purpose must be a non-empty trimmed string for ${entry.name}.`);
+    }
+    if (!isTrimmedNonEmptyString(entry.starter?.language) || !isTrimmedNonEmptyString(entry.starter?.code)) {
+      throw new Error(`docs-site/package-docs.json starter metadata must include non-empty trimmed language and code for ${entry.name}.`);
+    }
+    for (const listName of ['useCases', 'limits', 'integrationNotes']) {
+      if (!Array.isArray(entry[listName]) || entry[listName].length === 0 || entry[listName].some((value) => !isTrimmedNonEmptyString(value))) {
+        throw new Error(`docs-site/package-docs.json ${listName} must be a non-empty array of non-empty trimmed strings for ${entry.name}.`);
+      }
+    }
+    if (!Array.isArray(entry.relatedGuides) || entry.relatedGuides.length === 0) {
+      throw new Error(`docs-site/package-docs.json relatedGuides must be a non-empty list of {label, href} objects for ${entry.name}.`);
+    }
+    const relatedLabels = new Set();
+    const relatedHrefs = new Set();
+    for (const guide of entry.relatedGuides) {
+      if (!isTrimmedNonEmptyString(guide?.label) || !isTrimmedNonEmptyString(guide?.href)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides entries must include trimmed label and href strings for ${entry.name}.`);
+      }
+      if (!isSupportedGuideHref(guide.href)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides href must use a versioned Gluon docs path for ${entry.name}: ${guide.href}`);
+      }
+      if (relatedLabels.has(guide.label)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides contains duplicate label ${guide.label} for ${entry.name}.`);
+      }
+      if (relatedHrefs.has(guide.href)) {
+        throw new Error(`docs-site/package-docs.json relatedGuides contains duplicate href ${guide.href} for ${entry.name}.`);
+      }
+      relatedLabels.add(guide.label);
+      relatedHrefs.add(guide.href);
+    }
+  }
+}
+
+function isTrimmedNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0 && value === value.trim();
+}
+
+function isSupportedGuideHref(href) {
+  return /^\/gluon\/(?:latest|\d+\.\d+\.\d+)\/(?:api|cookbook|guides|migration|reference|examples)(?:\/[A-Za-z0-9._~!$&'()*+,;=:@/-]*)?\/?$/.test(href)
+    || /^\/gluon\/(?:latest|\d+\.\d+\.\d+)\/(?:api|cookbook|guides|migration|reference|examples)\/(?:[A-Za-z0-9._~!$&'()*+,;=:@/-]+\/)?(?:index\.html|index\.md)?$/.test(href);
+}


### PR DESCRIPTION
Closes #397

## Summary
- add one version-controlled semantic docs contract for every current public package
- render package purpose, real starter, use cases, limits, guide links, and integration notes from explicit metadata
- remove README-regex semantic extraction and fail closed on missing, duplicate, unsafe, or empty metadata
- validate escaped rendered output and derive package counts from the live contract

## Verification
- npm run check:docs
  - 857 API symbol pages and curated examples
  - 918 documentation pages built for 1.9.0
  - package metadata/rendered page assertions passed
- compiler starter parsed with the repository TypeScript/esbuild parser
- git diff --check
- independent read-only review: mergeable, no invented public APIs or unsafe metadata paths

## Shop decision
This changes the documentation portal and validation contract only; there is no user-visible GLUON GOODS application behavior to integrate.
