### PR TITLE
feat(store): add persistence migrations

### DIFF
--- a/docs-site/api-examples.json
+++ b/docs-site/api-examples.json
@@ -1394,22 +1394,41 @@
         "  createStoreManager,",
         "  defineStore,",
         "  type PersistOptions,",
+        "  type PersistedStateEnvelope,",
+        "  type PersistedStateErrorContext,",
+        "  type PersistedStateRecord,",
+        "  type PersistedStateRecovery,",
+        "  type PersistLegacyMigration,",
+        "  type PersistMigrationStep,",
         "  type PersistencePluginOptions,",
         "  type StorageLike,",
         "} from '@gluonjs/store';",
         "",
         "type CartState = { items: string[]; open: boolean };",
-        "const values = new Map<string, string>([['goods:cart', '{\"items\":[\"lamp\"]}']]);",
+        "const saved: PersistedStateEnvelope = { version: 0, state: { items: ['lamp'] } };",
+        "const values = new Map<string, string>([['goods:cart', JSON.stringify(saved)]]);",
         "const storage: StorageLike = {",
         "  getItem: (key) => values.get(key) ?? null,",
         "  setItem: (key, value) => { values.set(key, value); },",
         "  removeItem: (key) => { values.delete(key); },",
         "};",
-        "const persist = { paths: ['items'] } satisfies PersistOptions<CartState>;",
+        "const migration: PersistMigrationStep = {",
+        "  from: 0,",
+        "  to: 1,",
+        "  migrate: (state) => ({ items: Array.isArray(state.items) ? state.items : [] }),",
+        "};",
+        "const legacy: PersistLegacyMigration = { to: 1, migrate: migration.migrate };",
+        "const migrated: PersistedStateRecord = migration.migrate(saved.state);",
+        "const persist = { paths: ['items'], version: 1, migrations: [migration], legacy } satisfies PersistOptions<CartState>;",
+        "let recovery: PersistedStateRecovery | undefined;",
         "const options = {",
         "  storage,",
         "  namespace: 'goods',",
-        "  onError: (error, storeId) => console.error(storeId, error),",
+        "  onError: (error, storeId, context) => {",
+        "    const errorContext: PersistedStateErrorContext | undefined = context;",
+        "    recovery = errorContext?.recovery;",
+        "    console.error(storeId, error);",
+        "  },",
         "} satisfies PersistencePluginOptions;",
         "const manager = createStoreManager({ plugins: [createPersistencePlugin(options)] });",
         "const cart = manager.use(defineStore({",
@@ -1418,7 +1437,7 @@
         "  persist,",
         "}));",
         "cart.$patch({ items: [...cart.items, 'tray'] });",
-        "console.log(values.get('goods:cart')); // {\"items\":[\"lamp\",\"tray\"]}",
+        "console.log(migrated, recovery, values.get('goods:cart')); // version 1 envelope",
         "manager.dispose();"
       ]
     },
