### PR TITLE
docs: reconcile release and stability guidance (#398)

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,9 +871,24 @@ Custom Element component boundaries; `dev:benchmark:components` serves its
 interactive page on port 4175. Current evidence must not be generalized into
 an unsupported superiority claim or an unmeasured hardware claim.
 
+## Stability policy
+
+Gluon 1.9.0 ships three documentation states:
+
+- stable: the public package surfaces, application runtime, component packages,
+  tooling, and release guidance described in the versioned docs and package READMEs;
+- experimental: RFC-backed or opt-in surfaces that are explicitly labeled as such
+  in their own package or guide;
+- unsupported: behaviors that the contract documents reject or leave outside the
+  supported boundary.
+
+Historical RFC decisions remain preserved in `docs/rfcs/` and should be read as
+context, not as current release-state claims.
+
 ## Contributing
 
-The runtime exists, but the API remains experimental. Use [GitHub Issues](https://github.com/marcmalerei/gluon/issues) to discuss changes before implementation.
+Use [GitHub Issues](https://github.com/marcmalerei/gluon/issues) to discuss
+changes before implementation.
 
 ## License
 

--- a/docs-site/content/1.9.0/guides/releasing/index.md
+++ b/docs-site/content/1.9.0/guides/releasing/index.md
@@ -10,6 +10,10 @@ forms, i18n, JSON Forms, and SSR work tracked by epic
 a Quality-Gates-tested candidate followed only by its release-cut evidence and
 compatibility manifest.
 
+Release-state wording in this documentation follows the repository policy:
+stable describes shipped public contracts, experimental describes explicitly
+labeled opt-in surfaces, and unsupported marks boundaries the contract refuses.
+
 The immutable GitHub release is [`v1.9.0`](https://github.com/marcmalerei/gluon/releases/tag/v1.9.0),
 published from `06dc45457bbf9a109ae67f5048db8be63f0fda39`. Protected workflow
 run [31890472642](https://github.com/marcmalerei/gluon/actions/runs/31890472642)

--- a/docs-site/content/1.9.0/migration/upgrade/index.md
+++ b/docs-site/content/1.9.0/migration/upgrade/index.md
@@ -28,6 +28,14 @@ the application's Node or browser baseline in the same upgrade.
 
 ## Policy facts
 
+The current release policy distinguishes three states:
+
+- stable: public package surfaces, release guidance, and shipped runtime
+  contracts that the versioned docs and package READMEs describe;
+- experimental: explicitly labeled RFC-backed or opt-in surfaces;
+- unsupported: behaviors the contract rejects or leaves outside the supported
+  boundary.
+
 - `1.0` introduced the current semver policy: an incompatible public API
   change requires a major release.
 - A deprecated API remains for at least the next stable minor, and the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,8 +94,10 @@ Gluon currently provides:
 - representative Atom, Molecule, and Organism packages
 - ESM builds, TypeScript declarations, Chromium tests, and coverage thresholds
 
-The current repository does not provide language tooling, Devtools, or a public
-release.
+The current repository provides language tooling, Devtools, and a public
+release. The roadmap retains earlier milestone rows as historical delivery
+records; treat them as completed references unless a newer issue explicitly
+reopens the scope.
 
 ## Product principles
 
@@ -216,6 +218,14 @@ production single-page application without Vue.
 - The store covers typed state, getters, actions, subscriptions, plugins, HMR,
   Devtools hooks, and server isolation.
 - The reference SPA uses only public Gluon APIs and passes its end-to-end flows.
+
+## Historical milestone notes
+
+Milestones M2 through M5 are completed as a matter of repository history. The
+remaining GitHub milestone records are administrative references, not active
+implementation work. New documentation should describe the shipped 1.9 surface
+and the current support policy instead of restating those milestones as open
+plans.
 
 ## M3 — Developer Experience
 

--- a/packages/json-forms/README.md
+++ b/packages/json-forms/README.md
@@ -9,6 +9,13 @@ JSON Forms UI schema into one accessible, form-associated Web Component. It is
 an optional package: schema rendering and AJV validation do not enter
 `@gluonjs/core`.
 
+## Stability notes
+
+The package ships as part of the current `1.9.0` release line. Its documented
+schema and UI schema subset is stable; broader JSON Schema features and
+alternative renderer systems remain unsupported unless a later contract adds
+them.
+
 ```ts
 import {
   registerJsonForms,
@@ -75,7 +82,7 @@ layouts other than `VerticalLayout` remain unsupported. An unsupported schema
 or UI schema renders an explicit configuration error rather than silently
 dropping fields.
 
-## 1.6 delivery decision
+## Historical delivery decision
 
 The direct-property component was the first usable package slice identified in
 issue #256 and delivered in [#257](https://github.com/marcmalerei/gluon/issues/257).

--- a/packages/reactivity/README.md
+++ b/packages/reactivity/README.md
@@ -4,8 +4,8 @@
 </p>
 <!-- gluon-package-header:end -->
 
-DOM-free reactive state primitives for Gluon. The package is part of the
-lockstep Gluon `1.4.0` release line.
+DOM-free reactive state primitives for Gluon. The package ships as part of the
+current `1.9.0` release line.
 
 ```ts
 import { computed, effect, nextTick, reactive, ref } from '@gluonjs/reactivity';
@@ -34,6 +34,12 @@ await nextTick();
 - attached or detached `effectScope` ownership and `onScopeDispose`
 - scheduled `watch` and `watchEffect` with deterministic cleanup
 - global, scope-local, job-local, and effect-local error handlers
+
+## Stability notes
+
+The stable Reactivity entry is the default import path in `@gluonjs/reactivity`.
+Optional peer adapters in subpaths remain explicit and are documented as
+integration boundaries, not replacements for the stable entry.
 
 ## Optional external Signals
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -8,9 +8,15 @@ The official Gluon router provides deterministic route matching, browser/hash/
 memory histories, typed named routes, guards, failures, lazy route components,
 scroll restoration, and Gluon application bindings.
 
-The package is part of the lockstep Gluon `1.4.0` release line. Core and
+The package ships as part of the current `1.9.0` release line. Core and
 Reactivity are peers so an application has one shared application context and
 reactive identity.
+
+## Stability notes
+
+The router surface is stable in the current release line. Memory history is a
+supported DOM-free entry for Node, tests, and server resolution; unsupported
+transport, cache, and authentication policies remain outside the package.
 
 ## Browser application
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -8,7 +8,13 @@ The official Gluon store provides typed, application-scoped state without a
 DOM dependency. Store definitions infer state, computed getter values, action
 arguments, and action results from one definition.
 
-The package is part of the lockstep Gluon `1.4.0` release line.
+The package ships as part of the current `1.9.0` release line.
+
+## Stability notes
+
+The store surface is stable in the current release line. Application-scoped
+managers, snapshots, persistence plugins, and hydration remain supported; a
+process-wide singleton manager is still unsupported.
 
 ## Define and use a store
 

--- a/packages/test-utils/README.md
+++ b/packages/test-utils/README.md
@@ -8,6 +8,13 @@ The official Gluon test utilities mount public components and applications in a
 real browser without private runtime imports. The package targets Gluon's
 currently supported Chromium browser matrix.
 
+## Stability notes
+
+The package ships as part of the current `1.9.0` release line. Browser-facing
+helpers and SSR fixtures are stable; direct access to renderer parts, private
+runtime imports, and browser matrices beyond the documented evidence remain
+unsupported.
+
 ## Functional components
 
 ```ts

--- a/scripts/docs-consistency.d.mts
+++ b/scripts/docs-consistency.d.mts
@@ -1,0 +1,17 @@
+export interface DocsConsistencyEntry {
+  path: string;
+  text: string;
+}
+
+export interface DocsConsistencyOptions {
+  currentVersion: string;
+  releaseLinePaths?: string[];
+  requiredPhrasesByPath?: Record<string, string[]>;
+}
+
+export declare function findLockstepVersionMentions(text: string): string[];
+export declare function findContradictoryReleaseWording(text: string): string[];
+export declare function validateDocsConsistency(
+  entries: DocsConsistencyEntry[],
+  options: DocsConsistencyOptions,
+): void;

--- a/scripts/docs-consistency.mjs
+++ b/scripts/docs-consistency.mjs
@@ -1,0 +1,47 @@
+export function findLockstepVersionMentions(text) {
+  const versions = [];
+  const releaseLine = /(?:lockstep\s+Gluon|current)\s+`(\d+\.\d+\.\d+)`\s+release line/gi;
+  for (const match of text.matchAll(releaseLine)) versions.push(match[1]);
+  return versions;
+}
+
+export function findContradictoryReleaseWording(text) {
+  const findings = [];
+  if (/(?:the\s+)?API remains experimental/i.test(text)) findings.push('experimental-release-state');
+  if (/does not provide[^.\n]*(?:language tooling|Devtools)[^.\n]*public release/i.test(text)) findings.push('missing-shipped-surface');
+  return findings;
+}
+
+export function validateDocsConsistency(entries, options) {
+  const {
+    currentVersion,
+    releaseLinePaths = [],
+    requiredPhrasesByPath = {},
+  } = options;
+  if (!/^\d+\.\d+\.\d+$/.test(currentVersion)) throw new Error(`invalid current documentation version: ${currentVersion}`);
+
+  const entriesByPath = new Map(entries.map((entry) => [entry.path, entry]));
+  for (const entry of entries) {
+    const contradictions = findContradictoryReleaseWording(entry.text);
+    if (contradictions.length > 0) {
+      throw new Error(`${entry.path} contains contradictory release-state wording: ${contradictions.join(', ')}`);
+    }
+  }
+
+  for (const path of releaseLinePaths) {
+    const entry = entriesByPath.get(path);
+    if (!entry) throw new Error(`missing release-line documentation source: ${path}`);
+    const mentions = findLockstepVersionMentions(entry.text);
+    if (mentions.length === 0) throw new Error(`${path} does not name its current release line`);
+    const stale = mentions.filter((version) => version !== currentVersion);
+    if (stale.length > 0) throw new Error(`${path} contains stale lockstep version mentions: ${[...new Set(stale)].join(', ')}`);
+  }
+
+  for (const [path, phrases] of Object.entries(requiredPhrasesByPath)) {
+    const entry = entriesByPath.get(path);
+    if (!entry) throw new Error(`missing documentation source required by consistency policy: ${path}`);
+    for (const phrase of phrases) {
+      if (!entry.text.includes(phrase)) throw new Error(`${path} is missing required consistency phrase: ${phrase}`);
+    }
+  }
+}

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -1,5 +1,6 @@
 import { access, readFile, readdir } from 'node:fs/promises';
 import { basename, dirname, relative, resolve, sep } from 'node:path';
+import { validateDocsConsistency } from './docs-consistency.mjs';
 
 const root = resolve(import.meta.dirname, '..');
 const siteRoot = resolve(root, 'docs-site');
@@ -9,6 +10,7 @@ const packageContract = JSON.parse(await readFile(resolve(root, 'package-contrac
 const packageDocs = JSON.parse(await readFile(resolve(siteRoot, 'package-docs.json'), 'utf8'));
 const base = '/gluon/';
 validatePackageDocs(packageDocs, packageContract);
+await validateSourceDocs();
 
 if (!versions.supported.includes(versions.latest)) {
   throw new Error(`documentation latest ${versions.latest} is not a supported version`);
@@ -466,6 +468,61 @@ async function filesWithExtension(directory, extension) {
 
 function slash(value) { return value.split(sep).join('/'); }
 function escapeHtml(value) { return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;'); }
+
+async function validateSourceDocs() {
+  const rootPackage = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'));
+  const currentVersion = rootPackage.version;
+  if (versions.latest !== currentVersion) {
+    throw new Error(`latest docs version ${versions.latest} does not match root package version ${currentVersion}`);
+  }
+  const packagePaths = [
+    'packages/reactivity/README.md',
+    'packages/router/README.md',
+    'packages/store/README.md',
+    'packages/json-forms/README.md',
+    'packages/test-utils/README.md',
+  ];
+  const upgradePath = `docs-site/content/${versions.latest}/migration/upgrade/index.md`;
+  const releasingPath = `docs-site/content/${versions.latest}/guides/releasing/index.md`;
+  const sourceEntries = await Promise.all([
+    'README.md',
+    'docs/roadmap.md',
+    ...packagePaths,
+    upgradePath,
+    releasingPath,
+  ].map(async (path) => ({ path, text: await readFile(resolve(root, path), 'utf8') })));
+  const packagePolicy = Object.fromEntries(packagePaths.map((path) => [path, [
+    `current \`${currentVersion}\` release line`,
+    '## Stability notes',
+  ]]));
+  validateDocsConsistency(sourceEntries, {
+    currentVersion,
+    releaseLinePaths: packagePaths,
+    requiredPhrasesByPath: {
+      'README.md': [
+        '- stable: the public package surfaces',
+        '- experimental: RFC-backed or opt-in surfaces',
+        '- unsupported: behaviors that the contract documents reject',
+        'Historical RFC decisions remain preserved',
+      ],
+      'docs/roadmap.md': [
+        'provides language tooling, Devtools, and a public',
+        'Milestones M2 through M5 are completed',
+      ],
+      [upgradePath]: [
+        '- stable: public package surfaces',
+        '- experimental: explicitly labeled RFC-backed or opt-in surfaces',
+        '- unsupported: behaviors the contract rejects',
+      ],
+      [releasingPath]: [
+        'stable describes shipped public contracts',
+        'experimental describes explicitly',
+        'unsupported marks boundaries',
+      ],
+      ...packagePolicy,
+    },
+  });
+}
 
 function validatePackageDocs(packageDocs, packageContract) {
   if (!packageDocs || packageDocs.version !== 1 || !Array.isArray(packageDocs.packages)) {

--- a/tests/docs-consistency.spec.ts
+++ b/tests/docs-consistency.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+import {
+  findLockstepVersionMentions,
+  validateDocsConsistency,
+} from '../scripts/docs-consistency.mjs';
+
+describe('docs consistency helpers', () => {
+  test('finds only release-line versions instead of unrelated historical examples', () => {
+    expect(findLockstepVersionMentions(
+      'Part of the lockstep Gluon `1.4.0` release line; use the current `1.9.0` release line. Migration started at `1.0.0`.',
+    )).toEqual(['1.4.0', '1.9.0']);
+  });
+
+  test('rejects stale release lines and contradictory current-state wording', () => {
+    expect(() => validateDocsConsistency([
+      { path: 'packages/router/README.md', text: 'The package is part of the lockstep Gluon `1.4.0` release line.' },
+    ], { currentVersion: '1.9.0', releaseLinePaths: ['packages/router/README.md'] })).toThrow(/stale lockstep version mentions/i);
+
+    expect(() => validateDocsConsistency([
+      { path: 'README.md', text: 'The runtime exists, but the API remains experimental.' },
+    ], { currentVersion: '1.9.0' })).toThrow(/contradictory release-state wording/i);
+  });
+
+  test('requires policy language on its owning page and accepts a consistent set', () => {
+    const entries = [
+      { path: 'README.md', text: 'stable / experimental / unsupported' },
+      { path: 'packages/store/README.md', text: 'The package ships as part of the current `1.9.0` release line.\n## Stability notes' },
+    ];
+    expect(() => validateDocsConsistency(entries, {
+      currentVersion: '1.9.0',
+      requiredPhrasesByPath: { 'README.md': ['stable', 'missing phrase'] },
+    })).toThrow(/README\.md is missing required consistency phrase/i);
+
+    expect(() => validateDocsConsistency(entries, {
+      currentVersion: '1.9.0',
+      releaseLinePaths: ['packages/store/README.md'],
+      requiredPhrasesByPath: {
+        'README.md': ['stable', 'experimental', 'unsupported'],
+        'packages/store/README.md': ['## Stability notes'],
+      },
+    })).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #398

## Summary
- reconcile current 1.9.0 release-line wording across the root, roadmap, versioned guides, and package READMEs
- define stable, experimental, and unsupported documentation states
- add a source-level consistency validator for stale or contradictory release claims

## Verification
- npx vitest run tests/docs-consistency.spec.ts --browser.enabled=false --environment=node
- npm run check:docs
- git diff --check

## Shop application
Documentation governance has no honest customer-facing shop control; the canonical application remains unchanged.