### PR TITLE
docs: add version-to-version upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - a form-associated `@gluonjs/json-forms` Custom Element for the documented JSON Schema subset
 - request-free, DOM-independent form orchestration through `createFormController()` beside the native UI compositions
 - a tested, reversible [Vue-to-Gluon cutover playbook](docs-site/content/1.9.0/migration/vue-to-gluon-cutover/index.md)
+- a versioned [Gluon upgrade guide](docs-site/content/1.9.0/migration/upgrade/index.md)
 - nested templates, index-based arrays, and keyed `repeat()` reconciliation
 - standalone DOM-free reactivity with refs, proxies, effects, and computed values
 - reactive Custom Elements through `GluonElement`
@@ -795,6 +796,7 @@ The following points describe architectural advantages and design goals. Outcome
 - [Report-only Vue migration analyzer RFC](docs/rfcs/0003-report-only-vue-migration-analyzer.md)
 - [Bounded Vue codemod no-go decision](docs/vue-codemod-decision.md)
 - [Browser, runtime, and style transport ADR](docs/adrs/0001-browser-runtime-and-style-transport.md)
+- [Gluon upgrade guide](docs-site/content/1.9.0/migration/upgrade/index.md)
 - [Accessibility and compatibility support matrix](docs/support-matrix.md)
 - [Package, release, and supply-chain governance ADR](docs/adrs/0002-package-release-and-supply-chain-governance.md)
 - [Release operations and protected publication runbook](docs/releasing.md)

--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -96,6 +96,9 @@ observable results, lifecycle ownership, failure handling, and cleanup where the
 API requires them. The gate rejects compiler-only constructs such as declared
 argument tuples, empty type aliases, or bare value reads, as well as the former
 generic runtime-owner copy.
+The versioned migration tree also includes a maintained release-upgrade guide
+for lockstep package moves, semver policy, deprecation handling, rollback, and
+upgrade verification.
 
 All TypeScript and Vue example sources live in `examples/` and are compiled
 through `examples/tsconfig.json` plus the maintained Vite configurations;

--- a/docs-site/content/1.9.0/migration/index.md
+++ b/docs-site/content/1.9.0/migration/index.md
@@ -34,6 +34,11 @@ For a reversible route from coexistence to full application ownership, follow
 the [tested Vue-to-Gluon cutover playbook](./vue-to-gluon-cutover/). It uses the
 production GLUON GOODS product configurator below as one continuous case study.
 
+For version upgrades inside the current release train, follow the
+[Gluon upgrade guide](./upgrade/). It documents the lockstep package rule,
+supported Node and browser boundaries, semver and deprecation policy, and the
+verification commands that match the released `1.9.0` line.
+
 ## Vue-to-Gluon concept map
 
 | Vue concept | Gluon contract | Migration work |

