### PR TITLE
docs: finalize v1.10.0 release state

### DIFF
--- a/docs-site/content/1.10.0/guides/releasing/index.md
+++ b/docs-site/content/1.10.0/guides/releasing/index.md
@@ -1,10 +1,10 @@
 # Release readiness
 
-The `1.10.0` documentation describes the prepared lockstep candidate. All 21
-official manifests are at `1.10.0`; registry preflight found the target version
-absent while `1.9.0` remains the supported `latest` package train. Issue
-[#456](https://github.com/marcmalerei/gluon/issues/456) owns the release of the
-post-1.9 documentation, package, UI, tooling, security, persistence, forms, and
+The `1.10.0` documentation describes the completed lockstep release. All 21
+official manifests are at `1.10.0`, and the protected release workflow published
+`1.10.0` as the latest package train with npm provenance. Issue
+[#456](https://github.com/marcmalerei/gluon/issues/456) released the post-1.9
+documentation, package, UI, tooling, security, persistence, forms, and
 performance work tracked by epic
 [#390](https://github.com/marcmalerei/gluon/issues/390). The release cut retains
 a Quality-Gates-tested candidate followed only by its release-cut evidence and
@@ -14,10 +14,11 @@ Release-state wording in this documentation follows the repository policy:
 stable describes shipped public contracts, experimental describes explicitly
 labeled opt-in surfaces, and unsupported marks boundaries the contract refuses.
 
-The immutable [`v1.9.0`](https://github.com/marcmalerei/gluon/releases/tag/v1.9.0)
-release remains supported until the protected `v1.10.0` tag workflow completes
-browser, Node, performance, reproducibility, clean-room registry, provenance,
-and publication verification for all 21 packages.
+The immutable GitHub release is [`v1.10.0`](https://github.com/marcmalerei/gluon/releases/tag/v1.10.0),
+published from `d1763ef0646beaa3b5c6753b431f40ddec734ca9`. Protected workflow
+run [31922071023](https://github.com/marcmalerei/gluon/actions/runs/31922071023)
+passed browser, Node, performance, reproducibility, clean-room registry,
+provenance, and publication verification for all 21 packages.
 
 Gluon's release group contains 21 lockstep packages. The repository validates
 their common version, exact official dependencies, package contents,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,12 +9,15 @@ For day-to-day version upgrades, start with the
 
 ## Current publication state
 
-The machine-readable package contract records `publicationState: ready` and
-`scopeControl: verified` for the prepared `1.10.0` candidate. Every official
-manifest is public and lockstep at `1.10.0`. Registry preflight on 2026-08-16
-confirmed that all 21 package records expose `1.9.0` as `latest` and that
-`1.10.0` is absent. The immutable GitHub release `v1.9.0` remains the current
-finalized release until the protected `1.10.0` workflow completes. The
+The machine-readable package contract records `publicationState: released` and
+`scopeControl: verified` for `1.10.0`. Every official manifest is public and
+lockstep at `1.10.0`. Protected release workflow
+[31922071023](https://github.com/marcmalerei/gluon/actions/runs/31922071023)
+published all 21 package records to `latest` with provenance and verified the
+train from a clean directory. The immutable GitHub release
+[`v1.10.0`](https://github.com/marcmalerei/gluon/releases/tag/v1.10.0) was
+published on 2026-08-16 from tag commit
+`d1763ef0646beaa3b5c6753b431f40ddec734ca9` with 115 reviewed assets. The
 `v1.0.9` GitHub release remains a historical draft after its public-type
 verification failure. This is enforced locally by:
 
@@ -24,13 +27,14 @@ npm run check:release-contract
 
 ## v1.10.0 train handoff
 
-Issue [#456](https://github.com/marcmalerei/gluon/issues/456) establishes the
+Issue [#456](https://github.com/marcmalerei/gluon/issues/456) established the
 21-package `1.10.0` train for the complete post-1.9 roadmap tracked by epic
-[#390](https://github.com/marcmalerei/gluon/issues/390). The train uses the
-two-commit release cut: a Quality-Gates-tested candidate followed only by its
-release-cut evidence and compatibility manifest. The immutable `v1.9.0`
-release remains the supported baseline until the protected `v1.10.0` workflow
-completes.
+[#390](https://github.com/marcmalerei/gluon/issues/390). PR
+[#457](https://github.com/marcmalerei/gluon/pull/457) merged the tested
+candidate and its release-cut evidence as a preserved merge commit. The
+protected tag workflow completed candidate, reproducibility, browser-engine,
+Node-runtime, performance, fixture, registry, provenance, and publication
+checks. `v1.10.0` is now the supported `latest` baseline.
 
 ## v1.9.0 train handoff
 

--- a/package-contract.json
+++ b/package-contract.json
@@ -8,8 +8,8 @@
     "checkedAt": "2026-08-16",
     "scope": "@gluonjs",
     "scopeControl": "verified",
-    "publicationState": "ready",
-    "observation": "Registry preflight on 2026-08-16 confirmed that all 21 contracted package records expose 1.9.0 as latest and that version 1.10.0 is absent. Scope control and trusted publication remain verified by the completed 1.9.0 release contract."
+    "publicationState": "released",
+    "observation": "Protected release workflow 31922071023 completed successfully on 2026-08-16: all 21 contracted package records were published to latest at 1.10.0 with provenance and verified from a clean directory. Immutable GitHub release v1.10.0 was published from tag commit d1763ef0646beaa3b5c6753b431f40ddec734ca9 with 115 reviewed assets."
   },
   "packages": [
     {


### PR DESCRIPTION
## Summary
- mark the 21-package v1.10.0 train as released
- record protected Release run 31922071023, tag commit d1763ef, and 115 immutable assets
- update repository and versioned Pages release guidance to the verified live state

## Verification
- `npm run check:release-contract`
- `npm run build`
- `npm run check:release-artifacts`
- `npm run check:docs`
- live npm clean-room verification: 21/21 packages at latest 1.10.0 with integrity and provenance
- live Pages verification: versioned and latest roots plus 42/42 package portals
- GitHub release v1.10.0 is immutable, non-draft, non-prerelease with 115 digested assets

## Shop
No shop change: this slice records release operations state only and changes no public framework API or customer-visible capability.

Part of #456