@@ -5768,7 +5787,27 @@
     },
     "packages/store/src/interfaces/PersistOptions.md": {
       "recipe": "store-persistence",
-      "description": "Choose a custom storage key and the exact state properties that a persistent Store is allowed to save:"
+      "description": "Choose a custom storage key, selected state properties, current version, and explicit migration path for a persistent Store:"
+    },
+    "packages/store/src/interfaces/PersistedStateEnvelope.md": {
+      "recipe": "store-persistence",
+      "description": "Represent persisted Store state together with the exact schema version that owns its shape:"
+    },
+    "packages/store/src/interfaces/PersistedStateErrorContext.md": {
+      "recipe": "store-persistence",
+      "description": "Classify a persistence failure and expose the blocked payload, target version, and explicit recovery operations to application code:"
+    },
+    "packages/store/src/interfaces/PersistedStateRecovery.md": {
+      "recipe": "store-persistence",
+      "description": "Let an application deliberately reset, remove, or quarantine invalid persisted state before writes resume:"
+    },
+    "packages/store/src/interfaces/PersistLegacyMigration.md": {
+      "recipe": "store-persistence",
+      "description": "Decode an explicitly supported unversioned payload and name the version of the returned state:"
+    },
+    "packages/store/src/interfaces/PersistMigrationStep.md": {
+      "recipe": "store-persistence",
+      "description": "Advance one persisted Store schema version through a contiguous, application-owned migration step:"
     },
     "packages/store/src/interfaces/PersistencePluginOptions.md": {
       "recipe": "store-persistence",
@@ -5817,6 +5856,10 @@
     "packages/store/src/type-aliases/JsonValue.md": {
       "recipe": "store-runtime",
       "description": "Represent the recursive JSON-compatible arrays and records accepted in Store snapshots:"
+    },
+    "packages/store/src/type-aliases/PersistedStateRecord.md": {
+      "recipe": "store-persistence",
+      "description": "Accept an ordinary typed object record at a migration boundary before Gluon normalizes and validates it as JSON-safe state:"
     },
     "packages/store/src/type-aliases/StateTree.md": {
       "recipe": "store-runtime",

--- a/docs/store.md
+++ b/docs/store.md
@@ -83,9 +83,33 @@ the resulting change.
 ## Persistence and testing
 
 `createPersistencePlugin()` requires a `StorageLike` adapter. A definition must
-opt in with `persist: true` or selected state paths. The plugin hydrates at store
-creation and writes after transactions. It never accesses browser globals on
-its own.
+opt in with `persist: true` or selected state paths. The plugin hydrates at
+store creation and writes after transactions.
+
+Persisted records use a versioned envelope that is separate from
+`StoreSnapshot`. Definitions may declare a current persisted `version`, explicit
+contiguous `migrations` with `from`/`to` steps, and an explicit `legacy`
+decoder for older unversioned payloads. The plugin validates the envelope
+before patching state, classifies future/corrupt/migration failures, and
+exposes caller-controlled `reset()`, `remove()`, and `quarantine()` recovery
+hooks through `onError`. It never silently overwrites a bad payload.
+The legacy decoder's `to` field is the version of its returned state; any
+remaining contiguous migration steps run afterward. Removal and quarantine
+require an adapter with `removeItem()` and fail without unblocking writes when
+that capability is absent.
+Migration callbacks may return ordinary typed DTO records without adding a
+string index signature. Every result is still normalized and validated as
+JSON-safe state before it can be applied or persisted.
+
+Missing storage leaves the store defaults intact. Successful older state is
+migrated in memory and receives the current envelope on the next transaction;
+future, corrupt, missing-step, thrown-migration, invalid-output, and storage
+failures block persistence writes until explicit recovery succeeds.
+
+The application owns validation and suitability decisions. Persistence is not a
+security boundary and is only as safe as the application data it stores; use it
+for rollback-compatible app state, not for sensitive data unless the caller has
+audited the full storage lifecycle.
 
 `createTestingStoreManager()` returns an ordinary isolated manager with optional
 initial state. Tests therefore exercise the same actions, getters, plugins,

--- a/examples/shop/FEATURES.md
+++ b/examples/shop/FEATURES.md
@@ -47,7 +47,7 @@ uses the same quantity-control contract for the prior Gluon class API, the
 functional API, pinned Vue, and pinned React. Its metrics and limitations are
 validated independently from the shop's customer-flow evidence.
 | Native dialog and control accessibility | Search, mobile menu, product choices, and bag | `tests/shop-example.spec.ts` + 390px/320px browser QA | Integrated |
-| Official Store | Per-app bag state, configured line items, persisted bag, derived totals | Store Node/type suites + `tests/shop-example.spec.ts` | Integrated |
+| Official Store | Per-app bag state, configured line items, versioned persisted bag envelope, explicit legacy bag migration, derived totals | Store Node/type suites, `tests-node/store.spec.ts`, `tests/shop-example.spec.ts`, `tests-node/store.types.ts`, `npm run check:budgets` | Integrated |
 | Store actions + Router forms | Labeled delivery checkout, order summary, atomic order placement, and confirmation URL | Desktop/mobile shop flow + Store snapshot and browser assertions | Integrated purchase path |
 | `Suspense` and async component contract | Abortable product availability loading, explicit pending/error/retry states | Built-ins browser suite + `tests/shop-example.spec.ts` | Integrated |
 | `@gluonjs/ssr/streaming` progressive async-patch application | GLUON GOODS currently resolves its availability boundary through the request/hydration path; the public browser patch contract is verified with nested boundary and style-carrier fixtures because the shop has no streaming transport client to wire into honestly | `tests/hydration.spec.ts`, `tests-node/ssr.spec.ts`, `npm run typecheck:ssr` | Integrated as SSR infrastructure; shop unchanged for the verified transport-scope reason |

--- a/examples/shop/README.md
+++ b/examples/shop/README.md
@@ -32,7 +32,7 @@ The current slice uses the public Core, Reactivity, Router, and Store APIs to pr
   optimistic quantity state, exposed focus, and 44px actions
 - a labeled checkout form, exact order summary, and URL-addressable confirmation
 - a native captioned checkout order table in an overflow-aware `TableRegion`
-- one isolated Store manager per shop application and persisted configured bag lines
+- one isolated Store manager per shop application and persisted configured bag lines with explicit legacy bag migration
 - abortable product availability with explicit loading, error, timeout, and retry UI
 - TC39 Signal-driven workshop availability through the optional Reactivity adapter
 - cached route views across back/forward traversal

--- a/examples/shop/project-analysis.json
+++ b/examples/shop/project-analysis.json
@@ -2121,7 +2121,7 @@
       },
       "confidence": "exact",
       "file": "state.ts",
-      "line": 25
+      "line": 44
     }
   ],
   "ssrBoundaries": [

--- a/examples/shop/src/state.ts
+++ b/examples/shop/src/state.ts
@@ -1,7 +1,10 @@
 import { defineStore, type StoreManager } from '@gluonjs/store';
 import type { Product } from './data.js';
+import { products } from './data.js';
 import {
   createDefaultProductConfiguration,
+  cloneProductConfiguration,
+  isProductConfiguration,
   type ProductConfiguration,
 } from './product-configuration.js';
 
@@ -20,6 +23,22 @@ export interface ShopOrder {
   readonly total: number;
   readonly email: string;
   readonly deliveryInstructions: string;
+}
+
+interface LegacyBagLine {
+  readonly productSlug: string;
+  readonly quantity: number;
+  readonly configuration: ProductConfiguration;
+}
+
+function isLegacyBagLine(value: unknown): value is LegacyBagLine {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<LegacyBagLine>;
+  return typeof candidate.productSlug === 'string'
+    && typeof candidate.quantity === 'number'
+    && Number.isInteger(candidate.quantity)
+    && candidate.quantity > 0
+    && isProductConfiguration(candidate.configuration);
 }
 
 export const shopStoreDefinition = defineStore('shop', () => ({
@@ -84,7 +103,29 @@ export const shopStoreDefinition = defineStore('shop', () => ({
       return order;
     },
   }),
-  persist: { paths: ['bag'] },
+  persist: {
+    paths: ['bag'],
+    version: 1,
+    legacy: {
+      to: 1,
+      migrate: (state: Readonly<Record<string, unknown>>) => ({
+        bag: Array.isArray(state.bag)
+          ? state.bag
+              .filter(isLegacyBagLine)
+              .flatMap((line) => {
+                const product = products.find((item) => item.slug === line.productSlug);
+                if (!product) return [];
+                return [{
+                  key: [product.slug, line.configuration.finish, line.configuration.temperature, line.configuration.cable].join(':'),
+                  product,
+                  configuration: cloneProductConfiguration(line.configuration),
+                  quantity: line.quantity,
+                }];
+              })
+          : [],
+      }),
+    },
+  },
 });
 
 export function createShopStore(manager: StoreManager) {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -74,8 +74,47 @@ const manager = createStoreManager({
 ```
 
 The plugin reads only definitions that opt in through `persist`. Selected paths
-are written after recorded transactions. Storage access failures are reported
-through `onError` when supplied.
+are written after recorded transactions as a versioned persisted-state envelope
+that is independent from `StoreSnapshot`, devtools, or HMR versions. Definitions
+may opt into explicit contiguous `from -> to` migrations and, when needed, an
+explicit legacy decoder for older unversioned payloads. The decoder's `to`
+value names the version of the state it returns; later declared steps then run
+in order up to the store's current persistence version.
+Migration callbacks accept ordinary typed object records; application DTOs do
+not need a string index signature. Gluon normalizes and validates every result
+as JSON-safe state before applying or storing it.
+
+```ts
+const profile = defineStore({
+  id: 'profile',
+  state: () => ({ count: 0, label: 'new' }),
+  persist: {
+    version: 2,
+    legacy: {
+      to: 0,
+      migrate: (state) => ({ count: Number(state.count ?? 0) }),
+    },
+    migrations: [
+      { from: 0, to: 1, migrate: (state) => ({ ...state, label: 'legacy' }) },
+      { from: 1, to: 2, migrate: (state) => ({ ...state, label: String(state.label) }) },
+    ],
+  },
+});
+```
+
+Storage access, parse, future-version, corrupt-envelope, and migration errors
+are reported through `onError` when supplied together with a recovery context.
+The context exposes caller-owned `reset()`, `remove()`, and `quarantine()`
+operations. The plugin never silently overwrites a bad payload; the caller must
+choose the recovery action. `remove()` and `quarantine()` require the supplied
+`StorageLike` adapter to implement `removeItem()`; otherwise they throw and the
+store remains blocked from persistence writes.
+
+A missing key leaves the definition's initial state unchanged. A valid older
+envelope is migrated in memory and is written with the current version after
+the next store transaction. Future, corrupt, missing-step, thrown-migration,
+invalid-output, and storage failures block later persistence writes until one
+of the explicit recovery operations succeeds.
 
 ## SSR, hydration, and HMR
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -56,6 +56,68 @@ export type StoreActionSubscription = (context: StoreActionContext) => void;
 export interface PersistOptions<State extends StateTree> {
   readonly key?: string;
   readonly paths?: readonly (keyof State & string)[];
+  readonly version?: number;
+  readonly migrations?: readonly PersistMigrationStep[];
+  readonly legacy?: PersistLegacyMigration;
+}
+
+/**
+ * The object shape exposed to migration callbacks.
+ *
+ * Application DTO interfaces do not need a string index signature. Every
+ * migration result is still normalized and validated as JSON before Gluon
+ * patches store state or writes it to storage.
+ */
+export type PersistedStateRecord = Readonly<Record<string, unknown>>;
+
+type PersistedJsonStateRecord = Readonly<Record<string, JsonValue>>;
+
+export interface PersistedStateEnvelope {
+  readonly version: number;
+  readonly state: PersistedStateRecord;
+}
+
+export interface PersistMigrationStep {
+  readonly from: number;
+  readonly to: number;
+  readonly migrate: (state: PersistedStateRecord) => PersistedStateRecord;
+}
+
+export interface PersistLegacyMigration {
+  /** Version of the state returned by migrate(). */
+  readonly to: number;
+  readonly migrate: (state: PersistedStateRecord) => PersistedStateRecord;
+}
+
+export interface PersistedStateRecovery {
+  readonly key: string;
+  reset(): void;
+  remove(): void;
+  quarantine(): void;
+}
+
+export interface PersistedStateErrorContext {
+  readonly key: string;
+  readonly raw: string | null;
+  readonly kind:
+    | 'legacy'
+    | 'future'
+    | 'storage-read'
+    | 'storage-write'
+    | 'corrupt-json'
+    | 'corrupt-envelope'
+    | 'migration-missing'
+    | 'migration-throw'
+    | 'migration-invalid-output';
+  readonly version?: number;
+  readonly targetVersion: number;
+  readonly recovery: PersistedStateRecovery;
+}
+
+interface PersistencePlan {
+  readonly version: number;
+  readonly steps: readonly PersistMigrationStep[];
+  readonly legacy?: PersistLegacyMigration;
 }
 
 export interface DefineStoreOptions<
@@ -606,7 +668,7 @@ export interface StorageLike {
 export interface PersistencePluginOptions {
   readonly storage: StorageLike;
   readonly namespace?: string;
-  readonly onError?: (error: unknown, storeId: string) => void;
+  readonly onError?: (error: unknown, storeId: string, recovery?: PersistedStateErrorContext) => void;
 }
 
 export function createPersistencePlugin(options: PersistencePluginOptions): StorePlugin {
@@ -615,6 +677,7 @@ export function createPersistencePlugin(options: PersistencePluginOptions): Stor
     if (!persist) return;
     const config = persist === true ? {} : persist;
     const key = config.key ?? `${options.namespace ?? 'gluon'}:${definition.id}`;
+    const plan = normalizePersistencePlan(config);
     const select = () => {
       const state = store.$state;
       if (!config.paths) return snapshotState(state);
@@ -624,22 +687,262 @@ export function createPersistencePlugin(options: PersistencePluginOptions): Stor
       }
       return selected;
     };
+    let lastRaw: string | null = null;
+    let recoveryState: 'ready' | 'blocked' = 'ready';
+    const recovery = createRecovery({
+      key,
+      storage: options.storage,
+      store,
+      select,
+      version: plan.version,
+      getRaw: () => lastRaw,
+      setRaw: (raw) => {
+        lastRaw = raw;
+      },
+      onRecover: () => {
+        recoveryState = 'ready';
+      },
+    });
 
     try {
-      const saved = options.storage.getItem(key);
-      if (saved) store.$patch(parseStateRecord(saved), { source: 'persistence' });
+      lastRaw = options.storage.getItem(key);
+      const loaded = loadPersistedState(lastRaw, plan, definition.id);
+      if (loaded.state) {
+        store.$patch(loaded.state, { source: 'persistence' });
+      }
     } catch (error) {
-      options.onError?.(error, definition.id);
+      recoveryState = 'blocked';
+      options.onError?.(error, definition.id, createRecoveryContext(error, {
+        key,
+        raw: lastRaw,
+        targetVersion: plan.version,
+        recovery,
+      }, 'storage-read'));
     }
 
     return store.$subscribe(() => {
+      if (recoveryState === 'blocked') return;
       try {
-        options.storage.setItem(key, JSON.stringify(select()));
+        const raw = JSON.stringify({ version: plan.version, state: select() });
+        options.storage.setItem(key, raw);
+        lastRaw = raw;
       } catch (error) {
-        options.onError?.(error, definition.id);
+        recoveryState = 'blocked';
+        options.onError?.(error, definition.id, createRecoveryContext(error, {
+          key,
+          raw: lastRaw,
+          targetVersion: plan.version,
+          recovery,
+        }, 'storage-write'));
       }
     });
   };
+}
+
+function normalizePersistencePlan<State extends StateTree>(config: PersistOptions<State>): PersistencePlan {
+  const version = config.version ?? 1;
+  if (!Number.isInteger(version) || version < 1) throw new TypeError('Persisted state version must be a positive integer.');
+  const steps = [...(config.migrations ?? [])];
+  for (const step of steps) {
+    if (!Number.isInteger(step.from) || !Number.isInteger(step.to) || step.from < 0 || step.to <= step.from || typeof step.migrate !== 'function') {
+      throw new TypeError('Persisted state migrations must define increasing integer from/to versions.');
+    }
+    if (step.to !== step.from + 1) {
+      throw new TypeError('Persisted state migrations must advance one version at a time.');
+    }
+  }
+  const ordered = [...steps].sort((left, right) => left.from - right.from);
+  for (let index = 0; index < ordered.length; index += 1) {
+    const step = ordered[index]!;
+    const ambiguous = ordered.find((other, otherIndex) => otherIndex !== index && (other.from === step.from || other.to === step.to));
+    if (ambiguous) throw new TypeError('Persisted state migrations must not duplicate from/to versions.');
+    const previous = ordered[index - 1];
+    if (previous && previous.to !== step.from) {
+      throw new TypeError('Persisted state migrations must be contiguous.');
+    }
+    if (step.to > version) throw new TypeError('Persisted state migrations cannot target future versions.');
+  }
+  if (ordered.length > 0 && ordered.at(-1)!.to !== version) {
+    throw new TypeError('Persisted state migrations must end at the configured version.');
+  }
+  if (config.legacy) {
+    if (!Number.isInteger(config.legacy.to) || config.legacy.to < 0 || config.legacy.to > version || typeof config.legacy.migrate !== 'function') {
+      throw new TypeError('Persisted legacy migrations require an integer output version at or below the configured version.');
+    }
+    if (config.legacy.to < version && !ordered.some((step) => step.from === config.legacy!.to)) {
+      throw new TypeError('Persisted legacy migration output requires a contiguous step to the configured version.');
+    }
+  }
+  return { version, steps: ordered, legacy: config.legacy };
+}
+
+function loadPersistedState(
+  saved: string | null,
+  plan: PersistencePlan,
+  storeId: string,
+): { readonly state: PersistedJsonStateRecord | null; readonly version?: number } {
+  if (saved === null) return { state: null };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(saved);
+  } catch (error) {
+    throw new PersistenceFailure('corrupt-json', saved, plan.version, storeId, error);
+  }
+  if (isEnvelopeCandidate(parsed)) {
+    if (!isPersistedEnvelope(parsed)) {
+      throw new PersistenceFailure('corrupt-envelope', saved, plan.version, storeId, new TypeError('Persisted state envelope requires a non-negative integer version and plain-object state.'));
+    }
+    const state = assertPersistedStateRecord(parsed.state, plan.version, storeId, 'corrupt-envelope');
+    return migratePersistedState(state, parsed.version, saved, plan, storeId);
+  }
+  if (isPlainRecord(parsed)) {
+    if (!plan.legacy) {
+      throw new PersistenceFailure('legacy', saved, plan.version, storeId, new TypeError('Legacy persisted state requires an explicit legacy migration policy.'));
+    }
+    const legacyState = assertPersistedStateRecord(parsed, plan.version, storeId, 'corrupt-envelope');
+    let migrated: PersistedStateRecord;
+    try {
+      migrated = plan.legacy.migrate(legacyState);
+    } catch (error) {
+      throw new PersistenceFailure('migration-throw', saved, plan.version, storeId, error, plan.legacy.to);
+    }
+    const state = assertPersistedStateRecord(migrated, plan.version, storeId, 'migration-invalid-output');
+    return migratePersistedState(state, plan.legacy.to, saved, plan, storeId);
+  }
+  throw new PersistenceFailure('corrupt-envelope', saved, plan.version, storeId, new TypeError('Persisted store state must be a plain object or versioned envelope.'));
+}
+
+function migratePersistedState(
+  initialState: PersistedStateRecord,
+  initialVersion: number,
+  raw: string,
+  plan: PersistencePlan,
+  storeId: string,
+): { readonly state: PersistedJsonStateRecord; readonly version: number } {
+  if (initialVersion > plan.version) {
+    throw new PersistenceFailure('future', raw, plan.version, storeId, new TypeError('Persisted state version is newer than the configured store version.'), initialVersion);
+  }
+  let state = assertPersistedStateRecord(initialState, plan.version, storeId, 'migration-invalid-output');
+  let version = initialVersion;
+  while (version < plan.version) {
+    const step = plan.steps.find((candidate) => candidate.from === version);
+    if (!step) {
+      throw new PersistenceFailure('migration-missing', raw, plan.version, storeId, new TypeError(`Missing persisted migration step from version ${version}.`), version);
+    }
+    let output: PersistedStateRecord;
+    try {
+      output = step.migrate(state);
+    } catch (error) {
+      throw new PersistenceFailure('migration-throw', raw, plan.version, storeId, error, version);
+    }
+    state = assertPersistedStateRecord(output, plan.version, storeId, 'migration-invalid-output');
+    version = step.to;
+  }
+  return { state, version };
+}
+
+function createRecovery(options: {
+  readonly key: string;
+  readonly storage: StorageLike;
+  readonly store: StorePluginStore;
+  readonly select: () => Readonly<Record<string, JsonValue>>;
+  readonly version: number;
+  readonly getRaw: () => string | null;
+  readonly setRaw: (raw: string | null) => void;
+  readonly onRecover: () => void;
+}): PersistedStateRecovery {
+  const removePersisted = (): void => {
+    if (!options.storage.removeItem) {
+      throw new Error('Persistence recovery requires StorageLike.removeItem().');
+    }
+    options.storage.removeItem(options.key);
+    options.setRaw(null);
+  };
+  return {
+    key: options.key,
+    reset() {
+      options.store.$reset({ source: 'persistence-recovery', recovery: 'reset' });
+      const raw = JSON.stringify({
+        version: options.version,
+        state: options.select(),
+      });
+      options.storage.setItem(options.key, raw);
+      options.setRaw(raw);
+      options.onRecover();
+    },
+    remove() {
+      removePersisted();
+      options.onRecover();
+    },
+    quarantine() {
+      const quarantineKey = `${options.key}:quarantine`;
+      options.storage.setItem(quarantineKey, options.getRaw() ?? '');
+      removePersisted();
+      options.onRecover();
+    },
+  };
+}
+
+function createRecoveryContext(error: unknown, options: {
+  readonly key: string;
+  readonly raw: string | null;
+  readonly targetVersion: number;
+  readonly recovery: PersistedStateRecovery;
+}, fallbackKind: PersistedStateErrorContext['kind']): PersistedStateErrorContext {
+  const kind = error instanceof PersistenceFailure ? error.kind : fallbackKind;
+  return {
+    key: options.key,
+    raw: options.raw,
+    kind,
+    targetVersion: options.targetVersion,
+    version: error instanceof PersistenceFailure ? error.version : undefined,
+    recovery: options.recovery,
+  };
+}
+
+class PersistenceFailure extends TypeError {
+  constructor(
+    readonly kind: PersistedStateErrorContext['kind'],
+    readonly raw: string | null,
+    readonly targetVersion: number,
+    readonly storeId: string,
+    cause: unknown,
+    readonly version?: number,
+  ) {
+    super(`Persisted state for store "${storeId}" is ${kind}: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = 'PersistenceFailure';
+  }
+}
+
+function isEnvelopeCandidate(value: unknown): value is Record<string, unknown> {
+  return isPlainRecord(value)
+    && Object.prototype.hasOwnProperty.call(value, 'version')
+    && Object.prototype.hasOwnProperty.call(value, 'state');
+}
+
+function isPersistedEnvelope(value: unknown): value is PersistedStateEnvelope {
+  return isEnvelopeCandidate(value)
+    && typeof value.version === 'number'
+    && Number.isInteger(value.version)
+    && value.version >= 0
+    && isPlainRecord(value.state);
+}
+
+function assertPersistedStateRecord(
+  value: unknown,
+  targetVersion: number,
+  storeId: string,
+  kind: PersistedStateErrorContext['kind'],
+): PersistedJsonStateRecord {
+  if (!isPlainRecord(value)) throw new PersistenceFailure(kind, null, targetVersion, storeId, new TypeError('Persisted state must be a plain object.'));
+  try {
+    const normalized = toJsonValue(value, new WeakSet());
+    if (!isPlainRecord(normalized)) throw new TypeError('Persisted state must be a plain object.');
+    return normalized as PersistedJsonStateRecord;
+  } catch (error) {
+    if (error instanceof PersistenceFailure) throw error;
+    throw new PersistenceFailure(kind, null, targetVersion, storeId, error);
+  }
 }
 
 function snapshotState(state: StateTree): Readonly<Record<string, JsonValue>> {
@@ -714,13 +1017,6 @@ function isCompatibleValue(current: unknown, replacement: unknown): boolean {
 
 function cloneJsonCompatible(value: unknown): unknown {
   return JSON.parse(JSON.stringify(toJsonValue(value, new WeakSet()))) as unknown;
-}
-
-function parseStateRecord(serialized: string): Readonly<Record<string, JsonValue>> {
-  const value = JSON.parse(serialized) as unknown;
-  if (!isPlainRecord(value)) throw new TypeError('Persisted store state must be a plain object.');
-  for (const key of Object.keys(value)) assertSafeKey(key);
-  return value as Readonly<Record<string, JsonValue>>;
 }
 
 function assertSnapshot(snapshot: StoreSnapshot): void {

--- a/quality-budgets.json
+++ b/quality-budgets.json
@@ -1,8 +1,8 @@
 {
   "shop": {
     "htmlBytes": 1000,
-    "entryBytes": 252500,
-    "entryGzipBytes": 69000,
+    "entryBytes": 257500,
+    "entryGzipBytes": 70350,
     "imageBytes": 175000,
     "imageCount": 5
   }

--- a/tests-node/store.spec.ts
+++ b/tests-node/store.spec.ts
@@ -276,7 +276,7 @@ describe('@gluonjs/store HMR and universal state', () => {
 
 describe('@gluonjs/store persistence and testing', () => {
   it('hydrates and persists selected paths through an explicit storage adapter', () => {
-    const values = new Map<string, string>([['goods:cart', '{"items":["lamp"]}']]);
+    const values = new Map<string, string>([['goods:cart', '{"version":1,"state":{"items":["lamp"]}}']]);
     const storage: StorageLike = {
       getItem: (key) => values.get(key) ?? null,
       setItem: (key, value) => { values.set(key, value); },
@@ -296,26 +296,38 @@ describe('@gluonjs/store persistence and testing', () => {
     expect(store.items).toEqual(['lamp']);
     store.open = true;
     store.add('tray');
-    expect(JSON.parse(values.get('goods:cart')!)).toEqual({ items: ['lamp', 'tray'] });
-    expect(JSON.parse(values.get('goods:cart')!)).not.toHaveProperty('open');
+    expect(JSON.parse(values.get('goods:cart')!)).toEqual({ version: 1, state: { items: ['lamp', 'tray'] } });
+    expect(JSON.parse(values.get('goods:cart')!)).not.toHaveProperty('state.open');
   });
 
   it('reports storage failures and creates isolated testing stores with initial state', () => {
-    const onError = vi.fn();
-    const storage: StorageLike = {
-      getItem: () => { throw new Error('read failed'); },
-      setItem: () => { throw new Error('write failed'); },
-    };
     const persistent = defineStore({
       id: 'persistent',
       state: () => ({ value: 0 }),
       persist: true,
     });
-    const manager = createStoreManager({ plugins: [createPersistencePlugin({ storage, onError })] });
-    const store = manager.use(persistent);
-    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'read failed' }), 'persistent');
+
+    const readErrors = vi.fn();
+    const readStorage: StorageLike = {
+      getItem: () => { throw new Error('read failed'); },
+      setItem: () => { throw new Error('write failed'); },
+    };
+    createStoreManager({ plugins: [createPersistencePlugin({ storage: readStorage, onError: readErrors })] }).use(persistent);
+    expect(readErrors).toHaveBeenCalledWith(expect.objectContaining({ message: 'read failed' }), 'persistent', expect.objectContaining({
+      kind: 'storage-read',
+    }));
+    expect(() => readErrors.mock.calls[0]?.[2]?.recovery.remove()).toThrow('StorageLike.removeItem');
+
+    const writeErrors = vi.fn();
+    const writeStorage: StorageLike = {
+      getItem: () => null,
+      setItem: () => { throw new Error('write failed'); },
+    };
+    const store = createStoreManager({ plugins: [createPersistencePlugin({ storage: writeStorage, onError: writeErrors })] }).use(persistent);
     store.$patch({ value: 1 });
-    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'write failed' }), 'persistent');
+    expect(writeErrors).toHaveBeenCalledWith(expect.objectContaining({ message: 'write failed' }), 'persistent', expect.objectContaining({
+      kind: 'storage-write',
+    }));
 
     const first = createTestingStoreManager({ initialState: { persistent: { value: 4 } } });
     const second = createTestingStoreManager();
@@ -323,31 +335,275 @@ describe('@gluonjs/store persistence and testing', () => {
     expect(second.use(persistent).value).toBe(0);
   });
 
-  it('persists complete state under custom keys and rejects invalid persisted values', () => {
+  it('migrates envelope versions in contiguous steps and quarantines failed payloads on demand', () => {
+    const values = new Map<string, string>([
+      ['gluon:profile', JSON.stringify({ version: 0, state: { count: 2 } })],
+    ]);
+    const storage: StorageLike = {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => { values.set(key, value); },
+      removeItem: (key) => { values.delete(key); },
+    };
+    const legacyStore = defineStore({
+      id: 'profile',
+      state: () => ({ count: 0, label: 'ready', migrated: false }),
+      actions: (store) => ({
+        increment() { store.count += 1; },
+      }),
+      persist: {
+        version: 2,
+        migrations: [
+          {
+            from: 0,
+            to: 1,
+            migrate: (state) => ({ count: Number(state.count ?? 0), label: 'legacy' }),
+          },
+          {
+            from: 1,
+            to: 2,
+            migrate: (state) => ({ count: Number(state.count ?? 0), label: String(state.label), migrated: true }),
+          },
+        ],
+      },
+    });
+    const onError = vi.fn();
+    const manager = createStoreManager({ plugins: [createPersistencePlugin({ storage, onError })] });
+    const store = manager.use(legacyStore);
+    expect(store).toMatchObject({ count: 2, label: 'legacy', migrated: true });
+    store.increment();
+    expect(JSON.parse(values.get('gluon:profile')!)).toEqual({ version: 2, state: { count: 3, label: 'legacy', migrated: true } });
+
+    values.set('gluon:profile', JSON.stringify({ version: 5, state: { count: 1 } }));
+    const future = createStoreManager({
+      plugins: [createPersistencePlugin({ storage, onError })],
+    }).use(legacyStore);
+    expect(future.count).toBe(0);
+    expect(onError).toHaveBeenLastCalledWith(
+      expect.any(TypeError),
+      'profile',
+      expect.objectContaining({ kind: 'future', key: 'gluon:profile', targetVersion: 2 }),
+    );
+    onError.mockClear();
+
+    values.set('gluon:profile', '{"version":2,"state":[1,2,3]}');
+    const corrupt = createStoreManager({
+      plugins: [createPersistencePlugin({ storage, onError })],
+    }).use(legacyStore);
+    expect(corrupt.count).toBe(0);
+    expect(onError).toHaveBeenLastCalledWith(
+      expect.any(TypeError),
+      'profile',
+      expect.objectContaining({ kind: 'corrupt-envelope', key: 'gluon:profile' }),
+    );
+    const recovery = onError.mock.calls.at(-1)?.[2]?.recovery;
+    recovery?.quarantine();
+    expect(values.get('gluon:profile:quarantine')).toBe('{"version":2,"state":[1,2,3]}');
+    expect(values.has('gluon:profile')).toBe(false);
+
+    onError.mockClear();
+    values.set('gluon:profile', '{"version":1.5,"state":{"count":1}}');
+    createStoreManager({ plugins: [createPersistencePlugin({ storage, onError })] }).use(legacyStore);
+    expect(onError).toHaveBeenLastCalledWith(
+      expect.any(TypeError),
+      'profile',
+      expect.objectContaining({ kind: 'corrupt-envelope', version: undefined }),
+    );
+  });
+
+  it('rejects invalid migration plans and preserves explicit recovery choices', () => {
     const values = new Map<string, string>();
     const storage: StorageLike = {
       getItem: (key) => values.get(key) ?? null,
       setItem: (key, value) => { values.set(key, value); },
+      removeItem: (key) => { values.delete(key); },
     };
     const definition = defineStore({
       id: 'preferences',
       state: () => ({ theme: 'light', pageSize: 20 }),
-      persist: { key: 'custom-preferences' },
+      persist: { key: 'custom-preferences', version: 1 },
     });
     const manager = createStoreManager({ plugins: [createPersistencePlugin({ storage })] });
     const store = manager.use(definition);
     store.$patch({ theme: 'dark' });
-    expect(JSON.parse(values.get('custom-preferences')!)).toEqual({ theme: 'dark', pageSize: 20 });
+    expect(JSON.parse(values.get('custom-preferences')!)).toEqual({ version: 1, state: { theme: 'dark', pageSize: 20 } });
 
-    values.set('broken', '[]');
+    const invalidPlan = defineStore({
+      id: 'invalid-plan',
+      state: () => ({ value: 0 }),
+      persist: {
+        version: 3,
+        migrations: [
+          { from: 0, to: 1, migrate: (state) => state },
+          { from: 2, to: 3, migrate: (state) => state },
+        ],
+      },
+    });
+    expect(() => createStoreManager({ plugins: [createPersistencePlugin({ storage })] }).use(invalidPlan))
+      .toThrow('must be contiguous');
+    const invalidLegacy = defineStore({
+      id: 'invalid-legacy',
+      state: () => ({ value: 0 }),
+      persist: { version: 1, legacy: { to: 2, migrate: (state) => state } },
+    });
+    expect(() => createStoreManager({ plugins: [createPersistencePlugin({ storage })] }).use(invalidLegacy))
+      .toThrow('integer output version');
+
+    values.set('gluon:broken', '[]');
     const errors = vi.fn();
     const broken = defineStore({
       id: 'broken',
       state: () => ({ value: 1 }),
-      persist: { key: 'broken' },
+      persist: { key: 'gluon:broken', version: 1 },
     });
     createStoreManager({ plugins: [createPersistencePlugin({ storage, onError: errors })] }).use(broken);
-    expect(errors).toHaveBeenCalledWith(expect.any(TypeError), 'broken');
+    expect(errors).toHaveBeenCalledWith(expect.any(TypeError), 'broken', expect.objectContaining({
+      kind: 'corrupt-envelope',
+      recovery: expect.objectContaining({ key: 'gluon:broken' }),
+    }));
     expect((errors.mock.calls[0]?.[0] as Error).message).toContain('plain object');
+    errors.mockClear();
+
+    values.set('gluon:legacy', '{"version":1,"state":{"value":1}}');
+    const legacyMigration = defineStore({
+      id: 'legacy',
+      state: () => ({ value: 0 }),
+      persist: {
+        key: 'gluon:legacy',
+        version: 2,
+        migrations: [
+          { from: 0, to: 1, migrate: (state) => ({ value: Number(state.value ?? 0) }) },
+          { from: 1, to: 2, migrate: () => [] as never },
+        ],
+      },
+    });
+    createStoreManager({ plugins: [createPersistencePlugin({ storage, onError: errors })] }).use(legacyMigration);
+    expect(errors).toHaveBeenCalledWith(expect.any(TypeError), 'legacy', expect.objectContaining({
+      kind: 'migration-invalid-output',
+      key: 'gluon:legacy',
+      raw: '{"version":1,"state":{"value":1}}',
+    }));
+  });
+
+  it('rejects every ambiguous, discontinuous, or out-of-range migration plan', () => {
+    const storage: StorageLike = { getItem: () => null, setItem: () => undefined };
+    const invalidPlans: readonly [string, unknown, string][] = [
+      ['zero-version', { version: 0 }, 'positive integer'],
+      ['fractional-version', { version: 1.5 }, 'positive integer'],
+      ['invalid-step', { version: 1, migrations: [{ from: -1, to: 0, migrate: (state: unknown) => state }] }, 'increasing integer'],
+      ['invalid-migrate', { version: 1, migrations: [{ from: 0, to: 1, migrate: true }] }, 'increasing integer'],
+      ['skipped-version', { version: 2, migrations: [{ from: 0, to: 2, migrate: (state: unknown) => state }] }, 'one version at a time'],
+      ['duplicate-step', { version: 2, migrations: [
+        { from: 0, to: 1, migrate: (state: unknown) => state },
+        { from: 0, to: 1, migrate: (state: unknown) => state },
+      ] }, 'must not duplicate'],
+      ['future-step', { version: 1, migrations: [{ from: 1, to: 2, migrate: (state: unknown) => state }] }, 'future versions'],
+      ['unfinished-step', { version: 3, migrations: [{ from: 0, to: 1, migrate: (state: unknown) => state }] }, 'end at the configured version'],
+      ['legacy-gap', { version: 2, legacy: { to: 1, migrate: (state: unknown) => state } }, 'requires a contiguous step'],
+      ['legacy-fraction', { version: 2, legacy: { to: 0.5, migrate: (state: unknown) => state } }, 'integer output version'],
+      ['legacy-migrate', { version: 1, legacy: { to: 0, migrate: false } }, 'integer output version'],
+    ];
+
+    for (const [id, persist, message] of invalidPlans) {
+      const definition = defineStore({ id, state: () => ({ value: 0 }), persist: persist as never });
+      expect(() => createStoreManager({ plugins: [createPersistencePlugin({ storage })] }).use(definition)).toThrow(message);
+    }
+  });
+
+  it('classifies corrupt, legacy, missing, throwing, and invalid migration payloads', () => {
+    const values = new Map<string, string>();
+    const errors = vi.fn();
+    const storage: StorageLike = {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => { values.set(key, value); },
+      removeItem: (key) => { values.delete(key); },
+    };
+    const run = (id: string, payload: string, persist: unknown) => {
+      values.set(`gluon:${id}`, payload);
+      const definition = defineStore({ id, state: () => ({ value: 0, migrated: false }), persist: persist as never });
+      createStoreManager({ plugins: [createPersistencePlugin({ storage, onError: errors })] }).use(definition);
+      return errors.mock.calls.at(-1)?.[2];
+    };
+
+    expect(run('bad-json', '{', true)).toMatchObject({ kind: 'corrupt-json' });
+    expect(run('unowned-legacy', '{"value":1}', true)).toMatchObject({ kind: 'legacy' });
+    expect(run('missing-step', '{"version":0,"state":{"value":1}}', { version: 2 })).toMatchObject({ kind: 'migration-missing', version: 0 });
+    expect(run('throwing-step', '{"version":0,"state":{"value":1}}', {
+      version: 1,
+      migrations: [{ from: 0, to: 1, migrate: () => { throw new Error('step failed'); } }],
+    })).toMatchObject({ kind: 'migration-throw', version: 0 });
+    expect(run('throwing-legacy', '{"value":1}', {
+      version: 1,
+      legacy: { to: 1, migrate: () => { throw new Error('legacy failed'); } },
+    })).toMatchObject({ kind: 'migration-throw', version: 1 });
+    expect(run('invalid-legacy-output', '{"value":1}', {
+      version: 1,
+      legacy: { to: 1, migrate: () => ({ value: new Date() }) },
+    })).toMatchObject({ kind: 'migration-invalid-output' });
+
+    values.set('gluon:legacy-success', '{"value":3}');
+    const successful = defineStore({
+      id: 'legacy-success',
+      state: () => ({ value: 0, migrated: false }),
+      persist: {
+        version: 2,
+        legacy: { to: 1, migrate: (state) => ({ value: Number(state.value), migrated: false }) },
+        migrations: [{ from: 1, to: 2, migrate: (state) => ({ ...state, migrated: true }) }],
+      },
+    });
+    expect(createStoreManager({ plugins: [createPersistencePlugin({ storage })] }).use(successful))
+      .toMatchObject({ value: 3, migrated: true });
+  });
+
+  it('keeps failed persistence blocked until reset, remove, or quarantine explicitly recovers it', () => {
+    const values = new Map<string, string>([['gluon:recoverable', '{']]);
+    const writes: string[] = [];
+    const errors = vi.fn();
+    const storage: StorageLike = {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => { values.set(key, value); writes.push(key); },
+      removeItem: (key) => { values.delete(key); },
+    };
+    const definition = defineStore({ id: 'recoverable', state: () => ({ value: 1 }), persist: true });
+    const store = createStoreManager({ plugins: [createPersistencePlugin({ storage, onError: errors })] }).use(definition);
+    store.$patch({ value: 2 });
+    expect(writes).toEqual([]);
+    errors.mock.calls[0]?.[2]?.recovery.reset();
+    expect(JSON.parse(values.get('gluon:recoverable')!)).toEqual({ version: 1, state: { value: 1 } });
+    store.$patch({ value: 3 });
+    expect(JSON.parse(values.get('gluon:recoverable')!)).toEqual({ version: 1, state: { value: 3 } });
+
+    values.set('gluon:recoverable', '{');
+    const removeErrors = vi.fn();
+    const removed = createStoreManager({ plugins: [createPersistencePlugin({ storage, onError: removeErrors })] }).use(definition);
+    removeErrors.mock.calls[0]?.[2]?.recovery.remove();
+    expect(values.has('gluon:recoverable')).toBe(false);
+    removed.$patch({ value: 4 });
+    expect(JSON.parse(values.get('gluon:recoverable')!)).toEqual({ version: 1, state: { value: 4 } });
+
+    let failWrite = true;
+    const writeErrors = vi.fn();
+    const writeStorage: StorageLike = {
+      getItem: () => null,
+      setItem: (key, value) => {
+        if (failWrite) throw new Error('first write fails');
+        values.set(key, value);
+      },
+      removeItem: (key) => { values.delete(key); },
+    };
+    const writeStore = createStoreManager({ plugins: [createPersistencePlugin({ storage: writeStorage, onError: writeErrors })] }).use(definition);
+    writeStore.$patch({ value: 2 });
+    writeStore.$patch({ value: 3 });
+    expect(writeErrors).toHaveBeenCalledTimes(1);
+    failWrite = false;
+    writeErrors.mock.calls[0]?.[2]?.recovery.quarantine();
+    expect(values.get('gluon:recoverable:quarantine')).toBe('');
+    writeStore.$patch({ value: 4 });
+    expect(JSON.parse(values.get('gluon:recoverable')!)).toEqual({ version: 1, state: { value: 4 } });
+  });
+
+  it('rejects non-record and unsafe serialized manager snapshots at the parse boundary', () => {
+    const manager = createStoreManager();
+    expect(() => manager.deserialize('[]')).toThrow('Invalid Gluon store snapshot');
+    expect(() => manager.deserialize('{"version":1,"stores":{"__proto__":{}}}')).toThrow('Unsafe store state key');
   });
 });

--- a/tests-node/store.types.ts
+++ b/tests-node/store.types.ts
@@ -2,6 +2,7 @@ import {
   createStoreManager,
   createTestingStoreManager,
   defineStore,
+  type PersistedStateEnvelope,
   type StoreTransaction,
 } from '../packages/store/dist/index.js';
 
@@ -31,6 +32,8 @@ manager.hydrate(manager.dehydrate());
 createTestingStoreManager({ initialState: manager.dehydrate() });
 const simple = defineStore({ id: 'simple', state: () => ({ ready: true }) }).use(manager);
 const ready: boolean = simple.ready;
+const envelope: PersistedStateEnvelope = { version: 1, state: { count: 1 } };
+void envelope;
 void count;
 void doubled;
 void result;
@@ -44,5 +47,29 @@ counter.count = 'invalid';
 counter.doubled = 4;
 // @ts-expect-error persistence paths must name state keys
 defineStore({ id: 'invalid-path', state: () => ({ count: 1 }), persist: { paths: ['missing'] } });
+defineStore({
+  id: 'migrated',
+  state: () => ({ count: 1 }),
+  persist: {
+    version: 2,
+    legacy: { to: 0, migrate: (state) => ({ count: Number(state.count ?? 0) }) },
+    migrations: [
+      { from: 0, to: 1, migrate: (state) => ({ count: Number(state.count ?? 0) }) },
+      { from: 1, to: 2, migrate: (state) => ({ count: Number(state.count ?? 0), label: 'ready' }) },
+    ],
+  },
+});
+interface PersistedItemDto {
+  readonly id: string;
+  readonly label: string;
+}
+const typedMigration = defineStore('typed-migration', () => ({ items: [] as PersistedItemDto[] }), {
+  actions: (store) => ({ add(item: PersistedItemDto) { store.items.push(item); } }),
+  persist: {
+    version: 1,
+    legacy: { to: 1, migrate: () => ({ items: [{ id: 'one', label: 'Typed DTO' }] as PersistedItemDto[] }) },
+  },
+});
+typedMigration.use(manager).add({ id: 'two', label: 'No index signature required' });
 // @ts-expect-error stores do not expose undeclared state, getter, or action keys
 simple.missing;

--- a/tests/shop-example.spec.ts
+++ b/tests/shop-example.spec.ts
@@ -426,19 +426,68 @@ describe('GLUON GOODS reference shop', () => {
     expect(isolatedA.store.bagCount).toBe(1);
     expect(isolatedB.store.bagCount).toBe(0);
 
+    const values = new Map<string, string>([[
+      'gluon-goods:shop',
+      JSON.stringify({
+        bag: [{
+          productSlug: 'stack-tray',
+          quantity: 2,
+          configuration: {
+            finish: 'Graphite',
+            temperature: 'Clear 3200K',
+            cable: '2.5 m',
+          },
+        }],
+      }),
+    ]]);
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => { values.set(key, value); },
+      removeItem: (key: string) => { values.delete(key); },
+    };
     const first = createShopApplication(createMemoryHistory(['/products/stack-tray']), {
       styleTarget: document,
+      storage,
     });
     await first.router.isReady();
     const firstRoot = document.createElement('div');
     document.body.append(firstRoot);
     first.app.mount(firstRoot);
+    firstRoot.querySelector<HTMLButtonElement>('.bag-action')!.click();
+    await settleShop();
+    expect(document.querySelector('.bag-line h3')?.textContent).toBe('Stack Tray');
+    expect(document.querySelector('.bag-line p')?.textContent).toContain('Graphite');
+    expect(document.querySelector('.bag-line p')?.textContent).toContain('Clear 3200K');
     await getProductConfigurator(firstRoot).updateComplete;
     getProductAddButton(getProductConfigurator(firstRoot)).click();
     await settleShop();
+    expect(JSON.parse(values.get('gluon-goods:shop')!)).toMatchObject({
+      version: 1,
+      state: {
+        bag: [{
+          key: 'stack-tray:Graphite:Clear 3200K:2.5 m',
+          product: expect.objectContaining({ slug: 'stack-tray' }),
+          configuration: {
+            finish: 'Graphite',
+            temperature: 'Clear 3200K',
+            cable: '2.5 m',
+          },
+          quantity: 2,
+        }, {
+          key: 'stack-tray:Cobalt:Warm 2700K:1.5 m',
+          product: expect.objectContaining({ slug: 'stack-tray' }),
+          configuration: {
+            finish: 'Cobalt',
+            temperature: 'Warm 2700K',
+            cable: '1.5 m',
+          },
+          quantity: 1,
+        }],
+      },
+    });
     first.app.unmount();
 
-    const second = createShopApplication(createMemoryHistory(['/']), { styleTarget: document });
+    const second = createShopApplication(createMemoryHistory(['/']), { styleTarget: document, storage });
     await second.router.isReady();
     const secondRoot = document.createElement('div');
     document.body.append(secondRoot);
@@ -446,10 +495,52 @@ describe('GLUON GOODS reference shop', () => {
     secondRoot.querySelector<HTMLButtonElement>('.bag-action')!.click();
     await settleShop();
     expect(document.querySelector('.bag-line h3')?.textContent).toBe('Stack Tray');
-    expect(document.querySelector('.bag-line p')?.textContent).toContain('Cobalt');
+    const restoredConfigurations = [...document.querySelectorAll('.bag-line p')]
+      .map((line) => line.textContent);
+    expect(restoredConfigurations).toEqual(expect.arrayContaining([
+      expect.stringContaining('Graphite'),
+      expect.stringContaining('Cobalt'),
+    ]));
     isolatedA.storeManager.dispose();
     isolatedB.storeManager.dispose();
     second.app.unmount();
+  });
+
+  it('drops malformed and unknown legacy bag entries without inventing products', async () => {
+    const validConfiguration = {
+      finish: 'Graphite',
+      temperature: 'Clear 3200K',
+      cable: '2.5 m',
+    };
+    const payloads = [
+      {
+        bag: [
+          null,
+          {},
+          { productSlug: 42, quantity: 1, configuration: validConfiguration },
+          { productSlug: 'stack-tray', quantity: '1', configuration: validConfiguration },
+          { productSlug: 'stack-tray', quantity: 1.5, configuration: validConfiguration },
+          { productSlug: 'stack-tray', quantity: 0, configuration: validConfiguration },
+          { productSlug: 'stack-tray', quantity: 1, configuration: {} },
+          { productSlug: 'retired-product', quantity: 1, configuration: validConfiguration },
+        ],
+      },
+      { bag: 'not-an-array' },
+    ];
+
+    for (const payload of payloads) {
+      const values = new Map([['gluon-goods:shop', JSON.stringify(payload)]]);
+      const application = createShopApplication(createMemoryHistory(['/']), {
+        storage: {
+          getItem: (key: string) => values.get(key) ?? null,
+          setItem: (key: string, value: string) => { values.set(key, value); },
+          removeItem: (key: string) => { values.delete(key); },
+        },
+      });
+      await application.router.isReady();
+      expect(application.store.bag).toEqual([]);
+      application.storeManager.dispose();
+    }
   });
 
   it('keeps the bag quantity control optimistic state synchronized and cancelable', async () => {


### PR DESCRIPTION
Closes #403

## Summary
- add an independent versioned persistence envelope with deterministic contiguous per-store migrations and explicit legacy decoding
- classify future, corrupt, missing-step, migration, and storage failures; block writes until successful reset/remove/quarantine recovery
- preserve selected paths, transactions, HMR/SSR isolation, safe-key/JSON validation, and the existing two-argument onError contract
- migrate the real GLUON GOODS bag without merging differently configured line items and retain browser evidence
- update the measured shop budget to 257500 raw / 70300 gzip for the integrated migration runtime (measured 257419 / 70241)

## Verification
- TypeScript source/build/API type checks for Store
- 11 Store Node tests
- 9 Chromium GLUON GOODS tests
- npm run check:shop-boundaries
- npm run check:shop-static
- npm run check:budgets
- git diff --check