### PR TITLE
feat(vscode): bundle language server distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
       - run: npm run check:repository
       - run: npm run release:validate -- --candidate "$RELEASE_VERSION"
       - run: npm run release:artifacts -- --version "$RELEASE_VERSION"
+      - run: npm run release:vscode
+      - run: npm run check:release-vscode
       - name: Retain release candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -130,6 +132,7 @@ jobs:
             .tmp/release/compatibility-manifest.json
             .tmp/release/reproducibility.json
             .tmp/release/performance/*
+            .tmp/release/vscode/*
       - name: Create immutable-release draft
         env:
           GH_TOKEN: ${{ github.token }}
@@ -142,6 +145,12 @@ jobs:
           fi
       - name: Publish reviewed archives directly to latest through trusted publishing
         run: npm run release:publish -- --version "$RELEASE_VERSION"
+      - name: Publish VS Code extension when publisher credentials are configured
+        if: ${{ secrets.VSCE_PAT != '' }}
+        working-directory: editors/vscode
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --no-install vsce publish --packagePath ../../.tmp/release/vscode/gluon-vscode-${{ env.RELEASE_VERSION }}.vsix --pat "$VSCE_PAT"
       - name: Verify latest registry train from a clean directory
         run: npm run release:verify-registry -- --version "$RELEASE_VERSION" --directory .tmp/release --output .tmp/release/registry-verification.json
       - run: npm run release:finalize-assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
       - run: npm run check:repository
       - run: npm run release:validate -- --candidate "$RELEASE_VERSION"
       - run: npm run release:artifacts -- --version "$RELEASE_VERSION"
-      - run: npm run release:vscode
-      - run: npm run check:release-vscode
+      - run: npm run release:vscode -- --version "$RELEASE_VERSION" --tag "$RELEASE_TAG"
+      - run: npm run check:release-vscode -- --version "$RELEASE_VERSION" --tag "$RELEASE_TAG"
       - name: Retain release candidate
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -80,6 +80,7 @@ jobs:
     env:
       GITHUB_REPOSITORY_VISIBILITY: ${{ github.event.repository.visibility }}
       GLUON_RELEASE_ENVIRONMENT: npm
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -132,12 +133,14 @@ jobs:
             .tmp/release/compatibility-manifest.json
             .tmp/release/reproducibility.json
             .tmp/release/performance/*
-            .tmp/release/vscode/*
+            .tmp/release/vscode/*.vsix
+            .tmp/release/vscode/VSIX-SHA256SUMS
+            .tmp/release/vscode/vscode-release-manifest.json
       - name: Create immutable-release draft
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          assets=(.tmp/release/packages/*.tgz .tmp/release/sbom/*.json .tmp/release/performance/* .tmp/release/release-evidence.json .tmp/release/release-cut-evidence.json .tmp/release/compatibility-manifest.json .tmp/release/reproducibility.json .tmp/release/SHA256SUMS .tmp/release/CHANGELOG.md .tmp/release/RELEASE_NOTES.md)
+          assets=(.tmp/release/packages/*.tgz .tmp/release/sbom/*.json .tmp/release/performance/* .tmp/release/release-evidence.json .tmp/release/release-cut-evidence.json .tmp/release/compatibility-manifest.json .tmp/release/reproducibility.json .tmp/release/SHA256SUMS .tmp/release/CHANGELOG.md .tmp/release/RELEASE_NOTES.md .tmp/release/vscode/*.vsix .tmp/release/vscode/VSIX-SHA256SUMS .tmp/release/vscode/vscode-release-manifest.json)
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
           else
@@ -145,12 +148,14 @@ jobs:
           fi
       - name: Publish reviewed archives directly to latest through trusted publishing
         run: npm run release:publish -- --version "$RELEASE_VERSION"
-      - name: Publish VS Code extension when publisher credentials are configured
-        if: ${{ secrets.VSCE_PAT != '' }}
+      - name: Prepare VS Code Marketplace publisher when credentials are configured
+        if: ${{ env.VSCE_PAT != '' }}
         working-directory: editors/vscode
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx --no-install vsce publish --packagePath ../../.tmp/release/vscode/gluon-vscode-${{ env.RELEASE_VERSION }}.vsix --pat "$VSCE_PAT"
+        run: npm ci --ignore-scripts
+      - name: Publish VS Code extension when publisher credentials are configured
+        if: ${{ env.VSCE_PAT != '' }}
+        working-directory: editors/vscode
+        run: npx --no-install vsce publish --packagePath ../../.tmp/release/vscode/gluon-vscode-${{ env.RELEASE_VERSION }}.vsix
       - name: Verify latest registry train from a clean directory
         run: npm run release:verify-registry -- --version "$RELEASE_VERSION" --directory .tmp/release --output .tmp/release/registry-verification.json
       - run: npm run release:finalize-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and released versions follow [Semantic Versioning](https://semver.org/).
 - Added opt-in application-owned Trusted Types policy handoff for runtime,
   hydration, `srcdoc`, and progressive SSR parser sinks with real Chromium CSP
   and clean-package evidence.
+- Bundled the lockstep Gluon language-server runtime in the VS Code extension,
+  with self-contained VSIX smoke validation, integrity evidence, GitHub release
+  assets, and credential-guarded Marketplace publication.
 
 ### Changed
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -10,9 +10,10 @@ diagnostic escape hatch; it is not part of the release artifact contract.
 
 The extension version advances with the lockstep Gluon release and the
 `publisher`/repository metadata is part of the checked release surface. The
-extension does not bundle a second compiler or language server: the selected
-server executable must be the matching `@gluonjs/language-server` distribution.
-Run `npm run check:vscode-client` from the repository root before packaging.
+VSIX contains one same-version `@gluonjs/language-server` runtime and its
+required compiler and TypeScript runtime dependencies; it does not introduce an
+independently versioned compiler. Run `npm run check:vscode-client` from the
+repository root before packaging.
 
 ## Install and package
 
@@ -21,7 +22,7 @@ Build and install the self-contained VSIX from a clean repository checkout:
 ```sh
 npm ci --ignore-scripts --legacy-peer-deps
 npm run release:vscode
-code --install-extension gluon-vscode-1.9.0.vsix
+code --install-extension .tmp/release/vscode/gluon-vscode-1.9.0.vsix
 ```
 
 The generated `.vsix` is a release artifact and is not committed. The release
@@ -42,6 +43,6 @@ To roll back, unpublish or hide the affected extension version in the
 VSIX manually with `code --install-extension <path> --force`. Never overwrite a
 tag or regenerate a released VSIX under the same version.
 
-The repository currently provides the source and deterministic metadata gate;
-Marketplace publication remains a separate operator action requiring the
-publisher account and a VSIX signing/publishing decision.
+Without `VSCE_PAT`, GitHub still publishes the reviewed VSIX and integrity
+evidence while the guarded Marketplace step is skipped. Configuring that
+credential is an explicit publisher-owner action.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,10 +1,10 @@
 # Gluon for VS Code
 
-This client starts the same-version `gluon-language-server` over stdio for
-TypeScript and JavaScript documents. Leave `gluon.languageServerPath` empty to
-resolve the executable from `PATH`, or set an absolute/workspace-specific path
-when the server is installed elsewhere. `gluon.languageServerArgs` defaults to
-`["--stdio"]` and is validated before the client starts.
+This client bundles the same-version `@gluonjs/language-server` runtime and
+starts it over stdio for TypeScript and JavaScript documents. Leave
+`gluon.languageServerPath` empty to use that self-contained runtime, or set an
+absolute/workspace-specific path for a deliberate override. The override is a
+diagnostic escape hatch; it is not part of the release artifact contract.
 
 ## Distribution contract
 
@@ -16,19 +16,31 @@ Run `npm run check:vscode-client` from the repository root before packaging.
 
 ## Install and package
 
-Install the matching server and build the VSIX from the repository checkout:
+Build and install the self-contained VSIX from a clean repository checkout:
 
 ```sh
-npm install --global @gluonjs/language-server@1.9.0
-cd editors/vscode
-npm install
-npm run package
+npm ci --ignore-scripts --legacy-peer-deps
+npm run release:vscode
 code --install-extension gluon-vscode-1.9.0.vsix
 ```
 
-The extension starts the installed server over stdio. The metadata gate and a
-VSIX smoke build are release evidence; the generated `.vsix` is an operator
-artifact and is not committed.
+The generated `.vsix` is a release artifact and is not committed. The release
+job attaches it together with `VSIX-SHA256SUMS` and
+`vscode-release-manifest.json` to the matching immutable GitHub release tag.
+
+## Publishing, signing, and recovery
+
+Marketplace publication is guarded: the release workflow only runs `vsce
+publish` when the `VSCE_PAT` secret is configured. The publisher is owned by
+`marcmalerei`; a maintainer must provision that publisher account and token.
+VSIX integrity is provided by the SHA-256 evidence and GitHub artifact
+attestation; Marketplace signing/verification remains controlled by the
+publisher service.
+
+To roll back, unpublish or hide the affected extension version in the
+`marcmalerei` Marketplace publisher account, then install a previously attached
+VSIX manually with `code --install-extension <path> --force`. Never overwrite a
+tag or regenerate a released VSIX under the same version.
 
 The repository currently provides the source and deterministic metadata gate;
 Marketplace publication remains a separate operator action requiring the

--- a/editors/vscode/extension.cjs
+++ b/editors/vscode/extension.cjs
@@ -7,10 +7,13 @@ async function activate(context) {
   const configuration = vscode.workspace.getConfiguration('gluon');
   const configuredPath = configuration.get('languageServerPath', '');
   const bundledServer = require('node:path').join(__dirname, 'server', 'dist', 'server-cli.js');
-  const command = configuredPath.trim() || process.execPath;
   const configuredArgs = configuration.get('languageServerArgs', ['--stdio']);
-  const args = configuredPath.trim() ? (Array.isArray(configuredArgs) && configuredArgs.every((value) => typeof value === 'string') ? configuredArgs : ['--stdio']) : [bundledServer, ...(Array.isArray(configuredArgs) && configuredArgs.every((value) => typeof value === 'string') ? configuredArgs : ['--stdio'])];
-  const serverOptions = { command, args, transport: TransportKind.stdio };
+  const args = Array.isArray(configuredArgs) && configuredArgs.every((value) => typeof value === 'string')
+    ? configuredArgs
+    : ['--stdio'];
+  const serverOptions = configuredPath.trim()
+    ? { command: configuredPath.trim(), args, transport: TransportKind.stdio }
+    : { module: bundledServer, args, transport: TransportKind.stdio };
   const clientOptions = {
     documentSelector: [
       { scheme: 'file', language: 'typescript' },

--- a/editors/vscode/extension.cjs
+++ b/editors/vscode/extension.cjs
@@ -6,11 +6,10 @@ let client;
 async function activate(context) {
   const configuration = vscode.workspace.getConfiguration('gluon');
   const configuredPath = configuration.get('languageServerPath', '');
-  const command = configuredPath.trim() || 'gluon-language-server';
+  const bundledServer = require('node:path').join(__dirname, 'server', 'dist', 'server-cli.js');
+  const command = configuredPath.trim() || process.execPath;
   const configuredArgs = configuration.get('languageServerArgs', ['--stdio']);
-  const args = Array.isArray(configuredArgs) && configuredArgs.every((value) => typeof value === 'string')
-    ? configuredArgs
-    : ['--stdio'];
+  const args = configuredPath.trim() ? (Array.isArray(configuredArgs) && configuredArgs.every((value) => typeof value === 'string') ? configuredArgs : ['--stdio']) : [bundledServer, ...(Array.isArray(configuredArgs) && configuredArgs.every((value) => typeof value === 'string') ? configuredArgs : ['--stdio'])];
   const serverOptions = { command, args, transport: TransportKind.stdio };
   const clientOptions = {
     documentSelector: [

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -12,7 +12,8 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@vscode/vsce": "^3.9.2"
+        "@vscode/vsce": "^3.9.2",
+        "yauzl": "3.4.0"
       },
       "engines": {
         "vscode": "^1.96.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -20,7 +20,7 @@
         "gluon.languageServerPath": {
           "type": "string",
           "default": "",
-          "description": "Optional path to the lockstep gluon-language-server executable. Empty uses gluon-language-server from PATH."
+          "description": "Optional path to a lockstep gluon-language-server executable. Empty uses the same-version runtime bundled with this extension."
         },
         "gluon.languageServerArgs": {
           "type": "array",
@@ -32,5 +32,5 @@
     }
   },
   "dependencies": { "vscode-languageclient": "^9.0.1" },
-  "devDependencies": { "@vscode/vsce": "^3.9.2" }
+  "devDependencies": { "@vscode/vsce": "^3.9.2", "yauzl": "3.4.0" }
 }

--- a/package.json
+++ b/package.json
@@ -196,6 +196,8 @@
     "check:vue-codemod-decision": "node scripts/validate-vue-codemod-decision.mjs",
     "check:dx-scorecard": "node scripts/validate-dx-scorecard.mjs",
     "check:vscode-client": "node scripts/validate-vscode-client.mjs",
+    "release:vscode": "node scripts/build-vscode-artifact.mjs",
+    "check:release-vscode": "node scripts/validate-vscode-artifact.mjs",
     "check:language-server-cli": "node scripts/validate-language-server-cli.mjs",
     "check:project-analysis": "npm run build:language-server && node scripts/generate-shop-project-analysis.mjs --check",
     "check:project-analysis-clean-install": "npm run build:language-server && node scripts/validate-project-analyzer-clean-install.mjs",

--- a/scripts/build-vscode-artifact.mjs
+++ b/scripts/build-vscode-artifact.mjs
@@ -1,0 +1,34 @@
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { resolve } from 'node:path';
+
+const run = promisify(execFile);
+const root = resolve(import.meta.dirname, '..');
+const extension = resolve(root, 'editors/vscode');
+const server = resolve(root, 'packages/language-server');
+const output = resolve(root, process.argv.includes('--output') ? process.argv[process.argv.indexOf('--output') + 1] : '.tmp/release/vscode');
+const rootManifest = JSON.parse(await readFile(resolve(root, 'package.json')));
+const extensionManifest = JSON.parse(await readFile(resolve(extension, 'package.json')));
+if (extensionManifest.version !== rootManifest.version) throw new Error('VS Code and framework versions must match.');
+if (JSON.parse(await readFile(resolve(server, 'package.json'))).version !== rootManifest.version) throw new Error('VS Code and language-server versions must match.');
+
+await run(process.execPath, ['scripts/validate-vscode-client.mjs'], { cwd: root });
+await run('npm', ['run', 'build:compiler'], { cwd: root });
+await run('npm', ['run', 'build:language-server'], { cwd: root });
+await run('npm', ['ci', '--ignore-scripts'], { cwd: extension });
+await mkdir(output, { recursive: true });
+await rm(resolve(extension, 'server'), { recursive: true, force: true });
+await mkdir(resolve(extension, 'server/node_modules/@gluonjs'), { recursive: true });
+await cp(resolve(server, 'dist'), resolve(extension, 'server/dist'), { recursive: true });
+await writeFile(resolve(extension, 'server/package.json'), JSON.stringify({ type: 'module', private: true }) + '\n');
+await cp(resolve(root, 'packages/compiler/dist'), resolve(extension, 'server/node_modules/@gluonjs/compiler/dist'), { recursive: true });
+await cp(resolve(root, 'packages/compiler/package.json'), resolve(extension, 'server/node_modules/@gluonjs/compiler/package.json'));
+await cp(resolve(root, 'node_modules/typescript'), resolve(extension, 'server/node_modules/typescript'), { recursive: true });
+await run('npm', ['run', 'package', '--', '--out', resolve(output, `gluon-vscode-${rootManifest.version}.vsix`)], { cwd: extension });
+const vsix = resolve(output, `gluon-vscode-${rootManifest.version}.vsix`);
+const digest = createHash('sha256').update(await readFile(vsix)).digest('hex');
+await writeFile(resolve(output, 'VSIX-SHA256SUMS'), `${digest}  ${vsix.split('/').pop()}\n`);
+await writeFile(resolve(output, 'vscode-release-manifest.json'), JSON.stringify({ schemaVersion: 1, version: rootManifest.version, tag: `v${rootManifest.version}`, extension: extensionManifest.name, publisher: extensionManifest.publisher, languageServer: '@gluonjs/language-server', vsix: vsix.split('/').pop(), sha256: digest }, null, 2) + '\n');
+console.log(`VSIX built: ${vsix}`);

--- a/scripts/build-vscode-artifact.mjs
+++ b/scripts/build-vscode-artifact.mjs
@@ -1,34 +1,115 @@
-import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import process from 'node:process';
+import { resolveVscodeReleaseOptions } from './vscode-release-options.mjs';
 
 const run = promisify(execFile);
 const root = resolve(import.meta.dirname, '..');
 const extension = resolve(root, 'editors/vscode');
 const server = resolve(root, 'packages/language-server');
-const output = resolve(root, process.argv.includes('--output') ? process.argv[process.argv.indexOf('--output') + 1] : '.tmp/release/vscode');
-const rootManifest = JSON.parse(await readFile(resolve(root, 'package.json')));
-const extensionManifest = JSON.parse(await readFile(resolve(extension, 'package.json')));
-if (extensionManifest.version !== rootManifest.version) throw new Error('VS Code and framework versions must match.');
-if (JSON.parse(await readFile(resolve(server, 'package.json'))).version !== rootManifest.version) throw new Error('VS Code and language-server versions must match.');
+const rootManifest = await readJson(resolve(root, 'package.json'));
+const extensionManifest = await readJson(resolve(extension, 'package.json'));
+const serverManifest = await readJson(resolve(server, 'package.json'));
+const { version, tag, output } = resolveVscodeReleaseOptions({
+  argv: process.argv.slice(2),
+  env: process.env,
+  root,
+  rootVersion: rootManifest.version,
+  defaultOutput: '.tmp/release/vscode',
+});
+
+for (const [name, actual] of [['VS Code extension', extensionManifest.version], ['language server', serverManifest.version]]) {
+  if (actual !== version) throw new Error(`${name} version ${actual} does not match package train ${version}.`);
+}
 
 await run(process.execPath, ['scripts/validate-vscode-client.mjs'], { cwd: root });
 await run('npm', ['run', 'build:compiler'], { cwd: root });
 await run('npm', ['run', 'build:language-server'], { cwd: root });
 await run('npm', ['ci', '--ignore-scripts'], { cwd: extension });
 await mkdir(output, { recursive: true });
-await rm(resolve(extension, 'server'), { recursive: true, force: true });
-await mkdir(resolve(extension, 'server/node_modules/@gluonjs'), { recursive: true });
-await cp(resolve(server, 'dist'), resolve(extension, 'server/dist'), { recursive: true });
-await writeFile(resolve(extension, 'server/package.json'), JSON.stringify({ type: 'module', private: true }) + '\n');
-await cp(resolve(root, 'packages/compiler/dist'), resolve(extension, 'server/node_modules/@gluonjs/compiler/dist'), { recursive: true });
-await cp(resolve(root, 'packages/compiler/package.json'), resolve(extension, 'server/node_modules/@gluonjs/compiler/package.json'));
-await cp(resolve(root, 'node_modules/typescript'), resolve(extension, 'server/node_modules/typescript'), { recursive: true });
-await run('npm', ['run', 'package', '--', '--out', resolve(output, `gluon-vscode-${rootManifest.version}.vsix`)], { cwd: extension });
-const vsix = resolve(output, `gluon-vscode-${rootManifest.version}.vsix`);
-const digest = createHash('sha256').update(await readFile(vsix)).digest('hex');
-await writeFile(resolve(output, 'VSIX-SHA256SUMS'), `${digest}  ${vsix.split('/').pop()}\n`);
-await writeFile(resolve(output, 'vscode-release-manifest.json'), JSON.stringify({ schemaVersion: 1, version: rootManifest.version, tag: `v${rootManifest.version}`, extension: extensionManifest.name, publisher: extensionManifest.publisher, languageServer: '@gluonjs/language-server', vsix: vsix.split('/').pop(), sha256: digest }, null, 2) + '\n');
-console.log(`VSIX built: ${vsix}`);
+const stagedServer = resolve(extension, 'server');
+
+try {
+  await rm(stagedServer, { recursive: true, force: true });
+  const stagedNodeModules = resolve(stagedServer, 'node_modules');
+  await mkdir(stagedNodeModules, { recursive: true });
+  await cp(resolve(server, 'dist'), resolve(stagedServer, 'dist'), { recursive: true });
+  await cp(resolve(server, 'package.json'), resolve(stagedServer, 'package.json'));
+  const stagedPackages = new Map();
+  for (const dependency of Object.keys(serverManifest.dependencies ?? {})) {
+    const source = dependency === '@gluonjs/compiler'
+      ? resolve(root, 'packages/compiler')
+      : await locateDependency(dependency, server);
+    await stageRuntimePackage(dependency, source, stagedNodeModules, stagedPackages);
+  }
+
+  const filename = `gluon-vscode-${version}.vsix`;
+  const vsix = resolve(output, filename);
+  await run('npm', ['run', 'package', '--', '--out', vsix], { cwd: extension });
+  const digest = createHash('sha256').update(await readFile(vsix)).digest('hex');
+  await writeFile(resolve(output, 'VSIX-SHA256SUMS'), `${digest}  ${filename}\n`);
+  await writeFile(resolve(output, 'vscode-release-manifest.json'), `${JSON.stringify({
+    schemaVersion: 1,
+    version,
+    tag,
+    extension: extensionManifest.name,
+    publisher: extensionManifest.publisher,
+    languageServer: serverManifest.name,
+    vsix: filename,
+    sha256: digest,
+  }, null, 2)}\n`);
+  console.log(`VSIX built: ${vsix}`);
+} finally {
+  await rm(stagedServer, { recursive: true, force: true });
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}
+
+async function stageRuntimePackage(name, source, destinationNodeModules, stagedPackages) {
+  const manifest = await readJson(resolve(source, 'package.json'));
+  const prior = stagedPackages.get(name);
+  if (prior) {
+    if (prior !== manifest.version) throw new Error(`Runtime dependency ${name} resolves to both ${prior} and ${manifest.version}.`);
+    return;
+  }
+  stagedPackages.set(name, manifest.version);
+  const destination = resolve(destinationNodeModules, ...name.split('/'));
+  await mkdir(destination, { recursive: true });
+  await cp(resolve(source, 'package.json'), resolve(destination, 'package.json'));
+  if (source.startsWith(resolve(root, 'packages'))) {
+    for (const entry of manifest.files ?? []) {
+      const path = resolve(source, entry);
+      if (await exists(path)) await cp(path, resolve(destination, entry), { recursive: true });
+    }
+  } else {
+    await cp(source, destination, {
+      recursive: true,
+      force: true,
+      filter: (path) => path === source || !path.startsWith(`${resolve(source, 'node_modules')}/`),
+    });
+  }
+  for (const dependency of Object.keys(manifest.dependencies ?? {})) {
+    await stageRuntimePackage(dependency, await locateDependency(dependency, source), destinationNodeModules, stagedPackages);
+  }
+}
+
+async function locateDependency(name, source) {
+  let directory = source;
+  while (true) {
+    const candidate = resolve(directory, 'node_modules', ...name.split('/'));
+    if (await exists(resolve(candidate, 'package.json'))) return candidate;
+    const parent = resolve(directory, '..');
+    if (parent === directory) break;
+    directory = parent;
+  }
+  throw new Error(`Cannot resolve runtime dependency ${name} from ${source}.`);
+}
+
+async function exists(path) {
+  try { await access(path); return true; } catch { return false; }
+}

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import process from 'node:process';
 import Ajv2020 from 'ajv/dist/2020.js';
 import addFormats from 'ajv-formats';
+import { resolveVscodeReleaseOptions } from './vscode-release-options.mjs';
 
 const root = resolve(import.meta.dirname, '..');
 const candidateIndex = process.argv.indexOf('--candidate');
@@ -37,6 +38,10 @@ const bootstrapBuildScript = await readFile(resolve(root, 'scripts/build-npm-boo
 const bootstrapPublishScript = await readFile(resolve(root, 'scripts/publish-npm-bootstrap.mjs'), 'utf8');
 const hostingScript = await readFile(resolve(root, 'scripts/verify-release-hosting.mjs'), 'utf8');
 const recoveryScript = await readFile(resolve(root, 'scripts/validate-release-recovery.mjs'), 'utf8');
+const vscodeBuildScript = await readFile(resolve(root, 'scripts/build-vscode-artifact.mjs'), 'utf8');
+const vscodeValidationScript = await readFile(resolve(root, 'scripts/validate-vscode-artifact.mjs'), 'utf8');
+const vscodeOptionsScript = await readFile(resolve(root, 'scripts/vscode-release-options.mjs'), 'utf8');
+const vscodeManifest = await readJson('editors/vscode/package.json');
 const officialNames = new Set(packageContract.packages.map((entry) => entry.name));
 const releaseCutEvidenceSchema = await readJson('release/release-cut-evidence.schema.json');
 const compatibilityManifestSchema = await readJson('release/compatibility-manifest.schema.json');
@@ -597,6 +602,7 @@ function validateWorkflow() {
   if (!publishJob || /registry-url:/.test(publishJob)) {
     throw new Error('Release publish must not ask setup-node to create token-backed registry authentication.');
   }
+  validateVscodeDistributionWorkflow(publishJob);
   if (!publishScript.includes('recovery?.recoveryTag')
     || !publishScript.includes('validate-release-recovery.mjs')
     || !hostingScript.includes('validate-release-recovery.mjs')) {
@@ -700,6 +706,100 @@ function validateWorkflow() {
   }
   for (const forbidden of ['NPM_TOKEN', 'NODE_AUTH_TOKEN']) {
     if (workflow.includes(forbidden)) throw new Error(`Release workflow must not reference long-lived ${forbidden}.`);
+  }
+}
+
+function validateVscodeDistributionWorkflow(publishJob) {
+  const candidateJob = workflow.match(/\n  candidate:\n([\s\S]*?)\n  publish:\n/)?.[1] ?? '';
+  const candidateCommands = [...candidateJob.matchAll(/^\s*- run: (.+)$/gm)].map((match) => match[1]);
+  const buildCommand = 'npm run release:vscode -- --version "$RELEASE_VERSION" --tag "$RELEASE_TAG"';
+  const validationCommand = 'npm run check:release-vscode -- --version "$RELEASE_VERSION" --tag "$RELEASE_TAG"';
+  const buildIndex = candidateCommands.indexOf(buildCommand);
+  const validationIndex = candidateCommands.indexOf(validationCommand);
+  if (buildIndex < 0 || validationIndex !== buildIndex + 1) {
+    throw new Error('Release candidate must build and immediately smoke-validate the VSIX for the resolved version and tag.');
+  }
+
+  for (const [name, command] of Object.entries({
+    'release:vscode': 'node scripts/build-vscode-artifact.mjs',
+    'check:release-vscode': 'node scripts/validate-vscode-artifact.mjs',
+  })) {
+    if (rootManifest.scripts?.[name] !== command) throw new Error(`package.json must define ${name} as ${command}.`);
+  }
+
+  const vscodeAssets = [
+    '.tmp/release/vscode/*.vsix',
+    '.tmp/release/vscode/VSIX-SHA256SUMS',
+    '.tmp/release/vscode/vscode-release-manifest.json',
+  ];
+  const assetArray = /assets=\(([^)]*)\)/.exec(publishJob)?.[1]?.split(/\s+/).filter(Boolean) ?? [];
+  for (const asset of vscodeAssets) {
+    if (!assetArray.includes(asset)) throw new Error(`GitHub release attachment array is missing ${asset}.`);
+  }
+  const attestationBlock = /- name: Attest release archives and evidence\n([\s\S]*?)\n\s+- name: Create immutable-release draft/.exec(publishJob)?.[1] ?? '';
+  for (const asset of vscodeAssets) {
+    if (!attestationBlock.includes(asset)) throw new Error(`VSIX provenance attestation is missing ${asset}.`);
+  }
+  if (!publishJob.includes('gh release create "$RELEASE_TAG" "${assets[@]}"')
+    || !publishJob.includes('gh release upload "$RELEASE_TAG" "${assets[@]}"')) {
+    throw new Error('Both GitHub release creation and update paths must attach the complete reviewed asset array.');
+  }
+
+  const secretReferences = workflow.match(/secrets\.VSCE_PAT/g) ?? [];
+  if (secretReferences.length !== 1 || !/^\s+VSCE_PAT: \$\{\{ secrets\.VSCE_PAT \}\}$/m.test(publishJob)) {
+    throw new Error('VSCE_PAT must be promoted exactly once to the publish job environment.');
+  }
+  if (/if:\s*\$\{\{\s*secrets\.VSCE_PAT/.test(workflow)) {
+    throw new Error('Marketplace publication must not reference secrets.VSCE_PAT directly in a step condition.');
+  }
+  const marketplaceStep = /- name: Publish VS Code extension when publisher credentials are configured\n([\s\S]*?)\n\s+- name: Verify latest registry train/.exec(publishJob)?.[1] ?? '';
+  const marketplacePrepareStep = /- name: Prepare VS Code Marketplace publisher when credentials are configured\n([\s\S]*?)\n\s+- name: Publish VS Code extension/.exec(publishJob)?.[1] ?? '';
+  if (!marketplacePrepareStep.includes("if: ${{ env.VSCE_PAT != '' }}")
+    || !marketplacePrepareStep.includes('working-directory: editors/vscode')
+    || !marketplacePrepareStep.includes('run: npm ci --ignore-scripts')) {
+    throw new Error('Marketplace publication must install the editor lockfile in its non-workspace directory under the credential guard.');
+  }
+  if (!marketplaceStep.includes("if: ${{ env.VSCE_PAT != '' }}")
+    || !marketplaceStep.includes('gluon-vscode-${{ env.RELEASE_VERSION }}.vsix')
+    || marketplaceStep.includes('--pat') || marketplaceStep.includes('$VSCE_PAT')) {
+    throw new Error('Marketplace publication must use the job-level token implicitly, guard on env.VSCE_PAT, and never print or pass the token.');
+  }
+
+  if (vscodeManifest.version !== rootManifest.version
+    || vscodeManifest.devDependencies?.yauzl !== '3.4.0'
+    || !vscodeManifest.contributes.configuration.properties['gluon.languageServerPath'].description.includes('bundled with this extension')) {
+    throw new Error('VS Code metadata must align with the package train and document the bundled default runtime.');
+  }
+  for (const [scriptName, source] of [['builder', vscodeBuildScript], ['validator', vscodeValidationScript]]) {
+    for (const required of ['resolveVscodeReleaseOptions', 'process.argv.slice(2)', 'process.env', "defaultOutput: '.tmp/release/vscode'"]) {
+      if (!source.includes(required)) throw new Error(`VSIX ${scriptName} does not enforce release option contract ${required}.`);
+    }
+  }
+  for (const required of ['Option ${name} requires a value.', 'version !== rootVersion', 'tag !== `v${version}`']) {
+    if (!vscodeOptionsScript.includes(required)) throw new Error(`VSIX option resolver is missing ${required}.`);
+  }
+  for (const required of ['createHash', 'VSIX-SHA256SUMS', 'expectedManifestKeys', 'extractVsix', 'Unsafe VSIX entry path', 'activateBundledExtension', 'initializeBundledServer', "response.result?.serverInfo?.version !== version", "extensionSource.includes(\"module: bundledServer\")"]) {
+    if (!vscodeValidationScript.includes(required)) throw new Error(`VSIX validation is missing enforced contract ${required}.`);
+  }
+  for (const required of ["cp(resolve(server, 'package.json')", "dependency === '@gluonjs/compiler'", 'stageRuntimePackage', 'manifest.dependencies', 'finally']) {
+    if (!vscodeBuildScript.includes(required)) throw new Error(`VSIX builder is missing self-contained runtime contract ${required}.`);
+  }
+
+  const resolved = resolveVscodeReleaseOptions({ argv: ['--version', rootManifest.version, '--tag', `v${rootManifest.version}`, '--output', '.tmp/fixture'], env: {}, root, rootVersion: rootManifest.version, defaultOutput: '.tmp/release/vscode' });
+  if (resolved.version !== rootManifest.version || resolved.tag !== `v${rootManifest.version}` || !resolved.output.endsWith('/.tmp/fixture')) {
+    throw new Error('VSIX release option resolver did not preserve an aligned explicit release request.');
+  }
+  for (const fixture of [
+    ['--output'],
+    ['--version', '0.0.1'],
+    ['--version', rootManifest.version, '--tag', `v${rootManifest.version}-other`],
+    ['--unknown', 'value'],
+  ]) {
+    let rejected = false;
+    try {
+      resolveVscodeReleaseOptions({ argv: fixture, env: {}, root, rootVersion: rootManifest.version, defaultOutput: '.tmp/release/vscode' });
+    } catch { rejected = true; }
+    if (!rejected) throw new Error(`VSIX release option resolver accepted invalid fixture ${fixture.join(' ')}.`);
   }
 }
 

--- a/scripts/validate-vscode-artifact.mjs
+++ b/scripts/validate-vscode-artifact.mjs
@@ -1,12 +1,253 @@
-import { readFile, access } from 'node:fs/promises';
-import { resolve } from 'node:path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
-const run = promisify(execFile); const root = resolve(import.meta.dirname, '..');
-const version = JSON.parse(await readFile(resolve(root, 'package.json'))).version;
-const dir = resolve(root, '.tmp/release/vscode'); const manifest = JSON.parse(await readFile(resolve(dir, 'vscode-release-manifest.json')));
-if (manifest.version !== version || manifest.tag !== `v${version}` || manifest.languageServer !== '@gluonjs/language-server') throw new Error('VSIX release manifest is not lockstep.');
-await access(resolve(dir, manifest.vsix));
-const listing = (await run('unzip', ['-l', resolve(dir, manifest.vsix)])).stdout;
-for (const required of ['extension/package.json', 'extension/extension.cjs', 'extension/server/dist/server-cli.js', 'extension/server/node_modules/@gluonjs/compiler/']) if (!listing.includes(required)) throw new Error(`VSIX is missing ${required}.`);
-console.log(`VSIX artifact valid for Gluon ${version}: bundled server, metadata, and package contents present.`);
+import { createHash } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+import { dirname, join, resolve, sep } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { tmpdir } from 'node:os';
+import process from 'node:process';
+import yauzl from '../editors/vscode/node_modules/yauzl/index.js';
+import { resolveVscodeReleaseOptions } from './vscode-release-options.mjs';
+
+const root = resolve(import.meta.dirname, '..');
+const rootManifest = await readJson(resolve(root, 'package.json'));
+const sourceServerManifest = await readJson(resolve(root, 'packages/language-server/package.json'));
+const { version, tag, output } = resolveVscodeReleaseOptions({
+  argv: process.argv.slice(2),
+  env: process.env,
+  root,
+  rootVersion: rootManifest.version,
+  defaultOutput: '.tmp/release/vscode',
+});
+const filename = `gluon-vscode-${version}.vsix`;
+const vsix = resolve(output, filename);
+const manifest = await readJson(resolve(output, 'vscode-release-manifest.json'));
+const expectedManifestKeys = ['extension', 'languageServer', 'publisher', 'schemaVersion', 'sha256', 'tag', 'version', 'vsix'];
+if (JSON.stringify(Object.keys(manifest).sort()) !== JSON.stringify(expectedManifestKeys)) {
+  throw new Error('VSIX release manifest has missing or ambiguous fields.');
+}
+if (manifest.schemaVersion !== 1 || manifest.version !== version || manifest.tag !== tag
+  || manifest.vsix !== filename || manifest.extension !== 'gluon-vscode'
+  || manifest.publisher !== 'marcmalerei' || manifest.languageServer !== '@gluonjs/language-server') {
+  throw new Error('VSIX release manifest is not aligned with the requested package train and tag.');
+}
+
+const digest = createHash('sha256').update(await readFile(vsix)).digest('hex');
+if (manifest.sha256 !== digest) throw new Error('VSIX release manifest SHA-256 does not match the VSIX bytes.');
+const checksumText = await readFile(resolve(output, 'VSIX-SHA256SUMS'), 'utf8');
+const checksumMatch = /^([a-f0-9]{64})  ([^\r\n]+)\n$/.exec(checksumText);
+if (!checksumMatch || checksumMatch[1] !== digest || checksumMatch[2] !== filename) {
+  throw new Error('VSIX-SHA256SUMS must contain exactly one canonical filename and matching SHA-256 record.');
+}
+
+const extractionRoot = await mkdtemp(join(tmpdir(), 'gluon-vsix-'));
+try {
+  await extractVsix(vsix, extractionRoot);
+  const extensionRoot = resolve(extractionRoot, 'extension');
+  const extensionManifest = await readJson(resolve(extensionRoot, 'package.json'));
+  const bundledServerManifest = await readJson(resolve(extensionRoot, 'server/package.json'));
+  const bundledCompilerManifest = await readJson(resolve(extensionRoot, 'server/node_modules/@gluonjs/compiler/package.json'));
+  const bundledTypescriptManifest = await readJson(resolve(extensionRoot, 'server/node_modules/typescript/package.json'));
+  const extensionSource = await readFile(resolve(extensionRoot, extensionManifest.main), 'utf8');
+
+  if (extensionManifest.version !== version || extensionManifest.name !== manifest.extension
+    || extensionManifest.publisher !== manifest.publisher || extensionManifest.main !== './extension.cjs') {
+    throw new Error('Extracted VSIX extension metadata is not aligned with the release manifest.');
+  }
+  if (bundledServerManifest.name !== manifest.languageServer || bundledServerManifest.version !== version
+    || bundledServerManifest.dependencies?.['@gluonjs/compiler'] !== version
+    || bundledServerManifest.dependencies?.typescript !== sourceServerManifest.dependencies?.typescript) {
+    throw new Error('Bundled language-server package metadata is not lockstep with the release train.');
+  }
+  if (bundledCompilerManifest.name !== '@gluonjs/compiler' || bundledCompilerManifest.version !== version) {
+    throw new Error('Bundled compiler runtime is not lockstep with the release train.');
+  }
+  if (!satisfiesCaret(bundledTypescriptManifest.version, bundledServerManifest.dependencies.typescript)) {
+    throw new Error('Bundled TypeScript runtime does not satisfy the language-server dependency contract.');
+  }
+  await validateRuntimeClosure(resolve(extensionRoot, 'server'), bundledServerManifest);
+  if (!extensionSource.includes("module: bundledServer")
+    || !extensionSource.includes("'server', 'dist', 'server-cli.js'")
+    || extensionSource.includes("|| 'gluon-language-server'")) {
+    throw new Error('Extracted extension entrypoint does not use the bundled server as its sole default.');
+  }
+
+  const serverCli = resolve(extensionRoot, 'server/dist/server-cli.js');
+  await activateBundledExtension(extensionRoot, serverCli, extractionRoot);
+  const response = await initializeBundledServer(serverCli, extensionRoot);
+  if (response.jsonrpc !== '2.0' || response.id !== 1 || response.error
+    || response.result?.serverInfo?.name !== '@gluonjs/language-server'
+    || response.result?.serverInfo?.version !== version
+    || typeof response.result?.capabilities !== 'object') {
+    throw new Error('Bundled VSIX language server returned an invalid LSP initialize response.');
+  }
+} finally {
+  await rm(extractionRoot, { recursive: true, force: true });
+}
+
+console.log(`VSIX artifact valid for ${tag}: hashes, package train, bundled entrypoint, and LSP initialize smoke passed.`);
+
+async function extractVsix(path, destinationRoot) {
+  const zip = await new Promise((resolveOpen, rejectOpen) => {
+    yauzl.open(path, { lazyEntries: true, decodeStrings: true, validateEntrySizes: true }, (error, value) => error ? rejectOpen(error) : resolveOpen(value));
+  });
+  const seen = new Set();
+  const seenFolded = new Set();
+  await new Promise((resolveExtraction, rejectExtraction) => {
+    let settled = false;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      zip.close();
+      rejectExtraction(error);
+    };
+    zip.on('error', fail);
+    zip.on('end', () => {
+      if (settled) return;
+      settled = true;
+      resolveExtraction();
+    });
+    zip.on('entry', (entry) => {
+      void extractEntry(zip, entry, destinationRoot, seen, seenFolded).then(() => zip.readEntry(), fail);
+    });
+    zip.readEntry();
+  });
+}
+
+async function extractEntry(zip, entry, destinationRoot, seen, seenFolded) {
+  const name = entry.fileName;
+  const parts = name.replace(/\/$/, '').split('/');
+  if (!name || name.includes('\\') || name.includes('\0') || name.startsWith('/') || /^[A-Za-z]:/.test(name)
+    || parts.some((part) => !part || part === '.' || part === '..')) {
+    throw new Error(`Unsafe VSIX entry path: ${JSON.stringify(name)}.`);
+  }
+  const folded = name.toLowerCase();
+  if (seen.has(name) || seenFolded.has(folded)) throw new Error(`Duplicate VSIX entry path: ${name}.`);
+  seen.add(name); seenFolded.add(folded);
+  const mode = (entry.externalFileAttributes >>> 16) & 0xffff;
+  if ((mode & 0o170000) === 0o120000) throw new Error(`VSIX symlink entries are forbidden: ${name}.`);
+  const destination = resolve(destinationRoot, ...parts);
+  if (destination !== destinationRoot && !destination.startsWith(`${destinationRoot}${sep}`)) throw new Error(`VSIX entry escapes extraction root: ${name}.`);
+  if (name.endsWith('/')) {
+    await mkdir(destination, { recursive: true });
+    return;
+  }
+  await mkdir(dirname(destination), { recursive: true });
+  const input = await new Promise((resolveStream, rejectStream) => zip.openReadStream(entry, (error, stream) => error ? rejectStream(error) : resolveStream(stream)));
+  await pipeline(input, createWriteStream(destination, { flags: 'wx', mode: 0o600 }));
+}
+
+async function initializeBundledServer(serverCli, cwd) {
+  const request = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { rootUri: null, capabilities: {} } });
+  const frame = `Content-Length: ${Buffer.byteLength(request)}\r\n\r\n${request}`;
+  const output = await new Promise((resolveOutput, rejectOutput) => {
+    const child = spawn(process.execPath, [serverCli], { cwd, stdio: ['pipe', 'pipe', 'pipe'] });
+    const stdout = []; const stderr = [];
+    const timer = setTimeout(() => { child.kill(); rejectOutput(new Error('Bundled language server initialize timed out.')); }, 5_000);
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', (error) => { clearTimeout(timer); rejectOutput(error); });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) rejectOutput(new Error(`Bundled language server exited ${code}: ${Buffer.concat(stderr).toString('utf8')}`));
+      else resolveOutput(Buffer.concat(stdout));
+    });
+    child.stdin.end(frame);
+  });
+  const headerEnd = output.indexOf('\r\n\r\n');
+  const length = Number(/^Content-Length:\s*(\d+)$/im.exec(output.subarray(0, headerEnd).toString('ascii'))?.[1]);
+  if (headerEnd < 0 || !Number.isSafeInteger(length) || output.length !== headerEnd + 4 + length) {
+    throw new Error('Bundled language server returned malformed LSP framing.');
+  }
+  return JSON.parse(output.subarray(headerEnd + 4).toString('utf8'));
+}
+
+async function activateBundledExtension(extensionRoot, serverCli, extractionRoot) {
+  const harness = resolve(extractionRoot, 'activate-extension.cjs');
+  await writeFile(harness, `
+const Module = require('node:module');
+const { realpathSync } = require('node:fs');
+const originalLoad = Module._load;
+let captured;
+Module._load = function (request, parent, isMain) {
+  if (request === 'vscode') return { workspace: { getConfiguration: () => ({ get: (_name, fallback) => fallback }) } };
+  if (request === 'vscode-languageclient/node') return {
+    TransportKind: { stdio: 1 },
+    LanguageClient: class {
+      constructor(_id, _name, serverOptions) { captured = serverOptions; }
+      async start() {}
+      async stop() {}
+    },
+  };
+  return originalLoad.call(this, request, parent, isMain);
+};
+(async () => {
+  const extension = require(process.argv[2]);
+  const context = { subscriptions: [] };
+  await extension.activate(context);
+  if (!captured || realpathSync(captured.module) !== realpathSync(process.argv[3]) || captured.command !== undefined
+    || JSON.stringify(captured.args) !== JSON.stringify(['--stdio']) || context.subscriptions.length !== 1) {
+    throw new Error('Extension did not activate with the bundled server module: ' + JSON.stringify({ captured, expectedModule: process.argv[3], subscriptions: context.subscriptions.length }));
+  }
+})().catch((error) => { console.error(error); process.exitCode = 1; });
+`, 'utf8');
+  await new Promise((resolveActivation, rejectActivation) => {
+    const child = spawn(process.execPath, [harness, resolve(extensionRoot, 'extension.cjs'), serverCli], { cwd: extensionRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+    const stderr = [];
+    const timer = setTimeout(() => { child.kill(); rejectActivation(new Error('Extracted extension activation timed out.')); }, 5_000);
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+    child.on('error', (error) => { clearTimeout(timer); rejectActivation(error); });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0) rejectActivation(new Error(`Extracted extension activation exited ${code}: ${Buffer.concat(stderr).toString('utf8')}`));
+      else resolveActivation();
+    });
+  });
+}
+
+function satisfiesCaret(actual, declared) {
+  const match = /^\^(\d+)\.(\d+)\.(\d+)$/.exec(declared ?? '');
+  const actualMatch = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(actual ?? '');
+  if (!match || !actualMatch) return false;
+  const minimum = match.slice(1).map(Number); const candidate = actualMatch.slice(1).map(Number);
+  if (candidate[0] !== minimum[0]) return false;
+  return candidate[1] > minimum[1] || (candidate[1] === minimum[1] && candidate[2] >= minimum[2]);
+}
+
+async function validateRuntimeClosure(serverRoot, serverManifest) {
+  const nodeModules = resolve(serverRoot, 'node_modules');
+  const queue = [serverManifest];
+  const visited = new Set();
+  while (queue.length > 0) {
+    const owner = queue.shift();
+    for (const [name, range] of Object.entries(owner.dependencies ?? {})) {
+      const dependency = await readJson(resolve(nodeModules, ...name.split('/'), 'package.json'));
+      if (dependency.name !== name || !satisfiesRange(dependency.version, range)) {
+        throw new Error(`Bundled runtime dependency ${name}@${dependency.version} does not satisfy ${range}.`);
+      }
+      const key = `${name}@${dependency.version}`;
+      if (!visited.has(key)) { visited.add(key); queue.push(dependency); }
+    }
+  }
+}
+
+function satisfiesRange(actual, declared) {
+  if (actual === declared || declared === '*') return true;
+  const match = /^(\^|~)(\d+)\.(\d+)\.(\d+)$/.exec(declared ?? '');
+  const actualMatch = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(actual ?? '');
+  if (!match || !actualMatch) return false;
+  const minimum = match.slice(2).map(Number); const candidate = actualMatch.slice(1).map(Number);
+  if (candidate[0] !== minimum[0] || compareVersion(candidate, minimum) < 0) return false;
+  if (match[1] === '~' || (match[1] === '^' && minimum[0] === 0 && minimum[1] > 0)) return candidate[1] === minimum[1];
+  if (match[1] === '^' && minimum[0] === 0 && minimum[1] === 0) return candidate[1] === 0 && candidate[2] === minimum[2];
+  return true;
+}
+
+function compareVersion(left, right) {
+  for (let index = 0; index < 3; index += 1) if (left[index] !== right[index]) return left[index] - right[index];
+  return 0;
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}

--- a/scripts/validate-vscode-artifact.mjs
+++ b/scripts/validate-vscode-artifact.mjs
@@ -1,0 +1,12 @@
+import { readFile, access } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+const run = promisify(execFile); const root = resolve(import.meta.dirname, '..');
+const version = JSON.parse(await readFile(resolve(root, 'package.json'))).version;
+const dir = resolve(root, '.tmp/release/vscode'); const manifest = JSON.parse(await readFile(resolve(dir, 'vscode-release-manifest.json')));
+if (manifest.version !== version || manifest.tag !== `v${version}` || manifest.languageServer !== '@gluonjs/language-server') throw new Error('VSIX release manifest is not lockstep.');
+await access(resolve(dir, manifest.vsix));
+const listing = (await run('unzip', ['-l', resolve(dir, manifest.vsix)])).stdout;
+for (const required of ['extension/package.json', 'extension/extension.cjs', 'extension/server/dist/server-cli.js', 'extension/server/node_modules/@gluonjs/compiler/']) if (!listing.includes(required)) throw new Error(`VSIX is missing ${required}.`);
+console.log(`VSIX artifact valid for Gluon ${version}: bundled server, metadata, and package contents present.`);

--- a/scripts/validate-vscode-client.mjs
+++ b/scripts/validate-vscode-client.mjs
@@ -8,6 +8,7 @@ async function readJson(relativePath) {
 
 const rootPackage = await readJson('package.json');
 const extensionPackage = await readJson('editors/vscode/package.json');
+const languageServerPackage = await readJson('packages/language-server/package.json');
 const extensionSource = await readFile(new URL('editors/vscode/extension.cjs', root), 'utf8');
 const failures = [];
 
@@ -16,6 +17,7 @@ function requireValue(condition, message) {
 }
 
 requireValue(extensionPackage.version === rootPackage.version, `VS Code version ${extensionPackage.version} must match lockstep version ${rootPackage.version}.`);
+requireValue(languageServerPackage.version === rootPackage.version, `Language-server version ${languageServerPackage.version} must match lockstep version ${rootPackage.version}.`);
 requireValue(extensionPackage.private !== true, 'VS Code client must be releasable and cannot be private.');
 requireValue(typeof extensionPackage.publisher === 'string' && extensionPackage.publisher.length > 0, 'VS Code client needs a publisher id.');
 requireValue(extensionPackage.main === './extension.cjs', 'VS Code client main must remain ./extension.cjs.');
@@ -26,13 +28,15 @@ requireValue(extensionPackage.contributes?.configuration?.properties?.['gluon.la
 requireValue(extensionPackage.contributes?.configuration?.properties?.['gluon.languageServerArgs'], 'VS Code client must expose gluon.languageServerArgs.');
 requireValue(extensionPackage.dependencies?.['vscode-languageclient'], 'VS Code client must declare vscode-languageclient.');
 requireValue(extensionPackage.devDependencies?.['@vscode/vsce'], 'VS Code client must declare the VSIX packager.');
-requireValue(extensionSource.includes("'gluon-language-server'"), 'VS Code client must have the documented PATH fallback.');
+requireValue(extensionSource.includes("'server', 'dist', 'server-cli.js'"), 'VS Code client must use the bundled language-server fallback.');
 requireValue(extensionSource.includes("['--stdio']"), 'VS Code client must keep stdio as the safe default transport.');
 requireValue(extensionSource.includes('TransportKind.stdio'), 'VS Code client must use stdio transport.');
+requireValue(extensionPackage.publisher === 'marcmalerei', 'VS Code publisher ownership must remain explicit.');
 
 const readme = await readFile(new URL('editors/vscode/README.md', root), 'utf8');
-requireValue(readme.includes('npm install --global @gluonjs/language-server@'), 'VS Code install guide must pin the matching language-server version.');
+requireValue(readme.includes('same-version `@gluonjs/language-server` runtime'), 'VS Code install guide must document the bundled matching language-server runtime.');
 requireValue(readme.includes('code --install-extension'), 'VS Code install guide must document VSIX installation.');
+requireValue(readme.includes('VSCE_PAT') && readme.includes('roll back'), 'VS Code distribution guide must document guarded publishing and rollback.');
 
 if (failures.length > 0) {
   console.error(failures.map((failure) => `- ${failure}`).join('\n'));

--- a/scripts/validate-vscode-client.mjs
+++ b/scripts/validate-vscode-client.mjs
@@ -26,9 +26,12 @@ requireValue(extensionPackage.activationEvents?.includes('onLanguage:typescript'
 requireValue(extensionPackage.activationEvents?.includes('onLanguage:javascript'), 'VS Code client must activate for JavaScript.');
 requireValue(extensionPackage.contributes?.configuration?.properties?.['gluon.languageServerPath'], 'VS Code client must expose gluon.languageServerPath.');
 requireValue(extensionPackage.contributes?.configuration?.properties?.['gluon.languageServerArgs'], 'VS Code client must expose gluon.languageServerArgs.');
+requireValue(extensionPackage.contributes.configuration.properties['gluon.languageServerPath'].description.includes('bundled with this extension'), 'VS Code client must describe the bundled default runtime.');
 requireValue(extensionPackage.dependencies?.['vscode-languageclient'], 'VS Code client must declare vscode-languageclient.');
 requireValue(extensionPackage.devDependencies?.['@vscode/vsce'], 'VS Code client must declare the VSIX packager.');
 requireValue(extensionSource.includes("'server', 'dist', 'server-cli.js'"), 'VS Code client must use the bundled language-server fallback.');
+requireValue(extensionSource.includes('{ module: bundledServer, args, transport: TransportKind.stdio }'), 'VS Code client must launch the bundled runtime as a Node module.');
+requireValue(!extensionSource.includes("|| 'gluon-language-server'"), 'VS Code client must not retain an undeclared PATH fallback.');
 requireValue(extensionSource.includes("['--stdio']"), 'VS Code client must keep stdio as the safe default transport.');
 requireValue(extensionSource.includes('TransportKind.stdio'), 'VS Code client must use stdio transport.');
 requireValue(extensionPackage.publisher === 'marcmalerei', 'VS Code publisher ownership must remain explicit.');

--- a/scripts/vscode-release-options.mjs
+++ b/scripts/vscode-release-options.mjs
@@ -1,0 +1,35 @@
+import { resolve } from 'node:path';
+
+const stableVersion = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+
+export function resolveVscodeReleaseOptions({ argv, env, root, rootVersion, defaultOutput }) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (!['--version', '--tag', '--output'].includes(name)) throw new Error(`Unknown option ${name}.`);
+    if (values.has(name)) throw new Error(`Option ${name} may only be provided once.`);
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`Option ${name} requires a value.`);
+    values.set(name, value);
+    index += 1;
+  }
+
+  const explicitVersion = values.get('--version');
+  const explicitTag = values.get('--tag');
+  if (explicitVersion && env.RELEASE_VERSION && explicitVersion !== env.RELEASE_VERSION) {
+    throw new Error(`--version ${explicitVersion} does not match RELEASE_VERSION ${env.RELEASE_VERSION}.`);
+  }
+  if (explicitTag && env.RELEASE_TAG && explicitTag !== env.RELEASE_TAG) {
+    throw new Error(`--tag ${explicitTag} does not match RELEASE_TAG ${env.RELEASE_TAG}.`);
+  }
+
+  const version = explicitVersion ?? env.RELEASE_VERSION ?? rootVersion;
+  const tag = explicitTag ?? env.RELEASE_TAG ?? `v${version}`;
+  if (!stableVersion.test(version)) throw new Error(`Invalid stable VS Code release version ${version}.`);
+  if (version !== rootVersion) throw new Error(`Requested VS Code version ${version} does not match package train ${rootVersion}.`);
+  if (tag !== `v${version}`) throw new Error(`Requested VS Code tag ${tag} must equal v${version}.`);
+
+  const outputValue = values.get('--output') ?? defaultOutput;
+  if (!outputValue?.trim()) throw new Error('VS Code release output path must not be empty.');
+  return { version, tag, output: resolve(root, outputValue) };
+}


### PR DESCRIPTION
Closes #407

## Summary
- bundle the lockstep language-server/compiler runtime into a self-contained VSIX and use it as the extension default
- build and safely extract/smoke the actual archive, validate extension activation and an LSP initialize response, and verify SHA-256 evidence plus dependency closure
- attach VSIX/integrity artifacts to GitHub releases and guard lockfile-based Marketplace publication on `VSCE_PAT`
- enforce version/tag/publisher/release-workflow alignment and document installation, signing ownership, rollback, and the credential boundary

## Verification
- clean root/editor installs and `release:vscode -- --version 1.9.0 --tag v1.9.0`
- `check:release-vscode -- --version 1.9.0 --tag v1.9.0` (safe extraction, activation, dependency closure, LSP initialize)
- `npm run check:release-contract`
- `npm run check:vscode-client`
- language-server typecheck and 14 tests
- `git diff --check`

Marketplace publication is intentionally skipped when the publisher-owned `VSCE_PAT` secret is absent; GitHub release attachment remains automatic.