--- a/docs-site/content/1.9.0/migration/upgrade/index.md
+++ b/docs-site/content/1.9.0/migration/upgrade/index.md
@@ -1,0 +1,130 @@
+# Gluon upgrade guide
+
+Use this guide when moving an existing application or workspace to a newer
+Gluon release line.
+
+## Supported upgrade path
+
+Gluon is released as one lockstep package train. The current release line is
+`1.9.0`, and every official `@gluonjs/*` package and `create-gluon` ship at
+the same version in that line. When you upgrade, keep every consumed Gluon
+package on the same release version as the rest of the train.
+
+Supported release-to-release upgrades are the versioned lines recorded in the
+release archive and changelog. For the maintained documentation set, the
+current supported target is `1.9.0`; older versioned docs remain available in
+the archive until their release line leaves support.
+
+## Runtime prerequisites
+
+- Use Node `^22.12.0 || ^24.0.0`; this is the published package-engine range.
+- Run browser verification in the maintained Playwright Chromium, Firefox, and
+  WebKit lanes. This is not a promise for every branded browser release.
+- Browser styling requires constructable `CSSStyleSheet`, `replaceSync()`, and
+  `adoptedStyleSheets`; Gluon does not provide a `<style>` fallback.
+
+Read the [support matrix](/gluon/1.9.0/reference/support-matrix/) before changing
+the application's Node or browser baseline in the same upgrade.
+
+## Policy facts
+
+- `1.0` introduced the current semver policy: an incompatible public API
+  change requires a major release.
+- A deprecated API remains for at least the next stable minor, and the
+  documented alternative, migration instructions, changelog entry, and TypeScript
+  metadata are provided where applicable.
+- The documentation tree and package portal use the same versioned release line
+  as the released packages.
+- Application code must import public package entry points only. Private
+  repository imports and deep package internals are unsupported, and Gluon
+  does not provide automatic rewriting for them.
+
+## Before upgrading
+
+1. Start from a clean worktree or commit the pre-upgrade state on a dedicated
+   branch so rollback cannot discard unrelated changes.
+2. Record the installed Gluon version from `package.json` and the lockfile.
+3. Inventory every consumed `@gluonjs/*` package and `create-gluon`.
+4. Review the release archive, changelog, and diagnostic catalog for the
+   version you are moving to.
+5. Keep the package set lockstep on one version before and after the upgrade.
+
+### single-package app
+
+Use these commands from the application root:
+
+```sh
+npm pkg get dependencies devDependencies
+npm ls --depth=0 @gluonjs/core @gluonjs/reactivity @gluonjs/router @gluonjs/store @gluonjs/ssr @gluonjs/i18n @gluonjs/vite @gluonjs/gluon-components-vite @gluonjs/test-utils @gluonjs/devtools @gluonjs/devtools-api @gluonjs/graph @gluonjs/language-server @gluonjs/vue-migration-analyzer @gluonjs/quarks @gluonjs/atoms @gluonjs/molecules @gluonjs/organisms @gluonjs/json-forms create-gluon
+npm install --save-exact @gluonjs/core@1.9.0 @gluonjs/reactivity@1.9.0 @gluonjs/router@1.9.0 @gluonjs/store@1.9.0
+npm ci
+git diff -- package.json package-lock.json
+npm run typecheck
+npm run build
+npm test
+```
+
+The install line is an example for an application consuming those four
+packages. Remove packages it does not consume and add every other consumed
+official package with the same exact `1.9.0` target.
+
+### Workspace or root consumer
+
+Use these commands from the workspace root:
+
+```sh
+npm pkg get workspaces
+npm ls --depth=0 @gluonjs/core @gluonjs/reactivity @gluonjs/router @gluonjs/store @gluonjs/ssr @gluonjs/i18n @gluonjs/vite @gluonjs/gluon-components-vite @gluonjs/test-utils @gluonjs/devtools @gluonjs/devtools-api @gluonjs/graph @gluonjs/language-server @gluonjs/vue-migration-analyzer @gluonjs/quarks @gluonjs/atoms @gluonjs/molecules @gluonjs/organisms @gluonjs/json-forms create-gluon
+npm install --workspace ./apps/storefront --save-exact @gluonjs/core@1.9.0 @gluonjs/router@1.9.0 @gluonjs/store@1.9.0
+npm install --workspace ./apps/server --save-exact @gluonjs/ssr@1.9.0 @gluonjs/router@1.9.0 @gluonjs/store@1.9.0
+npm ci
+git diff -- package.json package-lock.json packages/*/package.json packages/*/package-lock.json
+npm run typecheck
+npm run build
+npm test
+```
+
+Replace the example workspace paths and package lists with the real consumers.
+If the workspace root itself consumes Gluon, update it with
+`npm install --include-workspace-root --save-exact` and the same target version.
+
+## Rollback
+
+If the upgrade does not validate, first inspect `git diff` and confirm that the
+listed files contain only upgrade changes. Then restore the previous lockstep
+release before making further edits:
+
+```sh
+git restore package.json package-lock.json
+npm ci
+npm run typecheck
+npm run build
+npm test
+```
+
+For a workspace, restore the same files in every affected package before
+re-running the clean install and verification commands.
+
+## Verification matrix
+
+Match the supported release with the existing customer-flow evidence:
+
+| Surface | Point to the real command or API |
+| --- | --- |
+| SSR and hydration | `npm run test:ssr` and `tests/hydration.spec.ts` |
+| Router deep links and back/forward | `npm run test:router-browser` and `tests/router.spec.ts` |
+| Store persistence | `npm run test:store` and `tests/shop-example.spec.ts` |
+| Usage-driven component styles | `npm run test:browser` and `tests/styles-and-element.spec.ts` |
+| Language server and editor tooling | `npm run test:language-server` and `gluon-language-server --stdio` |
+
+## Where to read next
+
+- [Changelog](https://github.com/marcmalerei/gluon/blob/main/CHANGELOG.md)
+- [Releases](https://github.com/marcmalerei/gluon/releases)
+- [Release archive](/gluon/archive/)
+- [Published package archive](https://www.npmjs.com/org/gluonjs)
+- [Diagnostic catalog](/gluon/1.9.0/reference/diagnostics/)
+- [Support matrix](/gluon/1.9.0/reference/support-matrix/)
+- [Release operations](/gluon/1.9.0/guides/releasing/)
+- [Migration index](/gluon/1.9.0/migration/)
+- [Package portal](/gluon/1.9.0/packages/)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,6 +4,8 @@ Gluon uses one lockstep release for the 21 packages in
 [`package-contract.json`](../package-contract.json). The executable release
 contract is [`release/release-contract.json`](../release/release-contract.json),
 and `.github/workflows/release.yml` is the only supported publication path.
+For day-to-day version upgrades, start with the
+[Gluon upgrade guide](/gluon/1.9.0/migration/upgrade/).
 
 ## Current publication state
 

--- a/scripts/build-docs.mjs
+++ b/scripts/build-docs.mjs
@@ -329,6 +329,7 @@ function packageIndexContent(version, packages) {
   return `<p class="eyebrow">${packages.length} packages · lockstep release train</p>
 <h1>Build with the package that owns the boundary.</h1>
 <p class="package-lede">Gluon is split into small public entry points. Find a package by capability, verify its runtime and peers, then open its API reference and runnable starter.</p>
+<p class="package-lede"><a href="${base}${version}/migration/upgrade/">Read the upgrade guide</a> for the lockstep release rule, rollback commands, and post-upgrade verification matrix.</p>
 <label class="package-search"><span>Search packages</span><input type="search" placeholder="Search by name or capability" data-package-search></label>
 <p class="package-search-status" data-package-search-status aria-live="polite">${packages.length} packages</p>
 <section class="package-cards" aria-label="Gluon packages">${cards}</section>`;

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -24,6 +24,7 @@ for (const version of versions.supported) {
     'api/index.html',
     'cookbook/index.html',
     'migration/index.html',
+    'migration/upgrade/index.html',
     'migration/vue-to-gluon-cutover/index.html',
     'migration/vue-analyzer/index.html',
     'migration/vue-codemod-decision/index.html',
@@ -44,6 +45,9 @@ if ((packageIndexHtml.match(/data-package-card/g) ?? []).length !== currentPacka
 }
 if (!packageIndexHtml.includes('public entry points')) {
   throw new Error('package portal index must name the displayed metric as public entry points.');
+}
+if (!packageIndexHtml.includes(`href="/gluon/${versions.latest}/migration/upgrade/"`)) {
+  throw new Error('package portal index must link to the versioned upgrade guide.');
 }
 for (const entry of currentPackages) {
   const packageSlug = entry.name === '@gluonjs/core' ? 'core' : entry.name.replace(/^@gluonjs\//, '');
@@ -156,6 +160,48 @@ const componentGuide = await readFile(resolve(
   versions.latest,
   'guides/components/index.md',
 ), 'utf8');
+const upgradeGuide = await readFile(resolve(
+  siteRoot,
+  'content',
+  versions.latest,
+  'migration/upgrade/index.md',
+), 'utf8');
+const normalizedUpgradeGuide = upgradeGuide.replace(/\s+/g, ' ');
+for (const required of [
+  '# Gluon upgrade guide',
+  'Supported release-to-release upgrades are the versioned lines recorded in the release archive and changelog.',
+  'A deprecated API remains for at least the next stable minor',
+  'Private repository imports and deep package internals are unsupported',
+  'Node `^22.12.0 || ^24.0.0`',
+  'Playwright Chromium, Firefox, and WebKit lanes',
+  'constructable `CSSStyleSheet`, `replaceSync()`, and `adoptedStyleSheets`',
+  'single-package app',
+  'Workspace or root consumer',
+  'Verification matrix',
+]) if (!normalizedUpgradeGuide.includes(required)) throw new Error(`upgrade guide is missing: ${required}`);
+for (const required of [
+  'npm ci',
+  'git diff -- package.json package-lock.json',
+  'npm run typecheck',
+  'npm run build',
+  'npm test',
+  'npm ls --depth=0 @gluonjs/core',
+  'npm install --save-exact @gluonjs/core@1.9.0',
+  'npm install --workspace ./apps/storefront --save-exact',
+  'npm pkg get workspaces',
+  'git restore package.json package-lock.json',
+]) if (!upgradeGuide.includes(required)) throw new Error(`upgrade guide commands are missing: ${required}`);
+for (const required of [
+  '/gluon/1.9.0/reference/diagnostics/',
+  'https://www.npmjs.com/org/gluonjs',
+]) if (!upgradeGuide.includes(required)) throw new Error(`upgrade guide link is missing: ${required}`);
+for (const required of [
+  'SSR and hydration',
+  'Router deep links and back/forward',
+  'Store persistence',
+  'Usage-driven component styles',
+  'Language server and editor tooling',
+]) if (!upgradeGuide.includes(required)) throw new Error(`upgrade guide verification matrix is missing: ${required}`);
 for (const required of [
   'The four terms to know',
   'Choose an authoring model',


### PR DESCRIPTION
Closes #391

## Summary
- add a versioned Gluon-to-Gluon upgrade guide with lockstep package commands, supported Node/browser/style prerequisites, deprecation and rollback policy
- link changelog, releases, docs/npm archives, diagnostics, support boundaries, package portal, README, and release runbook
- enforce the page, commands, prerequisites, links, and verification matrix in the docs gate

## Verification
- npm run check:docs
- node scripts/validate-docs.mjs
- git diff --check