### PR TITLE
Propagate nested component style dependencies (#373)

### DIFF
--- a/examples/component-library/README.md
+++ b/examples/component-library/README.md
@@ -55,9 +55,10 @@ entries; the example consumer imports the library package entry rather than
 the source implementation. Run `npm run check:component-library-package` to
 build it and inspect the exact tarball contents before a clean-consumer install.
 `npm run check:component-library-clean-install` packs the real library and
-Gluon dependencies, installs them in an empty temporary consumer, typechecks
-and production-builds that consumer, then verifies its browser interaction and
-teardown flow.
+the local Gluon dependencies needed by the consumer, installs them in an empty
+temporary consumer, typechecks and production-builds that consumer, then
+verifies its browser interaction, the propagated `@gluonjs/atoms` Radio
+styles, and teardown flow.
 
 Repository SSR coverage renders both public exports, including the picker's
 declarative Shadow DOM. Browser coverage retains the Atom's server nodes during

--- a/packages/atoms/README.md
+++ b/packages/atoms/README.md
@@ -35,7 +35,9 @@ provided.
 `StatusBadge`, `Switch`, `Textarea`, and `ToggleButton` expose immutable `Component.styles`
 metadata and have separately tree-shakable sheets. The renderer adopts only the
 sheets reachable from its active value tree and releases them with the render
-owner. `atomStyles` is deprecated; adopting it with exact rendering throws
+owner. Nested composition stays on that same path, so a public Molecule that
+calls `Radio()` directly still contributes the exact `radioStyles` sheet before
+the first measurable render and through hydration. `atomStyles` is deprecated; adopting it with exact rendering throws
 `GLUON_LEGACY_COMPONENT_STYLE_CONFLICT` rather than applying duplicate rules.
 `installUiTheme()` is deprecated in favor of `installUi()`.
 

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -55,6 +55,11 @@ tree and merges them between shared UI and application-owned sheets. Style
 manifests use deterministic IDs and ordered CSS text for initial carriers and
 browser handoff.
 
+Nested component composition participates in the same traversal. A public
+`defineMolecule()` wrapper that calls a public Atom such as `Radio()` still
+contributes the Atom's exact stylesheet dependency to the resolved request
+tree before the hydrated view becomes measurable or interactive.
+
 `SsrRequestOptions.signal` is optional. When supplied, the exact signal is
 available as `SsrRequestContext.signal` and reaches request loading, async
 boundaries, serialization, and progressive work. Abort rejects with the

--- a/scripts/validate-component-library-clean-install.mjs
+++ b/scripts/validate-component-library-clean-install.mjs
@@ -12,7 +12,10 @@ const directory = await mkdtemp(resolve(tmpdir(), 'gluon-component-library-clean
 
 try {
   const archives = [];
-  for (const packageDirectory of ['packages/reactivity', '.', 'packages/quarks', 'examples/component-library/library']) {
+  for (const packageDirectory of ['packages/reactivity', '.', 'packages/quarks', 'packages/atoms', 'examples/component-library/library']) {
+    if (packageDirectory === 'examples/component-library/library') {
+      await execFile('npm', ['run', 'build'], { cwd: resolve(root, packageDirectory), maxBuffer: 20 * 1024 * 1024 });
+    }
     const packed = JSON.parse((await execFile('npm', [
       'pack', '--json', '--ignore-scripts', '--pack-destination', directory,
     ], { cwd: resolve(root, packageDirectory) })).stdout)[0];
@@ -30,56 +33,92 @@ try {
   }, null, 2));
   await writeFile(resolve(consumer, 'index.html'), '<main id="app"></main><script type="module" src="/src/main.ts"></script>');
   await writeFile(resolve(consumer, 'src/main.ts'), `
-    import { createApp, html } from '@gluonjs/core';
+    import { createApp, defineMolecule, html } from '@gluonjs/core';
+    import { Radio } from '@gluonjs/atoms';
     import { createComponentLibraryLoader } from '@gluonjs/quarks';
     import { componentLibraryManifest } from '@gluonjs/example-component-library/manifest';
+    const RadioField = defineMolecule((props: { readonly name: string; readonly label: string }) => html\`
+      <label class="radio-field">
+        \${Radio({ name: props.name, attributes: { 'aria-label': props.label } })}
+        <span>\${props.label}</span>
+      </label>
+    \`, 'RadioField');
     const loader = createComponentLibraryLoader(componentLibraryManifest, { load: async (entry) => {
       const module: Record<string, unknown> = entry.id === 'product-badge'
         ? await import('@gluonjs/example-component-library/product-badge')
         : await import('@gluonjs/example-component-library/product-picker');
       return module[entry.exportName];
     } });
-    const ProductBadge = (await loader.load('product-badge')).value as (label: string) => ReturnType<typeof html>;
+    const badge = (await loader.load('product-badge')).value as (label: string) => ReturnType<typeof html>;
     await loader.load('product-picker');
-    const app = createApp(() => html\`<section><p>\${ProductBadge('In stock')}</p><example-product-picker value="1"></example-product-picker></section>\`).mount(document.querySelector('#app')!);
+    const app = createApp(() => html\`<section><p>\${badge('In stock')}</p><example-product-picker value="1"></example-product-picker>\${RadioField({ name: 'finish', label: 'Graphite' })}</section>\`).mount(document.querySelector('#app')!);
     Object.assign(window, { componentLibraryUnmount: () => { app.unmount(); loader.dispose(); } });
   `);
-  await execFile('npm', ['install', ...archives, 'vite@8.2.1', 'typescript@5.9.3', '--ignore-scripts', '--no-audit', '--no-fund'], {
+  await execFile('npm', ['install', ...archives, 'vite@8.2.1', 'typescript@5.9.3', '@types/node@22.12.0', '--ignore-scripts', '--no-audit', '--no-fund'], {
     cwd: consumer, maxBuffer: 20 * 1024 * 1024,
   });
   await execFile(resolve(consumer, 'node_modules/.bin/tsc'), ['--noEmit'], { cwd: consumer });
   await execFile(resolve(consumer, 'node_modules/.bin/vite'), ['build'], { cwd: consumer });
 
-  const server = createServer(async (request, response) => {
-    try {
-      const pathname = new URL(request.url ?? '/', 'http://localhost').pathname;
-      const relative = pathname === '/' ? 'index.html' : pathname.slice(1);
-      const body = await readFile(resolve(consumer, 'dist', relative));
-      response.writeHead(200, { 'content-type': contentType(relative) });
-      response.end(body);
-    } catch {
-      response.writeHead(404).end();
-    }
-  });
-  await new Promise((resolveServer) => server.listen(0, '127.0.0.1', resolveServer));
-  const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('Clean component-library consumer server did not bind a TCP port.');
   const browser = await chromium.launch();
   try {
-    const page = await browser.newPage();
-    await page.goto(`http://127.0.0.1:${address.port}`);
-    const picker = page.locator('example-product-picker');
-    await picker.locator('[aria-label="Increase quantity"]').click();
-    if (await picker.locator('output').textContent() !== '2' || !await page.getByText('In stock').count()) {
-      throw new Error('Packed component-library consumer browser flow is incomplete.');
+    let server;
+    try {
+      server = createServer(async (request, response) => {
+        try {
+          const pathname = new URL(request.url ?? '/', 'http://localhost').pathname;
+          const relative = pathname === '/' ? 'index.html' : pathname.slice(1);
+          const body = await readFile(resolve(consumer, 'dist', relative));
+          response.writeHead(200, { 'content-type': contentType(relative) });
+          response.end(body);
+        } catch {
+          response.writeHead(404).end();
+        }
+      });
+      await new Promise((resolveServer) => server.listen(0, '127.0.0.1', resolveServer));
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Clean component-library consumer server did not bind a TCP port.');
+
+      const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+      try {
+        await page.goto(`http://127.0.0.1:${address.port}`);
+        const radioMetrics = await page.locator('input.gluon-radio').evaluate((radio) => {
+          const style = getComputedStyle(radio);
+          return {
+            inlineSize: style.inlineSize,
+            blockSize: style.blockSize,
+          };
+        });
+        if (radioMetrics.inlineSize !== '20px' || radioMetrics.blockSize !== '20px') {
+          throw new Error(`Packed consumer radio measurement is incorrect: ${JSON.stringify(radioMetrics)}`);
+        }
+
+        const picker = page.locator('example-product-picker');
+        await picker.locator('[aria-label="Increase quantity"]').click();
+        if (await picker.locator('output').textContent() !== '2' || !await page.getByText('In stock').count()) {
+          throw new Error('Packed component-library consumer browser flow is incomplete.');
+        }
+
+        await page.evaluate(() => window.componentLibraryUnmount?.());
+        if (await page.locator('example-product-picker').count() !== 0) throw new Error('Packed component-library consumer teardown is incomplete.');
+
+        console.log(JSON.stringify({
+          consumer: 'packed local clean install',
+          archives: Object.fromEntries(archives.map((value) => [value.split('/').at(-1), value.split('/').at(-1)])),
+          viewport: { width: 390, height: 844 },
+          geometry: { radio: radioMetrics },
+        }, null, 2));
+      } finally {
+        await page.close();
+      }
+    } finally {
+      if (server) {
+        await new Promise((resolveServer, rejectServer) => server.close((error) => error ? rejectServer(error) : resolveServer()));
+      }
     }
-    await page.evaluate(() => window.componentLibraryUnmount());
-    if (await page.locator('example-product-picker').count() !== 0) throw new Error('Packed component-library consumer teardown is incomplete.');
   } finally {
     await browser.close();
-    await new Promise((resolveServer, rejectServer) => server.close((error) => error ? rejectServer(error) : resolveServer()));
   }
-  console.log('component-library clean install valid: packed public package, typecheck, production build, browser interaction, and teardown');
 } finally {
   await rm(directory, { recursive: true, force: true });
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -324,6 +324,12 @@ export function createComponentStyleSelection(value: TemplateValue): StyleSheetS
     .map(({ id, sheet, scope = 'gluon-component' }) => ({ id, sheet, scope })));
 }
 
+function collectComponentStyleDependencies(value: TemplateValue): readonly ComponentStyleDependency[] {
+  const dependencies = new Map<string, ComponentStyleDependency>();
+  collectComponentStyles(value, dependencies);
+  return [...dependencies.values()];
+}
+
 function collectComponentStyles(
   value: unknown,
   dependencies: Map<string, ComponentStyleDependency>,
@@ -1670,6 +1676,7 @@ export function render(
   if (!isTemplateResult(result)) {
     throw new TypeError('render() expects a TemplateResult created by html or svg.');
   }
+  const styleDependencies = collectComponentStyleDependencies(result);
 
   let current = getRootInstance(container);
   const currentTemplateMatches = current?.template.strings === result.strings
@@ -1685,7 +1692,7 @@ export function render(
     && currentNodesInPlace
     && !current.hydrated
     && current.rootStyleDependenciesEmpty
-    && result.styleDependencies.length === 0
+    && styleDependencies.length === 0
     && fastStringBinding
     && typeof fastStringValue === 'string'
     && !fastStringBinding.directive
@@ -1699,7 +1706,7 @@ export function render(
     && currentNodesInPlace
     && !current.suspended
     && !current.hydrated
-    && result.styleDependencies.length === 0
+    && styleDependencies.length === 0
     && current.styles.isActiveAndEmpty
   ) {
     applyBindings(current.bindings, result.values);
@@ -1723,8 +1730,8 @@ export function render(
     && (currentNodesInPlace || rootNodesAreInPlace(container, current.nodes))
   ) {
     current.styles.resume();
-    current.styles.claim(current.styleClaim, result.styleDependencies);
-    current.rootStyleDependenciesEmpty = result.styleDependencies.length === 0;
+    current.styles.claim(current.styleClaim, styleDependencies);
+    current.rootStyleDependenciesEmpty = styleDependencies.length === 0;
     if (current.hydrated) {
       current.hydrated = false;
       current.suspended = false;
@@ -1749,7 +1756,7 @@ export function render(
   const styles = current?.styles ?? new RenderStyleTracker(styleTarget);
   const styleClaim = current?.styleClaim ?? {};
   styles.resume();
-  styles.claim(styleClaim, result.styleDependencies);
+  styles.claim(styleClaim, styleDependencies);
   if (current) {
     clearRootInstance(container);
     disconnectBindings(current.bindings);
@@ -1767,7 +1774,7 @@ export function render(
       styles,
       styleClaim,
       fastStringBinding: findFastStringBinding(bindings),
-      rootStyleDependenciesEmpty: result.styleDependencies.length === 0,
+      rootStyleDependenciesEmpty: styleDependencies.length === 0,
       nodes,
       suspended: false,
     });
@@ -1820,6 +1827,7 @@ export function hydrate(
 ): HydrationResult {
   if (!container) return Object.freeze({ mismatches: [], retained: false, recovered: false });
   if (!isTemplateResult(result)) throw new TypeError('hydrate() expects a TemplateResult created by html or svg.');
+  const styleDependencies = collectComponentStyleDependencies(result);
   const expectedTemplate = document.createElement('template');
   expectedTemplate.innerHTML = options.expectedMarkup;
   const mismatches: HydrationMismatch[] = [];
@@ -1841,7 +1849,7 @@ export function hydrate(
 
   const styles = new RenderStyleTracker(resolveRenderStyleTarget(container));
   const styleClaim = {};
-  styles.claim(styleClaim, result.styleDependencies);
+  styles.claim(styleClaim, styleDependencies);
   try {
     const context = createHydrationAdoptionContext(container, styles, options.markerOffset ?? 0);
     const compiled = getCompiledTemplate(result);
@@ -1852,7 +1860,7 @@ export function hydrate(
       styles,
       styleClaim,
       fastStringBinding: findFastStringBinding(bindings),
-      rootStyleDependenciesEmpty: result.styleDependencies.length === 0,
+      rootStyleDependenciesEmpty: styleDependencies.length === 0,
       nodes: [...container.childNodes],
       suspended: false,
       hydrated: true,

--- a/tests/component-styles.spec.ts
+++ b/tests/component-styles.spec.ts
@@ -10,6 +10,7 @@ import {
   createApp,
   compareComponentStyles,
   createComponentStyleDependency,
+  createComponentStyleSelection,
   createComponentStyleOwner,
   css,
   defineMolecule,
@@ -17,6 +18,7 @@ import {
   directive,
   html,
   nothing,
+  repeat,
   render,
   unmount,
 } from '@gluonjs/core';
@@ -29,6 +31,7 @@ import {
   inputStyles,
   labelStyles,
   progressStyles,
+  Radio,
   radioStyles,
   selectStyles,
   statusBadgeStyles,
@@ -55,6 +58,8 @@ import {
 } from '@gluonjs/molecules';
 import { appShellStyles } from '@gluonjs/organisms';
 import { nextTick } from '@gluonjs/reactivity';
+import { hydrateTemplate } from '@gluonjs/ssr/hydration';
+import { createStyleManifest, prepareForHydration, renderStyleCarriers } from '@gluonjs/ssr';
 
 const allComponentSheets = [
   accordionStyles,
@@ -197,6 +202,44 @@ describe('usage-driven component styles', () => {
     expect(document.adoptedStyleSheets).toContain(buttonStyles);
     render(html`${nothing}${nothing}`, first);
     expect(document.adoptedStyleSheets).not.toContain(buttonStyles);
+  });
+
+  it('collects Radio styles through a molecule wrapper before first measurable render and hydration', async () => {
+    const RadioField = defineMolecule((props: { readonly name: string; readonly label: string }) => html`
+      <label class="radio-field">
+        ${repeat([props], (item) => item.name, (item) => Radio({
+          name: item.name,
+          attributes: { 'aria-label': item.label },
+        }))}
+        <span>${props.label}</span>
+      </label>
+    `, 'RadioField');
+    const value = html`${RadioField({ name: 'finish', label: 'Graphite' })}`;
+
+    expect(createComponentStyleSelection(value).entries).toEqual([
+      { id: 'gluon-atom-radio', sheet: radioStyles, scope: 'gluon-component' },
+    ]);
+
+    const selection = createComponentStyleSelection(value);
+    const manifest = createStyleManifest(selection);
+    const prepared = await prepareForHydration(value);
+    const styleHost = document.createElement('div');
+    const styleRoot = styleHost.attachShadow({ mode: 'open' });
+    styleRoot.innerHTML = renderStyleCarriers(manifest);
+    const root = document.createElement('div');
+    root.innerHTML = prepared.html;
+    const label = root.querySelector('label.radio-field');
+    styleRoot.append(root);
+    document.body.append(styleHost);
+
+    const result = await hydrateTemplate(value, root, { styleRoot, styles: manifest });
+
+    expect(result).toMatchObject({ retained: true, recovered: false });
+    expect(root.querySelector('label.radio-field')).toBe(label);
+    expect(styleRoot.adoptedStyleSheets).toContain(radioStyles);
+    expect(styleRoot.adoptedStyleSheets.filter((sheet) => sheet === radioStyles)).toHaveLength(1);
+    styleHost.remove();
+    root.remove();
   });
 
   it('keeps deterministic layer order and unrelated sheet order', () => {

--- a/tests/ui-visual.spec.ts
+++ b/tests/ui-visual.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { beforeEach, expect, test } from 'vitest';
 import { page } from 'vitest/browser';
 import {
   Button,
@@ -19,10 +19,13 @@ import {
   css,
   render,
   unadoptStyles,
+  unmount,
 } from '../src/index.js';
 import { Accordion, ButtonGroup, Card, ChoiceGroup, ControlField, DialogSurface, Disclosure, EmptyState, FormField, InlineNotice, SegmentedControl, TableRegion, Tabs, createDialogSurfaceController } from '@gluonjs/molecules';
 import { AppShell } from '@gluonjs/organisms';
 import { Listbox, q } from '@gluonjs/quarks';
+
+beforeEach(() => unmount(document.body));
 
 test('matches the stable light-theme UI composition', async () => {
   document.body.replaceChildren();


### PR DESCRIPTION
Closes #373

## Summary
- collect nested component stylesheet dependencies before root render and hydration claims
- reuse one traversal for arrays, nested templates, keyed RepeatResult values, and conflicting-id detection
- retain nested Atom dependencies on composed Molecule results
- prove the production clean-install handoff with a packed public-package consumer at 390x844
- document nested client/SSR composition behavior

## Verification
- npx vitest run tests/component-styles.spec.ts (12/12)
- npm run check:component-library-clean-install
  - clean packed install/typecheck/Vite build
  - input.gluon-radio first measurement: 20px x 20px
  - existing Product Picker interaction and teardown retained
- npm run build:core
- npm run check:budgets
- git diff --check
- independent read-only review after RepeatResult fix: mergeable

## Shop decision
The current GLUON GOODS flow does not render Radio through a composed Molecule, so adding a decorative route would not be honest acceptance. The canonical packed component-library consumer reproduces the real downstream failure shape and remains the visible acceptance surface.
